### PR TITLE
[2/3]: implement `blockbeat`

### DIFF
--- a/chainio/README.md
+++ b/chainio/README.md
@@ -1,0 +1,152 @@
+# Chainio 
+
+`chainio` is a package designed to provide blockchain data access to various
+subsystems within `lnd`. When a new block is received, it is encapsulated in a
+`Blockbeat` object and disseminated to all registered consumers. Consumers may
+receive these updates either concurrently or sequentially, based on their
+registration configuration, ensuring that each subsystem maintains a
+synchronized view of the current block state.
+
+The main components include:
+
+- `Blockbeat`: An interface that provides information about the block.
+
+- `Consumer`: An interface that specifies how subsystems handle the blockbeat.
+
+- `BlockbeatDispatcher`: The core service responsible for receiving each block
+  and distributing it to all consumers.
+
+Additionally, the `BeatConsumer` struct provides a partial implementation of
+the `Consumer` interface. This struct helps reduce code duplication, allowing
+subsystems to avoid re-implementing the `ProcessBlock` method and provides a
+commonly used `NotifyBlockProcessed` method.
+
+
+### Register a Consumer
+
+Consumers within the same queue are notified **sequentially**, while all queues
+are notified **concurrently**. A queue consists of a slice of consumers, which
+are notified in left-to-right order. Developers are responsible for determining
+dependencies in block consumption across subsystems: independent subsystems
+should be notified concurrently, whereas dependent subsystems should be
+notified sequentially.
+
+To notify the consumers concurrently, put them in different queues,
+```go
+// consumer1 and consumer2 will be notified concurrently.
+queue1 := []chainio.Consumer{consumer1}
+blockbeatDispatcher.RegisterQueue(consumer1)
+
+queue2 := []chainio.Consumer{consumer2}
+blockbeatDispatcher.RegisterQueue(consumer2)
+```
+
+To notify the consumers sequentially, put them in the same queue,
+```go
+// consumers will be notified sequentially via,
+// consumer1 -> consumer2 -> consumer3
+queue := []chainio.Consumer{
+   consumer1,
+   consumer2,
+   consumer3,
+}
+blockbeatDispatcher.RegisterQueue(queue)
+```
+
+### Implement the `Consumer` Interface
+
+Implementing the `Consumer` interface is straightforward. Below is an example
+of how
+[`sweep.TxPublisher`](https://github.com/lightningnetwork/lnd/blob/5cec466fad44c582a64cfaeb91f6d5fd302fcf85/sweep/fee_bumper.go#L310)
+implements this interface.
+
+To start, embed the partial implementation `chainio.BeatConsumer`, which
+already provides the `ProcessBlock` implementation and commonly used
+`NotifyBlockProcessed` method,  and exposes `BlockbeatChan` for the consumer to
+receive blockbeats.
+
+```go
+type TxPublisher struct {
+   started atomic.Bool
+   stopped atomic.Bool
+
+   chainio.BeatConsumer
+
+   ...
+```
+
+We should also remember to initialize this `BeatConsumer`,
+
+```go
+...
+// Mount the block consumer.
+tp.BeatConsumer = chainio.NewBeatConsumer(tp.quit, tp.Name())
+```
+
+Finally, in the main event loop, read from `BlockbeatChan`, process the
+received blockbeat, and, crucially, call `beat.NotifyBlockProcessed` to inform
+the blockbeat dispatcher that processing is complete.
+
+```go
+for {
+      select {
+      case beat := <-t.BlockbeatChan:
+         // Consume this blockbeat, usually it means updating the subsystem
+         // using the new block data.
+
+         // Notify we've processed the block.
+         t.NotifyBlockProcessed(beat, nil)
+
+      ...
+```
+
+### Existing Queues
+
+Currently, we have a single queue of consumers dedicated to handling force
+closures. This queue includes `ChainArbitrator`, `UtxoSweeper`, and
+`TxPublisher`, with `ChainArbitrator` managing two internal consumers:
+`chainWatcher` and `ChannelArbitrator`. The blockbeat flows sequentially
+through the chain as follows: `ChainArbitrator => chainWatcher =>
+ChannelArbitrator => UtxoSweeper => TxPublisher`. The following diagram
+illustrates the flow within the public subsystems.
+
+```mermaid
+sequenceDiagram
+		autonumber
+		participant bb as BlockBeat
+		participant cc as ChainArb
+		participant us as UtxoSweeper
+		participant tp as TxPublisher
+		
+		note left of bb: 0. received block x,<br>dispatching...
+		
+    note over bb,cc: 1. send block x to ChainArb,<br>wait for its done signal
+		bb->>cc: block x
+		rect rgba(165, 0, 85, 0.8)
+      critical signal processed
+        cc->>bb: processed block
+      option Process error or timeout
+        bb->>bb: error and exit
+      end
+    end
+
+    note over bb,us: 2. send block x to UtxoSweeper, wait for its done signal
+		bb->>us: block x
+		rect rgba(165, 0, 85, 0.8)
+      critical signal processed
+        us->>bb: processed block
+      option Process error or timeout
+        bb->>bb: error and exit
+      end
+    end
+
+    note over bb,tp: 3. send block x to TxPublisher, wait for its done signal
+		bb->>tp: block x
+		rect rgba(165, 0, 85, 0.8)
+      critical signal processed
+        tp->>bb: processed block
+      option Process error or timeout
+        bb->>bb: error and exit
+      end
+    end
+```

--- a/chainio/blockbeat.go
+++ b/chainio/blockbeat.go
@@ -1,0 +1,55 @@
+package chainio
+
+import (
+	"fmt"
+
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightningnetwork/lnd/build"
+	"github.com/lightningnetwork/lnd/chainntnfs"
+)
+
+// Beat implements the Blockbeat interface. It contains the block epoch and a
+// customized logger.
+//
+// TODO(yy): extend this to check for confirmation status - which serves as the
+// single source of truth, to avoid the potential race between receiving blocks
+// and `GetTransactionDetails/RegisterSpendNtfn/RegisterConfirmationsNtfn`.
+type Beat struct {
+	// epoch is the current block epoch the blockbeat is aware of.
+	epoch chainntnfs.BlockEpoch
+
+	// log is the customized logger for the blockbeat which prints the
+	// block height.
+	log btclog.Logger
+}
+
+// Compile-time check to ensure Beat satisfies the Blockbeat interface.
+var _ Blockbeat = (*Beat)(nil)
+
+// NewBeat creates a new beat with the specified block epoch and a customized
+// logger.
+func NewBeat(epoch chainntnfs.BlockEpoch) *Beat {
+	b := &Beat{
+		epoch: epoch,
+	}
+
+	// Create a customized logger for the blockbeat.
+	logPrefix := fmt.Sprintf("Height[%6d]:", b.Height())
+	b.log = build.NewPrefixLog(logPrefix, clog)
+
+	return b
+}
+
+// Height returns the height of the block epoch.
+//
+// NOTE: Part of the Blockbeat interface.
+func (b *Beat) Height() int32 {
+	return b.epoch.Height
+}
+
+// logger returns the logger for the blockbeat.
+//
+// NOTE: Part of the private blockbeat interface.
+func (b *Beat) logger() btclog.Logger {
+	return b.log
+}

--- a/chainio/blockbeat_test.go
+++ b/chainio/blockbeat_test.go
@@ -1,0 +1,28 @@
+package chainio
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/lightningnetwork/lnd/chainntnfs"
+	"github.com/stretchr/testify/require"
+)
+
+var errDummy = errors.New("dummy error")
+
+// TestNewBeat tests the NewBeat and Height functions.
+func TestNewBeat(t *testing.T) {
+	t.Parallel()
+
+	// Create a testing epoch.
+	epoch := chainntnfs.BlockEpoch{
+		Height: 1,
+	}
+
+	// Create the beat and check the internal state.
+	beat := NewBeat(epoch)
+	require.Equal(t, epoch, beat.epoch)
+
+	// Check the height function.
+	require.Equal(t, epoch.Height, beat.Height())
+}

--- a/chainio/consumer.go
+++ b/chainio/consumer.go
@@ -1,0 +1,113 @@
+package chainio
+
+// BeatConsumer defines a supplementary component that should be used by
+// subsystems which implement the `Consumer` interface. It partially implements
+// the `Consumer` interface by providing the method `ProcessBlock` such that
+// subsystems don't need to re-implement it.
+//
+// While inheritance is not commonly used in Go, subsystems embedding this
+// struct cannot pass the interface check for `Consumer` because the `Name`
+// method is not implemented, which gives us a "mortise and tenon" structure.
+// In addition to reducing code duplication, this design allows `ProcessBlock`
+// to work on the concrete type `Beat` to access its internal states.
+type BeatConsumer struct {
+	// BlockbeatChan is a channel to receive blocks from Blockbeat. The
+	// received block contains the best known height and the txns confirmed
+	// in this block.
+	BlockbeatChan chan Blockbeat
+
+	// name is the name of the consumer which embeds the BlockConsumer.
+	name string
+
+	// quit is a channel that closes when the BlockConsumer is shutting
+	// down.
+	//
+	// NOTE: this quit channel should be mounted to the same quit channel
+	// used by the subsystem.
+	quit chan struct{}
+
+	// errChan is a buffered chan that receives an error returned from
+	// processing this block.
+	errChan chan error
+}
+
+// NewBeatConsumer creates a new BlockConsumer.
+func NewBeatConsumer(quit chan struct{}, name string) BeatConsumer {
+	// Refuse to start `lnd` if the quit channel is not initialized. We
+	// treat this case as if we are facing a nil pointer dereference, as
+	// there's no point to return an error here, which will cause the node
+	// to fail to be started anyway.
+	if quit == nil {
+		panic("quit channel is nil")
+	}
+
+	b := BeatConsumer{
+		BlockbeatChan: make(chan Blockbeat),
+		name:          name,
+		errChan:       make(chan error, 1),
+		quit:          quit,
+	}
+
+	return b
+}
+
+// ProcessBlock takes a blockbeat and sends it to the consumer's blockbeat
+// channel. It will send it to the subsystem's BlockbeatChan, and block until
+// the processed result is received from the subsystem. The subsystem must call
+// `NotifyBlockProcessed` after it has finished processing the block.
+//
+// NOTE: part of the `chainio.Consumer` interface.
+func (b *BeatConsumer) ProcessBlock(beat Blockbeat) error {
+	// Update the current height.
+	beat.logger().Tracef("set current height for [%s]", b.name)
+
+	select {
+	// Send the beat to the blockbeat channel. It's expected that the
+	// consumer will read from this channel and process the block. Once
+	// processed, it should return the error or nil to the beat.Err chan.
+	case b.BlockbeatChan <- beat:
+		beat.logger().Tracef("Sent blockbeat to [%s]", b.name)
+
+	case <-b.quit:
+		beat.logger().Debugf("[%s] received shutdown before sending "+
+			"beat", b.name)
+
+		return nil
+	}
+
+	// Check the consumer's err chan. We expect the consumer to call
+	// `beat.NotifyBlockProcessed` to send the error back here.
+	select {
+	case err := <-b.errChan:
+		beat.logger().Debugf("[%s] processed beat: err=%v", b.name, err)
+
+		return err
+
+	case <-b.quit:
+		beat.logger().Debugf("[%s] received shutdown", b.name)
+	}
+
+	return nil
+}
+
+// NotifyBlockProcessed signals that the block has been processed. It takes the
+// blockbeat being processed and an error resulted from processing it. This
+// error is then sent back to the consumer's err chan to unblock
+// `ProcessBlock`.
+//
+// NOTE: This method must be called by the subsystem after it has finished
+// processing the block.
+func (b *BeatConsumer) NotifyBlockProcessed(beat Blockbeat, err error) {
+	// Update the current height.
+	beat.logger().Debugf("[%s]: notifying beat processed", b.name)
+
+	select {
+	case b.errChan <- err:
+		beat.logger().Debugf("[%s]: notified beat processed, err=%v",
+			b.name, err)
+
+	case <-b.quit:
+		beat.logger().Debugf("[%s] received shutdown before notifying "+
+			"beat processed", b.name)
+	}
+}

--- a/chainio/consumer_test.go
+++ b/chainio/consumer_test.go
@@ -1,0 +1,202 @@
+package chainio
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lightningnetwork/lnd/fn"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewBeatConsumer tests the NewBeatConsumer function.
+func TestNewBeatConsumer(t *testing.T) {
+	t.Parallel()
+
+	quitChan := make(chan struct{})
+	name := "test"
+
+	// Test the NewBeatConsumer function.
+	b := NewBeatConsumer(quitChan, name)
+
+	// Assert the state.
+	require.Equal(t, quitChan, b.quit)
+	require.Equal(t, name, b.name)
+	require.NotNil(t, b.BlockbeatChan)
+}
+
+// TestProcessBlockSuccess tests when the block is processed successfully, no
+// error is returned.
+func TestProcessBlockSuccess(t *testing.T) {
+	t.Parallel()
+
+	// Create a test consumer.
+	quitChan := make(chan struct{})
+	b := NewBeatConsumer(quitChan, "test")
+
+	// Create a mock beat.
+	mockBeat := &MockBlockbeat{}
+	defer mockBeat.AssertExpectations(t)
+	mockBeat.On("logger").Return(clog)
+
+	// Mock the consumer's err chan.
+	consumerErrChan := make(chan error, 1)
+	b.errChan = consumerErrChan
+
+	// Call the method under test.
+	resultChan := make(chan error, 1)
+	go func() {
+		resultChan <- b.ProcessBlock(mockBeat)
+	}()
+
+	// Assert the beat is sent to the blockbeat channel.
+	beat, err := fn.RecvOrTimeout(b.BlockbeatChan, time.Second)
+	require.NoError(t, err)
+	require.Equal(t, mockBeat, beat)
+
+	// Send nil to the consumer's error channel.
+	consumerErrChan <- nil
+
+	// Assert the result of ProcessBlock is nil.
+	result, err := fn.RecvOrTimeout(resultChan, time.Second)
+	require.NoError(t, err)
+	require.Nil(t, result)
+}
+
+// TestProcessBlockConsumerQuitBeforeSend tests when the consumer is quit
+// before sending the beat, the method returns immediately.
+func TestProcessBlockConsumerQuitBeforeSend(t *testing.T) {
+	t.Parallel()
+
+	// Create a test consumer.
+	quitChan := make(chan struct{})
+	b := NewBeatConsumer(quitChan, "test")
+
+	// Create a mock beat.
+	mockBeat := &MockBlockbeat{}
+	defer mockBeat.AssertExpectations(t)
+	mockBeat.On("logger").Return(clog)
+
+	// Call the method under test.
+	resultChan := make(chan error, 1)
+	go func() {
+		resultChan <- b.ProcessBlock(mockBeat)
+	}()
+
+	// Instead of reading the BlockbeatChan, close the quit channel.
+	close(quitChan)
+
+	// Assert ProcessBlock returned nil.
+	result, err := fn.RecvOrTimeout(resultChan, time.Second)
+	require.NoError(t, err)
+	require.Nil(t, result)
+}
+
+// TestProcessBlockConsumerQuitAfterSend tests when the consumer is quit after
+// sending the beat, the method returns immediately.
+func TestProcessBlockConsumerQuitAfterSend(t *testing.T) {
+	t.Parallel()
+
+	// Create a test consumer.
+	quitChan := make(chan struct{})
+	b := NewBeatConsumer(quitChan, "test")
+
+	// Create a mock beat.
+	mockBeat := &MockBlockbeat{}
+	defer mockBeat.AssertExpectations(t)
+	mockBeat.On("logger").Return(clog)
+
+	// Mock the consumer's err chan.
+	consumerErrChan := make(chan error, 1)
+	b.errChan = consumerErrChan
+
+	// Call the method under test.
+	resultChan := make(chan error, 1)
+	go func() {
+		resultChan <- b.ProcessBlock(mockBeat)
+	}()
+
+	// Assert the beat is sent to the blockbeat channel.
+	beat, err := fn.RecvOrTimeout(b.BlockbeatChan, time.Second)
+	require.NoError(t, err)
+	require.Equal(t, mockBeat, beat)
+
+	// Instead of sending nil to the consumer's error channel, close the
+	// quit chanel.
+	close(quitChan)
+
+	// Assert ProcessBlock returned nil.
+	result, err := fn.RecvOrTimeout(resultChan, time.Second)
+	require.NoError(t, err)
+	require.Nil(t, result)
+}
+
+// TestNotifyBlockProcessedSendErr asserts the error can be sent and read by
+// the beat via NotifyBlockProcessed.
+func TestNotifyBlockProcessedSendErr(t *testing.T) {
+	t.Parallel()
+
+	// Create a test consumer.
+	quitChan := make(chan struct{})
+	b := NewBeatConsumer(quitChan, "test")
+
+	// Create a mock beat.
+	mockBeat := &MockBlockbeat{}
+	defer mockBeat.AssertExpectations(t)
+	mockBeat.On("logger").Return(clog)
+
+	// Mock the consumer's err chan.
+	consumerErrChan := make(chan error, 1)
+	b.errChan = consumerErrChan
+
+	// Call the method under test.
+	done := make(chan error)
+	go func() {
+		defer close(done)
+		b.NotifyBlockProcessed(mockBeat, errDummy)
+	}()
+
+	// Assert the error is sent to the beat's err chan.
+	result, err := fn.RecvOrTimeout(consumerErrChan, time.Second)
+	require.NoError(t, err)
+	require.ErrorIs(t, result, errDummy)
+
+	// Assert the done channel is closed.
+	result, err = fn.RecvOrTimeout(done, time.Second)
+	require.NoError(t, err)
+	require.Nil(t, result)
+}
+
+// TestNotifyBlockProcessedOnQuit asserts NotifyBlockProcessed exits
+// immediately when the quit channel is closed.
+func TestNotifyBlockProcessedOnQuit(t *testing.T) {
+	t.Parallel()
+
+	// Create a test consumer.
+	quitChan := make(chan struct{})
+	b := NewBeatConsumer(quitChan, "test")
+
+	// Create a mock beat.
+	mockBeat := &MockBlockbeat{}
+	defer mockBeat.AssertExpectations(t)
+	mockBeat.On("logger").Return(clog)
+
+	// Mock the consumer's err chan - we don't buffer it so it will block
+	// on sending the error.
+	consumerErrChan := make(chan error)
+	b.errChan = consumerErrChan
+
+	// Call the method under test.
+	done := make(chan error)
+	go func() {
+		defer close(done)
+		b.NotifyBlockProcessed(mockBeat, errDummy)
+	}()
+
+	// Close the quit channel so the method will return.
+	close(b.quit)
+
+	// Assert the done channel is closed.
+	result, err := fn.RecvOrTimeout(done, time.Second)
+	require.NoError(t, err)
+	require.Nil(t, result)
+}

--- a/chainio/dispatcher.go
+++ b/chainio/dispatcher.go
@@ -1,0 +1,105 @@
+package chainio
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// DefaultProcessBlockTimeout is the timeout value used when waiting for one
+// consumer to finish processing the new block epoch.
+var DefaultProcessBlockTimeout = 60 * time.Second
+
+// ErrProcessBlockTimeout is the error returned when a consumer takes too long
+// to process the block.
+var ErrProcessBlockTimeout = errors.New("process block timeout")
+
+// DispatchSequential takes a list of consumers and notify them about the new
+// epoch sequentially. It requires the consumer to finish processing the block
+// within the specified time, otherwise a timeout error is returned.
+func DispatchSequential(b Blockbeat, consumers []Consumer) error {
+	for _, c := range consumers {
+		// Send the beat to the consumer.
+		err := notifyAndWait(b, c, DefaultProcessBlockTimeout)
+		if err != nil {
+			b.logger().Errorf("Failed to process block: %v", err)
+
+			return err
+		}
+	}
+
+	return nil
+}
+
+// DispatchConcurrent notifies each consumer concurrently about the blockbeat.
+// It requires the consumer to finish processing the block within the specified
+// time, otherwise a timeout error is returned.
+func DispatchConcurrent(b Blockbeat, consumers []Consumer) error {
+	// errChans is a map of channels that will be used to receive errors
+	// returned from notifying the consumers.
+	errChans := make(map[string]chan error, len(consumers))
+
+	// Notify each queue in goroutines.
+	for _, c := range consumers {
+		// Create a signal chan.
+		errChan := make(chan error, 1)
+		errChans[c.Name()] = errChan
+
+		// Notify each consumer concurrently.
+		go func(c Consumer, beat Blockbeat) {
+			// Send the beat to the consumer.
+			errChan <- notifyAndWait(
+				b, c, DefaultProcessBlockTimeout,
+			)
+		}(c, b)
+	}
+
+	// Wait for all consumers in each queue to finish.
+	for name, errChan := range errChans {
+		err := <-errChan
+		if err != nil {
+			b.logger().Errorf("Consumer=%v failed to process "+
+				"block: %v", name, err)
+
+			return err
+		}
+	}
+
+	return nil
+}
+
+// notifyAndWait sends the blockbeat to the specified consumer. It requires the
+// consumer to finish processing the block within the specified time, otherwise
+// a timeout error is returned.
+func notifyAndWait(b Blockbeat, c Consumer, timeout time.Duration) error {
+	b.logger().Debugf("Waiting for consumer[%s] to process it", c.Name())
+
+	// Record the time it takes the consumer to process this block.
+	start := time.Now()
+
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- c.ProcessBlock(b)
+	}()
+
+	// We expect the consumer to finish processing this block under 30s,
+	// otherwise a timeout error is returned.
+	select {
+	case err := <-errChan:
+		if err == nil {
+			break
+		}
+
+		return fmt.Errorf("%s got err in ProcessBlock: %w", c.Name(),
+			err)
+
+	case <-time.After(timeout):
+		return fmt.Errorf("consumer %s: %w", c.Name(),
+			ErrProcessBlockTimeout)
+	}
+
+	b.logger().Debugf("Consumer[%s] processed block in %v", c.Name(),
+		time.Since(start))
+
+	return nil
+}

--- a/chainio/dispatcher.go
+++ b/chainio/dispatcher.go
@@ -3,7 +3,12 @@ package chainio
 import (
 	"errors"
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"time"
+
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightningnetwork/lnd/chainntnfs"
 )
 
 // DefaultProcessBlockTimeout is the timeout value used when waiting for one
@@ -13,6 +18,195 @@ var DefaultProcessBlockTimeout = 60 * time.Second
 // ErrProcessBlockTimeout is the error returned when a consumer takes too long
 // to process the block.
 var ErrProcessBlockTimeout = errors.New("process block timeout")
+
+// BlockbeatDispatcher is a service that handles dispatching new blocks to
+// `lnd`'s subsystems. During startup, subsystems that are block-driven should
+// implement the `Consumer` interface and register themselves via
+// `RegisterQueue`. When two subsystems are independent of each other, they
+// should be registered in different queues so blocks are notified concurrently.
+// Otherwise, when living in the same queue, the subsystems are notified of the
+// new blocks sequentially, which means it's critical to understand the
+// relationship of these systems to properly handle the order.
+type BlockbeatDispatcher struct {
+	wg sync.WaitGroup
+
+	// notifier is used to receive new block epochs.
+	notifier chainntnfs.ChainNotifier
+
+	// beat is the latest blockbeat received.
+	beat Blockbeat
+
+	// consumerQueues is a map of consumers that will receive blocks. Its
+	// key is a unique counter and its value is a queue of consumers. Each
+	// queue is notified concurrently, and consumers in the same queue is
+	// notified sequentially.
+	consumerQueues map[uint32][]Consumer
+
+	// counter is used to assign a unique id to each queue.
+	counter atomic.Uint32
+
+	// quit is used to signal the BlockbeatDispatcher to stop.
+	quit chan struct{}
+}
+
+// NewBlockbeatDispatcher returns a new blockbeat dispatcher instance.
+func NewBlockbeatDispatcher(n chainntnfs.ChainNotifier) *BlockbeatDispatcher {
+	return &BlockbeatDispatcher{
+		notifier:       n,
+		quit:           make(chan struct{}),
+		consumerQueues: make(map[uint32][]Consumer),
+	}
+}
+
+// RegisterQueue takes a list of consumers and registers them in the same
+// queue.
+//
+// NOTE: these consumers are notified sequentially.
+func (b *BlockbeatDispatcher) RegisterQueue(consumers []Consumer) {
+	qid := b.counter.Add(1)
+
+	b.consumerQueues[qid] = append(b.consumerQueues[qid], consumers...)
+	clog.Infof("Registered queue=%d with %d blockbeat consumers", qid,
+		len(consumers))
+
+	for _, c := range consumers {
+		clog.Debugf("Consumer [%s] registered in queue %d", c.Name(),
+			qid)
+	}
+}
+
+// Start starts the blockbeat dispatcher - it registers a block notification
+// and monitors and dispatches new blocks in a goroutine. It will refuse to
+// start if there are no registered consumers.
+func (b *BlockbeatDispatcher) Start() error {
+	// Make sure consumers are registered.
+	if len(b.consumerQueues) == 0 {
+		return fmt.Errorf("no consumers registered")
+	}
+
+	// Start listening to new block epochs. We should get a notification
+	// with the current best block immediately.
+	blockEpochs, err := b.notifier.RegisterBlockEpochNtfn(nil)
+	if err != nil {
+		return fmt.Errorf("register block epoch ntfn: %w", err)
+	}
+
+	clog.Infof("BlockbeatDispatcher is starting with %d consumer queues",
+		len(b.consumerQueues))
+	defer clog.Debug("BlockbeatDispatcher started")
+
+	b.wg.Add(1)
+	go b.dispatchBlocks(blockEpochs)
+
+	return nil
+}
+
+// Stop shuts down the blockbeat dispatcher.
+func (b *BlockbeatDispatcher) Stop() {
+	clog.Info("BlockbeatDispatcher is stopping")
+	defer clog.Debug("BlockbeatDispatcher stopped")
+
+	// Signal the dispatchBlocks goroutine to stop.
+	close(b.quit)
+	b.wg.Wait()
+}
+
+func (b *BlockbeatDispatcher) log() btclog.Logger {
+	return b.beat.logger()
+}
+
+// dispatchBlocks listens to new block epoch and dispatches it to all the
+// consumers. Each queue is notified concurrently, and the consumers in the
+// same queue are notified sequentially.
+//
+// NOTE: Must be run as a goroutine.
+func (b *BlockbeatDispatcher) dispatchBlocks(
+	blockEpochs *chainntnfs.BlockEpochEvent) {
+
+	defer b.wg.Done()
+	defer blockEpochs.Cancel()
+
+	for {
+		select {
+		case blockEpoch, ok := <-blockEpochs.Epochs:
+			if !ok {
+				clog.Debugf("Block epoch channel closed")
+
+				return
+			}
+
+			clog.Infof("Received new block %v at height %d, "+
+				"notifying consumers...", blockEpoch.Hash,
+				blockEpoch.Height)
+
+			// Record the time it takes the consumer to process
+			// this block.
+			start := time.Now()
+
+			// Update the current block epoch.
+			b.beat = NewBeat(*blockEpoch)
+
+			// Notify all consumers.
+			err := b.notifyQueues()
+			if err != nil {
+				b.log().Errorf("Notify block failed: %v", err)
+			}
+
+			b.log().Infof("Notified all consumers on new block "+
+				"in %v", time.Since(start))
+
+		case <-b.quit:
+			b.log().Debugf("BlockbeatDispatcher quit signal " +
+				"received")
+
+			return
+		}
+	}
+}
+
+// notifyQueues notifies each queue concurrently about the latest block epoch.
+func (b *BlockbeatDispatcher) notifyQueues() error {
+	// errChans is a map of channels that will be used to receive errors
+	// returned from notifying the consumers.
+	errChans := make(map[uint32]chan error, len(b.consumerQueues))
+
+	// Notify each queue in goroutines.
+	for qid, consumers := range b.consumerQueues {
+		b.log().Debugf("Notifying queue=%d with %d consumers", qid,
+			len(consumers))
+
+		// Create a signal chan.
+		errChan := make(chan error, 1)
+		errChans[qid] = errChan
+
+		// Notify each queue concurrently.
+		go func(qid uint32, c []Consumer, beat Blockbeat) {
+			// Notify each consumer in this queue sequentially.
+			errChan <- DispatchSequential(beat, c)
+		}(qid, consumers, b.beat)
+	}
+
+	// Wait for all consumers in each queue to finish.
+	for qid, errChan := range errChans {
+		select {
+		case err := <-errChan:
+			if err != nil {
+				return fmt.Errorf("queue=%d got err: %w", qid,
+					err)
+			}
+
+			b.log().Debugf("Notified queue=%d", qid)
+
+		case <-b.quit:
+			b.log().Debugf("BlockbeatDispatcher quit signal " +
+				"received, exit notifyQueues")
+
+			return nil
+		}
+	}
+
+	return nil
+}
 
 // DispatchSequential takes a list of consumers and notify them about the new
 // epoch sequentially. It requires the consumer to finish processing the block

--- a/chainio/dispatcher_test.go
+++ b/chainio/dispatcher_test.go
@@ -1,0 +1,161 @@
+package chainio
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNotifyAndWaitOnConsumerErr asserts when the consumer returns an error,
+// it's returned by notifyAndWait.
+func TestNotifyAndWaitOnConsumerErr(t *testing.T) {
+	t.Parallel()
+
+	// Create a mock consumer.
+	consumer := &MockConsumer{}
+	defer consumer.AssertExpectations(t)
+	consumer.On("Name").Return("mocker")
+
+	// Create a mock beat.
+	mockBeat := &MockBlockbeat{}
+	defer mockBeat.AssertExpectations(t)
+	mockBeat.On("logger").Return(clog)
+
+	// Mock ProcessBlock to return an error.
+	consumer.On("ProcessBlock", mockBeat).Return(errDummy).Once()
+
+	// Call the method under test.
+	err := notifyAndWait(mockBeat, consumer, DefaultProcessBlockTimeout)
+
+	// We expect the error to be returned.
+	require.ErrorIs(t, err, errDummy)
+}
+
+// TestNotifyAndWaitOnConsumerErr asserts when the consumer successfully
+// processed the beat, no error is returned.
+func TestNotifyAndWaitOnConsumerSuccess(t *testing.T) {
+	t.Parallel()
+
+	// Create a mock consumer.
+	consumer := &MockConsumer{}
+	defer consumer.AssertExpectations(t)
+	consumer.On("Name").Return("mocker")
+
+	// Create a mock beat.
+	mockBeat := &MockBlockbeat{}
+	defer mockBeat.AssertExpectations(t)
+	mockBeat.On("logger").Return(clog)
+
+	// Mock ProcessBlock to return nil.
+	consumer.On("ProcessBlock", mockBeat).Return(nil).Once()
+
+	// Call the method under test.
+	err := notifyAndWait(mockBeat, consumer, DefaultProcessBlockTimeout)
+
+	// We expect a nil error to be returned.
+	require.NoError(t, err)
+}
+
+// TestNotifyAndWaitOnConsumerTimeout asserts when the consumer times out
+// processing the block, the timeout error is returned.
+func TestNotifyAndWaitOnConsumerTimeout(t *testing.T) {
+	t.Parallel()
+
+	// Set timeout to be 10ms.
+	processBlockTimeout := 10 * time.Millisecond
+
+	// Create a mock consumer.
+	consumer := &MockConsumer{}
+	defer consumer.AssertExpectations(t)
+	consumer.On("Name").Return("mocker")
+
+	// Create a mock beat.
+	mockBeat := &MockBlockbeat{}
+	defer mockBeat.AssertExpectations(t)
+	mockBeat.On("logger").Return(clog)
+
+	// Mock ProcessBlock to return nil but blocks on returning.
+	consumer.On("ProcessBlock", mockBeat).Return(nil).Run(
+		func(args mock.Arguments) {
+			// Sleep one second to block on the method.
+			time.Sleep(processBlockTimeout * 100)
+		}).Once()
+
+	// Call the method under test.
+	err := notifyAndWait(mockBeat, consumer, processBlockTimeout)
+
+	// We expect a timeout error to be returned.
+	require.ErrorIs(t, err, ErrProcessBlockTimeout)
+}
+
+// TestDispatchSequential checks that the beat is sent to the consumers
+// sequentially.
+func TestDispatchSequential(t *testing.T) {
+	t.Parallel()
+
+	// Create three mock consumers.
+	consumer1 := &MockConsumer{}
+	defer consumer1.AssertExpectations(t)
+	consumer1.On("Name").Return("mocker1")
+
+	consumer2 := &MockConsumer{}
+	defer consumer2.AssertExpectations(t)
+	consumer2.On("Name").Return("mocker2")
+
+	consumer3 := &MockConsumer{}
+	defer consumer3.AssertExpectations(t)
+	consumer3.On("Name").Return("mocker3")
+
+	consumers := []Consumer{consumer1, consumer2, consumer3}
+
+	// Create a mock beat.
+	mockBeat := &MockBlockbeat{}
+	defer mockBeat.AssertExpectations(t)
+	mockBeat.On("logger").Return(clog)
+
+	// prevConsumer specifies the previous consumer that was called.
+	var prevConsumer string
+
+	// Mock the ProcessBlock on consumers to reutrn immediately.
+	consumer1.On("ProcessBlock", mockBeat).Return(nil).Run(
+		func(args mock.Arguments) {
+			// Check the order of the consumers.
+			//
+			// The first consumer should have no previous consumer.
+			require.Empty(t, prevConsumer)
+
+			// Set the consumer as the previous consumer.
+			prevConsumer = consumer1.Name()
+		}).Once()
+
+	consumer2.On("ProcessBlock", mockBeat).Return(nil).Run(
+		func(args mock.Arguments) {
+			// Check the order of the consumers.
+			//
+			// The second consumer should see consumer1.
+			require.Equal(t, consumer1.Name(), prevConsumer)
+
+			// Set the consumer as the previous consumer.
+			prevConsumer = consumer2.Name()
+		}).Once()
+
+	consumer3.On("ProcessBlock", mockBeat).Return(nil).Run(
+		func(args mock.Arguments) {
+			// Check the order of the consumers.
+			//
+			// The third consumer should see consumer2.
+			require.Equal(t, consumer2.Name(), prevConsumer)
+
+			// Set the consumer as the previous consumer.
+			prevConsumer = consumer3.Name()
+		}).Once()
+
+	// Call the method under test.
+	err := DispatchSequential(mockBeat, consumers)
+	require.NoError(t, err)
+
+	// Check the previous consumer is the last consumer.
+	require.Equal(t, consumer3.Name(), prevConsumer)
+}

--- a/chainio/interface.go
+++ b/chainio/interface.go
@@ -1,9 +1,11 @@
 package chainio
 
+import "github.com/btcsuite/btclog/v2"
+
 // Blockbeat defines an interface that can be used by subsystems to retrieve
-// block data. It is sent by the BlockbeatDispatcher whenever a new block is
-// received. Once the subsystem finishes processing the block, it must signal
-// it by calling NotifyBlockProcessed.
+// block data. It is sent by the BlockbeatDispatcher to all the registered
+// consumers whenever a new block is received. Once the consumer finishes
+// processing the block, it must signal it by calling `NotifyBlockProcessed`.
 //
 // The blockchain is a state machine - whenever there's a state change, it's
 // manifested in a block. The blockbeat is a way to notify subsystems of this
@@ -11,8 +13,19 @@ package chainio
 // other words, subsystems must react to this state change and should consider
 // being driven by the blockbeat in their own state machines.
 type Blockbeat interface {
+	// blockbeat is a private interface that's only used in this package.
+	blockbeat
+
 	// Height returns the current block height.
 	Height() int32
+}
+
+// blockbeat defines a set of private methods used in this package to make
+// interaction with the blockbeat easier.
+type blockbeat interface {
+	// logger returns the internal logger used by the blockbeat which has a
+	// block height prefix.
+	logger() btclog.Logger
 }
 
 // Consumer defines a blockbeat consumer interface. Subsystems that need block

--- a/chainio/interface.go
+++ b/chainio/interface.go
@@ -1,0 +1,40 @@
+package chainio
+
+// Blockbeat defines an interface that can be used by subsystems to retrieve
+// block data. It is sent by the BlockbeatDispatcher whenever a new block is
+// received. Once the subsystem finishes processing the block, it must signal
+// it by calling NotifyBlockProcessed.
+//
+// The blockchain is a state machine - whenever there's a state change, it's
+// manifested in a block. The blockbeat is a way to notify subsystems of this
+// state change, and to provide them with the data they need to process it. In
+// other words, subsystems must react to this state change and should consider
+// being driven by the blockbeat in their own state machines.
+type Blockbeat interface {
+	// Height returns the current block height.
+	Height() int32
+}
+
+// Consumer defines a blockbeat consumer interface. Subsystems that need block
+// info must implement it.
+type Consumer interface {
+	// TODO(yy): We should also define the start methods used by the
+	// consumers such that when implementing the interface, the consumer
+	// will always be started with a blockbeat. This cannot be enforced at
+	// the moment as we need refactor all the start methods to only take a
+	// beat.
+	//
+	// Start(beat Blockbeat) error
+
+	// Name returns a human-readable string for this subsystem.
+	Name() string
+
+	// ProcessBlock takes a blockbeat and processes it. It should not
+	// return until the subsystem has updated its state based on the block
+	// data.
+	//
+	// NOTE: The consumer must try its best to NOT return an error. If an
+	// error is returned from processing the block, it means the subsystem
+	// cannot react to onchain state changes and lnd will shutdown.
+	ProcessBlock(b Blockbeat) error
+}

--- a/chainio/log.go
+++ b/chainio/log.go
@@ -1,0 +1,32 @@
+package chainio
+
+import (
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightningnetwork/lnd/build"
+)
+
+// Subsystem defines the logging code for this subsystem.
+const Subsystem = "CHIO"
+
+// clog is a logger that is initialized with no output filters. This means the
+// package will not perform any logging by default until the caller requests
+// it.
+var clog btclog.Logger
+
+// The default amount of logging is none.
+func init() {
+	UseLogger(build.NewSubLogger(Subsystem, nil))
+}
+
+// DisableLog disables all library log output. Logging output is disabled by
+// default until UseLogger is called.
+func DisableLog() {
+	UseLogger(btclog.Disabled)
+}
+
+// UseLogger uses a specified Logger to output package logging info. This
+// should be used in preference to SetLogWriter if the caller is also using
+// btclog.
+func UseLogger(logger btclog.Logger) {
+	clog = logger
+}

--- a/chainio/mocks.go
+++ b/chainio/mocks.go
@@ -1,0 +1,50 @@
+package chainio
+
+import (
+	"github.com/btcsuite/btclog/v2"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockConsumer is a mock implementation of the Consumer interface.
+type MockConsumer struct {
+	mock.Mock
+}
+
+// Compile-time constraint to ensure MockConsumer implements Consumer.
+var _ Consumer = (*MockConsumer)(nil)
+
+// Name returns a human-readable string for this subsystem.
+func (m *MockConsumer) Name() string {
+	args := m.Called()
+	return args.String(0)
+}
+
+// ProcessBlock takes a blockbeat and processes it. A receive-only error chan
+// must be returned.
+func (m *MockConsumer) ProcessBlock(b Blockbeat) error {
+	args := m.Called(b)
+
+	return args.Error(0)
+}
+
+// MockBlockbeat is a mock implementation of the Blockbeat interface.
+type MockBlockbeat struct {
+	mock.Mock
+}
+
+// Compile-time constraint to ensure MockBlockbeat implements Blockbeat.
+var _ Blockbeat = (*MockBlockbeat)(nil)
+
+// Height returns the current block height.
+func (m *MockBlockbeat) Height() int32 {
+	args := m.Called()
+
+	return args.Get(0).(int32)
+}
+
+// logger returns the logger for the blockbeat.
+func (m *MockBlockbeat) logger() btclog.Logger {
+	args := m.Called()
+
+	return args.Get(0).(btclog.Logger)
+}

--- a/chanacceptor/rpcacceptor.go
+++ b/chanacceptor/rpcacceptor.go
@@ -357,6 +357,30 @@ func (r *RPCAcceptor) sendAcceptRequests(errChan chan error,
 					commitmentType = lnrpc.CommitmentType_SIMPLE_TAPROOT
 
 				case channelFeatures.OnlyContains(
+					lnwire.SimpleTaprootOverlayChansRequired,
+					lnwire.ZeroConfRequired,
+					lnwire.ScidAliasRequired,
+				):
+					commitmentType = lnrpc.CommitmentType_SIMPLE_TAPROOT_OVERLAY
+
+				case channelFeatures.OnlyContains(
+					lnwire.SimpleTaprootOverlayChansRequired,
+					lnwire.ZeroConfRequired,
+				):
+					commitmentType = lnrpc.CommitmentType_SIMPLE_TAPROOT_OVERLAY
+
+				case channelFeatures.OnlyContains(
+					lnwire.SimpleTaprootOverlayChansRequired,
+					lnwire.ScidAliasRequired,
+				):
+					commitmentType = lnrpc.CommitmentType_SIMPLE_TAPROOT_OVERLAY
+
+				case channelFeatures.OnlyContains(
+					lnwire.SimpleTaprootOverlayChansRequired,
+				):
+					commitmentType = lnrpc.CommitmentType_SIMPLE_TAPROOT_OVERLAY
+
+				case channelFeatures.OnlyContains(
 					lnwire.StaticRemoteKeyRequired,
 				):
 					commitmentType = lnrpc.CommitmentType_STATIC_REMOTE_KEY

--- a/contractcourt/anchor_resolver.go
+++ b/contractcourt/anchor_resolver.go
@@ -84,7 +84,7 @@ func (c *anchorResolver) ResolverKey() []byte {
 }
 
 // Resolve offers the anchor output to the sweeper and waits for it to be swept.
-func (c *anchorResolver) Resolve(_ bool) (ContractResolver, error) {
+func (c *anchorResolver) Resolve() (ContractResolver, error) {
 	// Attempt to update the sweep parameters to the post-confirmation
 	// situation. We don't want to force sweep anymore, because the anchor
 	// lost its special purpose to get the commitment confirmed. It is just

--- a/contractcourt/breach_arbitrator_test.go
+++ b/contractcourt/breach_arbitrator_test.go
@@ -36,7 +36,7 @@ import (
 )
 
 var (
-	defaultTimeout = 30 * time.Second
+	defaultTimeout = 10 * time.Second
 
 	breachOutPoints = []wire.OutPoint{
 		{

--- a/contractcourt/breach_resolver.go
+++ b/contractcourt/breach_resolver.go
@@ -47,7 +47,7 @@ func (b *breachResolver) ResolverKey() []byte {
 // been broadcast.
 //
 // TODO(yy): let sweeper handle the breach inputs.
-func (b *breachResolver) Resolve(_ bool) (ContractResolver, error) {
+func (b *breachResolver) Resolve() (ContractResolver, error) {
 	if !b.subscribed {
 		complete, err := b.SubscribeBreachComplete(
 			&b.ChanPoint, b.replyChan,

--- a/contractcourt/chain_arbitrator.go
+++ b/contractcourt/chain_arbitrator.go
@@ -267,6 +267,9 @@ type ChainArbitrator struct {
 	// active channels that it must still watch over.
 	chanSource *channeldb.DB
 
+	// beat is the current best known blockbeat.
+	beat chainio.Blockbeat
+
 	quit chan struct{}
 
 	wg sync.WaitGroup
@@ -801,18 +804,11 @@ func (c *ChainArbitrator) Start() error {
 		}
 	}
 
-	// Subscribe to a single stream of block epoch notifications that we
-	// will dispatch to all active arbitrators.
-	blockEpoch, err := c.cfg.Notifier.RegisterBlockEpochNtfn(nil)
-	if err != nil {
-		return err
-	}
-
 	// Start our goroutine which will dispatch blocks to each arbitrator.
 	c.wg.Add(1)
 	go func() {
 		defer c.wg.Done()
-		c.dispatchBlocks(blockEpoch)
+		c.dispatchBlocks()
 	}()
 
 	// TODO(roasbeef): eventually move all breach watching here
@@ -820,100 +816,54 @@ func (c *ChainArbitrator) Start() error {
 	return nil
 }
 
-// blockRecipient contains the information we need to dispatch a block to a
-// channel arbitrator.
-type blockRecipient struct {
-	// chanPoint is the funding outpoint of the channel.
-	chanPoint wire.OutPoint
-
-	// blocks is the channel that new block heights are sent into. This
-	// channel should be sufficiently buffered as to not block the sender.
-	blocks chan<- int32
-
-	// quit is closed if the receiving entity is shutting down.
-	quit chan struct{}
-}
-
 // dispatchBlocks consumes a block epoch notification stream and dispatches
 // blocks to each of the chain arb's active channel arbitrators. This function
 // must be run in a goroutine.
-func (c *ChainArbitrator) dispatchBlocks(
-	blockEpoch *chainntnfs.BlockEpochEvent) {
-
-	// getRecipients is a helper function which acquires the chain arb
-	// lock and returns a set of block recipients which can be used to
-	// dispatch blocks.
-	getRecipients := func() []blockRecipient {
-		c.Lock()
-		blocks := make([]blockRecipient, 0, len(c.activeChannels))
-		for _, channel := range c.activeChannels {
-			blocks = append(blocks, blockRecipient{
-				chanPoint: channel.cfg.ChanPoint,
-				blocks:    channel.blocks,
-				quit:      channel.quit,
-			})
-		}
-		c.Unlock()
-
-		return blocks
-	}
-
-	// On exit, cancel our blocks subscription and close each block channel
-	// so that the arbitrators know they will no longer be receiving blocks.
-	defer func() {
-		blockEpoch.Cancel()
-
-		recipients := getRecipients()
-		for _, recipient := range recipients {
-			close(recipient.blocks)
-		}
-	}()
-
+func (c *ChainArbitrator) dispatchBlocks() {
 	// Consume block epochs until we receive the instruction to shutdown.
 	for {
 		select {
 		// Consume block epochs, exiting if our subscription is
 		// terminated.
-		case block, ok := <-blockEpoch.Epochs:
-			if !ok {
-				log.Trace("dispatchBlocks block epoch " +
-					"cancelled")
-				return
-			}
+		case beat := <-c.BlockbeatChan:
+			// Set the current blockbeat.
+			c.beat = beat
 
-			// Get the set of currently active channels block
-			// subscription channels and dispatch the block to
-			// each.
-			for _, recipient := range getRecipients() {
-				select {
-				// Deliver the block to the arbitrator.
-				case recipient.blocks <- block.Height:
-
-				// If the recipient is shutting down, exit
-				// without delivering the block. This may be
-				// the case when two blocks are mined in quick
-				// succession, and the arbitrator resolves
-				// after the first block, and does not need to
-				// consume the second block.
-				case <-recipient.quit:
-					log.Debugf("channel: %v exit without "+
-						"receiving block: %v",
-						recipient.chanPoint,
-						block.Height)
-
-				// If the chain arb is shutting down, we don't
-				// need to deliver any more blocks (everything
-				// will be shutting down).
-				case <-c.quit:
-					return
-				}
-			}
+			// Send this blockbeat to all the active channels and
+			// wait for them to finish processing it.
+			c.handleBlockbeat(beat)
 
 		// Exit if the chain arbitrator is shutting down.
 		case <-c.quit:
 			return
 		}
 	}
+}
+
+// handleBlockbeat sends the blockbeat to all active channel arbitrator in
+// parallel and wait for them to finish processing it.
+func (c *ChainArbitrator) handleBlockbeat(beat chainio.Blockbeat) {
+	// Read the active channels in a lock.
+	c.Lock()
+
+	// Create a slice to record active channel arbitrator.
+	channels := make([]chainio.Consumer, 0, len(c.activeChannels))
+
+	// Copy the active channels to the slice.
+	for _, channel := range c.activeChannels {
+		channels = append(channels, channel)
+	}
+
+	c.Unlock()
+
+	// Iterate all the copied channels and send the blockbeat to them.
+	//
+	// NOTE: This method will timeout if the processing of blocks of the
+	// subsystems is too long (60s).
+	err := chainio.DispatchConcurrent(beat, channels)
+
+	// Notify the chain arbitrator has processed the block.
+	c.NotifyBlockProcessed(beat, err)
 }
 
 // republishClosingTxs will load any stored cooperative or unilateral closing

--- a/contractcourt/chain_arbitrator.go
+++ b/contractcourt/chain_arbitrator.go
@@ -798,7 +798,7 @@ func (c *ChainArbitrator) Start() error {
 				arbitrator.cfg.ChanPoint)
 		}
 
-		if err := arbitrator.Start(startState); err != nil {
+		if err := arbitrator.Start(startState, c.beat); err != nil {
 			stopAndLog()
 			return err
 		}
@@ -1215,7 +1215,7 @@ func (c *ChainArbitrator) WatchNewChannel(newChan *channeldb.OpenChannel) error 
 	// arbitrators, then launch it.
 	c.activeChannels[chanPoint] = channelArb
 
-	if err := channelArb.Start(nil); err != nil {
+	if err := channelArb.Start(nil, c.beat); err != nil {
 		return err
 	}
 

--- a/contractcourt/chain_arbitrator.go
+++ b/contractcourt/chain_arbitrator.go
@@ -574,13 +574,16 @@ func (c *ChainArbitrator) ResolveContract(chanPoint wire.OutPoint) error {
 }
 
 // Start launches all goroutines that the ChainArbitrator needs to operate.
-func (c *ChainArbitrator) Start() error {
+func (c *ChainArbitrator) Start(beat chainio.Blockbeat) error {
 	if !atomic.CompareAndSwapInt32(&c.started, 0, 1) {
 		return nil
 	}
 
-	log.Infof("ChainArbitrator starting with config: budget=[%v]",
-		&c.cfg.Budget)
+	// Set the current beat.
+	c.beat = beat
+
+	log.Infof("ChainArbitrator starting at height %d with budget=[%v]",
+		&c.cfg.Budget, c.beat.Height())
 
 	// First, we'll fetch all the channels that are still open, in order to
 	// collect them within our set of active contracts.

--- a/contractcourt/chain_arbitrator.go
+++ b/contractcourt/chain_arbitrator.go
@@ -587,135 +587,15 @@ func (c *ChainArbitrator) Start(beat chainio.Blockbeat) error {
 
 	// First, we'll fetch all the channels that are still open, in order to
 	// collect them within our set of active contracts.
-	openChannels, err := c.chanSource.ChannelStateDB().FetchAllChannels()
-	if err != nil {
+	if err := c.loadOpenChannels(); err != nil {
 		return err
-	}
-
-	if len(openChannels) > 0 {
-		log.Infof("Creating ChannelArbitrators for %v active channels",
-			len(openChannels))
-	}
-
-	// For each open channel, we'll configure then launch a corresponding
-	// ChannelArbitrator.
-	for _, channel := range openChannels {
-		chanPoint := channel.FundingOutpoint
-		channel := channel
-
-		// First, we'll create an active chainWatcher for this channel
-		// to ensure that we detect any relevant on chain events.
-		breachClosure := func(ret *lnwallet.BreachRetribution) error {
-			return c.cfg.ContractBreach(chanPoint, ret)
-		}
-
-		chainWatcher, err := newChainWatcher(
-			chainWatcherConfig{
-				chanState:           channel,
-				notifier:            c.cfg.Notifier,
-				signer:              c.cfg.Signer,
-				isOurAddr:           c.cfg.IsOurAddress,
-				contractBreach:      breachClosure,
-				extractStateNumHint: lnwallet.GetStateNumHint,
-				auxLeafStore:        c.cfg.AuxLeafStore,
-				auxResolver:         c.cfg.AuxResolver,
-			},
-		)
-		if err != nil {
-			return err
-		}
-
-		c.activeWatchers[chanPoint] = chainWatcher
-		channelArb, err := newActiveChannelArbitrator(
-			channel, c, chainWatcher.SubscribeChannelEvents(),
-		)
-		if err != nil {
-			return err
-		}
-
-		c.activeChannels[chanPoint] = channelArb
-
-		// Republish any closing transactions for this channel.
-		err = c.republishClosingTxs(channel)
-		if err != nil {
-			log.Errorf("Failed to republish closing txs for "+
-				"channel %v", chanPoint)
-		}
 	}
 
 	// In addition to the channels that we know to be open, we'll also
 	// launch arbitrators to finishing resolving any channels that are in
 	// the pending close state.
-	closingChannels, err := c.chanSource.ChannelStateDB().FetchClosedChannels(
-		true,
-	)
-	if err != nil {
+	if err := c.loadPendingCloseChannels(); err != nil {
 		return err
-	}
-
-	if len(closingChannels) > 0 {
-		log.Infof("Creating ChannelArbitrators for %v closing channels",
-			len(closingChannels))
-	}
-
-	// Next, for each channel is the closing state, we'll launch a
-	// corresponding more restricted resolver, as we don't have to watch
-	// the chain any longer, only resolve the contracts on the confirmed
-	// commitment.
-	//nolint:lll
-	for _, closeChanInfo := range closingChannels {
-		// We can leave off the CloseContract and ForceCloseChan
-		// methods as the channel is already closed at this point.
-		chanPoint := closeChanInfo.ChanPoint
-		arbCfg := ChannelArbitratorConfig{
-			ChanPoint:             chanPoint,
-			ShortChanID:           closeChanInfo.ShortChanID,
-			ChainArbitratorConfig: c.cfg,
-			ChainEvents:           &ChainEventSubscription{},
-			IsPendingClose:        true,
-			ClosingHeight:         closeChanInfo.CloseHeight,
-			CloseType:             closeChanInfo.CloseType,
-			PutResolverReport: func(tx kvdb.RwTx,
-				report *channeldb.ResolverReport) error {
-
-				return c.chanSource.PutResolverReport(
-					tx, c.cfg.ChainHash, &chanPoint, report,
-				)
-			},
-			FetchHistoricalChannel: func() (*channeldb.OpenChannel, error) {
-				chanStateDB := c.chanSource.ChannelStateDB()
-				return chanStateDB.FetchHistoricalChannel(&chanPoint)
-			},
-			FindOutgoingHTLCDeadline: func(
-				htlc channeldb.HTLC) fn.Option[int32] {
-
-				return c.FindOutgoingHTLCDeadline(
-					closeChanInfo.ShortChanID, htlc,
-				)
-			},
-		}
-		chanLog, err := newBoltArbitratorLog(
-			c.chanSource.Backend, arbCfg, c.cfg.ChainHash, chanPoint,
-		)
-		if err != nil {
-			return err
-		}
-		arbCfg.MarkChannelResolved = func() error {
-			if c.cfg.NotifyFullyResolvedChannel != nil {
-				c.cfg.NotifyFullyResolvedChannel(chanPoint)
-			}
-
-			return c.ResolveContract(chanPoint)
-		}
-
-		// We create an empty map of HTLC's here since it's possible
-		// that the channel is in StateDefault and updateActiveHTLCs is
-		// called. We want to avoid writing to an empty map. Since the
-		// channel is already in the process of being resolved, no new
-		// HTLCs will be added.
-		c.activeChannels[chanPoint] = NewChannelArbitrator(
-			arbCfg, make(map[HtlcSetKey]htlcSet), chanLog,
-		)
 	}
 
 	// Now, we'll start all chain watchers in parallel to shorten start up
@@ -769,7 +649,7 @@ func (c *ChainArbitrator) Start(beat chainio.Blockbeat) error {
 	// transaction.
 	var startStates map[wire.OutPoint]*chanArbStartState
 
-	err = kvdb.View(c.chanSource, func(tx walletdb.ReadTx) error {
+	err := kvdb.View(c.chanSource, func(tx walletdb.ReadTx) error {
 		for _, arbitrator := range c.activeChannels {
 			startState, err := arbitrator.getStartState(tx)
 			if err != nil {
@@ -1335,4 +1215,148 @@ func (c *ChainArbitrator) FindOutgoingHTLCDeadline(scid lnwire.ShortChannelID,
 // NOTE: part of the `chainio.Consumer` interface.
 func (c *ChainArbitrator) Name() string {
 	return "ChainArbitrator"
+}
+
+// loadOpenChannels loads all channels that are currently open in the database
+// and registers them with the chainWatcher for future notification.
+func (c *ChainArbitrator) loadOpenChannels() error {
+	openChannels, err := c.chanSource.ChannelStateDB().FetchAllChannels()
+	if err != nil {
+		return err
+	}
+
+	if len(openChannels) == 0 {
+		return nil
+	}
+
+	log.Infof("Creating ChannelArbitrators for %v active channels",
+		len(openChannels))
+
+	// For each open channel, we'll configure then launch a corresponding
+	// ChannelArbitrator.
+	for _, channel := range openChannels {
+		chanPoint := channel.FundingOutpoint
+		channel := channel
+
+		// First, we'll create an active chainWatcher for this channel
+		// to ensure that we detect any relevant on chain events.
+		breachClosure := func(ret *lnwallet.BreachRetribution) error {
+			return c.cfg.ContractBreach(chanPoint, ret)
+		}
+
+		chainWatcher, err := newChainWatcher(
+			chainWatcherConfig{
+				chanState:           channel,
+				notifier:            c.cfg.Notifier,
+				signer:              c.cfg.Signer,
+				isOurAddr:           c.cfg.IsOurAddress,
+				contractBreach:      breachClosure,
+				extractStateNumHint: lnwallet.GetStateNumHint,
+				auxLeafStore:        c.cfg.AuxLeafStore,
+				auxResolver:         c.cfg.AuxResolver,
+			},
+		)
+		if err != nil {
+			return err
+		}
+
+		c.activeWatchers[chanPoint] = chainWatcher
+		channelArb, err := newActiveChannelArbitrator(
+			channel, c, chainWatcher.SubscribeChannelEvents(),
+		)
+		if err != nil {
+			return err
+		}
+
+		c.activeChannels[chanPoint] = channelArb
+
+		// Republish any closing transactions for this channel.
+		err = c.republishClosingTxs(channel)
+		if err != nil {
+			log.Errorf("Failed to republish closing txs for "+
+				"channel %v", chanPoint)
+		}
+	}
+
+	return nil
+}
+
+// loadPendingCloseChannels loads all channels that are currently pending
+// closure in the database and registers them with the ChannelArbitrator to
+// continue the resolution process.
+func (c *ChainArbitrator) loadPendingCloseChannels() error {
+	chanStateDB := c.chanSource.ChannelStateDB()
+
+	closingChannels, err := chanStateDB.FetchClosedChannels(true)
+	if err != nil {
+		return err
+	}
+
+	if len(closingChannels) == 0 {
+		return nil
+	}
+
+	log.Infof("Creating ChannelArbitrators for %v closing channels",
+		len(closingChannels))
+
+	// Next, for each channel is the closing state, we'll launch a
+	// corresponding more restricted resolver, as we don't have to watch
+	// the chain any longer, only resolve the contracts on the confirmed
+	// commitment.
+	//nolint:lll
+	for _, closeChanInfo := range closingChannels {
+		// We can leave off the CloseContract and ForceCloseChan
+		// methods as the channel is already closed at this point.
+		chanPoint := closeChanInfo.ChanPoint
+		arbCfg := ChannelArbitratorConfig{
+			ChanPoint:             chanPoint,
+			ShortChanID:           closeChanInfo.ShortChanID,
+			ChainArbitratorConfig: c.cfg,
+			ChainEvents:           &ChainEventSubscription{},
+			IsPendingClose:        true,
+			ClosingHeight:         closeChanInfo.CloseHeight,
+			CloseType:             closeChanInfo.CloseType,
+			PutResolverReport: func(tx kvdb.RwTx,
+				report *channeldb.ResolverReport) error {
+
+				return c.chanSource.PutResolverReport(
+					tx, c.cfg.ChainHash, &chanPoint, report,
+				)
+			},
+			FetchHistoricalChannel: func() (*channeldb.OpenChannel, error) {
+				return chanStateDB.FetchHistoricalChannel(&chanPoint)
+			},
+			FindOutgoingHTLCDeadline: func(
+				htlc channeldb.HTLC) fn.Option[int32] {
+
+				return c.FindOutgoingHTLCDeadline(
+					closeChanInfo.ShortChanID, htlc,
+				)
+			},
+		}
+		chanLog, err := newBoltArbitratorLog(
+			c.chanSource.Backend, arbCfg, c.cfg.ChainHash, chanPoint,
+		)
+		if err != nil {
+			return err
+		}
+		arbCfg.MarkChannelResolved = func() error {
+			if c.cfg.NotifyFullyResolvedChannel != nil {
+				c.cfg.NotifyFullyResolvedChannel(chanPoint)
+			}
+
+			return c.ResolveContract(chanPoint)
+		}
+
+		// We create an empty map of HTLC's here since it's possible
+		// that the channel is in StateDefault and updateActiveHTLCs is
+		// called. We want to avoid writing to an empty map. Since the
+		// channel is already in the process of being resolved, no new
+		// HTLCs will be added.
+		c.activeChannels[chanPoint] = NewChannelArbitrator(
+			arbCfg, make(map[HtlcSetKey]htlcSet), chanLog,
+		)
+	}
+
+	return nil
 }

--- a/contractcourt/chain_arbitrator.go
+++ b/contractcourt/chain_arbitrator.go
@@ -335,11 +335,10 @@ func (a *arbChannel) NewAnchorResolutions() (*lnwallet.AnchorResolutions,
 // ForceCloseChan should force close the contract that this attendant is
 // watching over. We'll use this when we decide that we need to go to chain. It
 // should in addition tell the switch to remove the corresponding link, such
-// that we won't accept any new updates. The returned summary contains all items
-// needed to eventually resolve all outputs on chain.
+// that we won't accept any new updates.
 //
 // NOTE: Part of the ArbChannel interface.
-func (a *arbChannel) ForceCloseChan() (*lnwallet.LocalForceCloseSummary, error) {
+func (a *arbChannel) ForceCloseChan() (*wire.MsgTx, error) {
 	// First, we mark the channel as borked, this ensure
 	// that no new state transitions can happen, and also
 	// that the link won't be loaded into the switch.
@@ -386,7 +385,15 @@ func (a *arbChannel) ForceCloseChan() (*lnwallet.LocalForceCloseSummary, error) 
 	if err != nil {
 		return nil, err
 	}
-	return chanMachine.ForceClose()
+
+	closeSummary, err := chanMachine.ForceClose(
+		lnwallet.WithSkipContractResolutions(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return closeSummary.CloseTx, nil
 }
 
 // newActiveChannelArbitrator creates a new instance of an active channel

--- a/contractcourt/chain_arbitrator_test.go
+++ b/contractcourt/chain_arbitrator_test.go
@@ -83,7 +83,6 @@ func TestChainArbitratorRepublishCloses(t *testing.T) {
 		ChainIO: &mock.ChainIO{},
 		Notifier: &mock.ChainNotifier{
 			SpendChan: make(chan *chainntnfs.SpendDetail),
-			EpochChan: make(chan *chainntnfs.BlockEpoch),
 			ConfChan:  make(chan *chainntnfs.TxConfirmation),
 		},
 		PublishTx: func(tx *wire.MsgTx, _ string) error {
@@ -168,7 +167,6 @@ func TestResolveContract(t *testing.T) {
 		ChainIO: &mock.ChainIO{},
 		Notifier: &mock.ChainNotifier{
 			SpendChan: make(chan *chainntnfs.SpendDetail),
-			EpochChan: make(chan *chainntnfs.BlockEpoch),
 			ConfChan:  make(chan *chainntnfs.TxConfirmation),
 		},
 		PublishTx: func(tx *wire.MsgTx, _ string) error {

--- a/contractcourt/chain_arbitrator_test.go
+++ b/contractcourt/chain_arbitrator_test.go
@@ -96,7 +96,8 @@ func TestChainArbitratorRepublishCloses(t *testing.T) {
 		chainArbCfg, db,
 	)
 
-	if err := chainArb.Start(); err != nil {
+	beat := newBeatFromHeight(0)
+	if err := chainArb.Start(beat); err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
@@ -183,7 +184,8 @@ func TestResolveContract(t *testing.T) {
 	chainArb := NewChainArbitrator(
 		chainArbCfg, db,
 	)
-	if err := chainArb.Start(); err != nil {
+	beat := newBeatFromHeight(0)
+	if err := chainArb.Start(beat); err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {

--- a/contractcourt/chain_watcher_test.go
+++ b/contractcourt/chain_watcher_test.go
@@ -504,14 +504,24 @@ func TestChainWatcherLocalForceCloseDetect(t *testing.T) {
 		// outputs.
 		select {
 		case summary := <-chanEvents.LocalUnilateralClosure:
+			resOpt := summary.LocalForceCloseSummary.
+				ContractResolutions
+
+			resolutions, err := resOpt.UnwrapOrErr(
+				fmt.Errorf("resolutions not found"),
+			)
+			if err != nil {
+				t.Fatalf("unable to get resolutions: %v", err)
+			}
+
 			// Make sure we correctly extracted the commit
 			// resolution if we had a local output.
 			if remoteOutputOnly {
-				if summary.CommitResolution != nil {
+				if resolutions.CommitResolution != nil {
 					t.Fatalf("expected no commit resolution")
 				}
 			} else {
-				if summary.CommitResolution == nil {
+				if resolutions.CommitResolution == nil {
 					t.Fatalf("expected commit resolution")
 				}
 			}

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -462,7 +462,9 @@ func (c *ChannelArbitrator) getStartState(tx kvdb.RTx) (*chanArbStartState,
 // Start starts all the goroutines that the ChannelArbitrator needs to operate.
 // If takes a start state, which will be looked up on disk if it is not
 // provided.
-func (c *ChannelArbitrator) Start(state *chanArbStartState) error {
+func (c *ChannelArbitrator) Start(state *chanArbStartState,
+	beat chainio.Blockbeat) error {
+
 	if !atomic.CompareAndSwapInt32(&c.started, 0, 1) {
 		return nil
 	}
@@ -484,10 +486,8 @@ func (c *ChannelArbitrator) Start(state *chanArbStartState) error {
 	// Set our state from our starting state.
 	c.state = state.currentState
 
-	_, bestHeight, err := c.cfg.ChainIO.GetBestBlock()
-	if err != nil {
-		return err
-	}
+	// Get the starting height.
+	bestHeight := beat.Height()
 
 	// If the channel has been marked pending close in the database, and we
 	// haven't transitioned the state machine to StateContractClosed (or a

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -14,6 +14,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/chainio"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/fn"
@@ -330,6 +331,10 @@ type ChannelArbitrator struct {
 	started int32 // To be used atomically.
 	stopped int32 // To be used atomically.
 
+	// Embed the blockbeat consumer struct to get access to the method
+	// `NotifyBlockProcessed` and the `BlockbeatChan`.
+	chainio.BeatConsumer
+
 	// startTimestamp is the time when this ChannelArbitrator was started.
 	startTimestamp time.Time
 
@@ -404,7 +409,7 @@ func NewChannelArbitrator(cfg ChannelArbitratorConfig,
 		unmerged[RemotePendingHtlcSet] = htlcSets[RemotePendingHtlcSet]
 	}
 
-	return &ChannelArbitrator{
+	c := &ChannelArbitrator{
 		log:              log,
 		blocks:           make(chan int32, arbitratorBlockBufferSize),
 		signalUpdates:    make(chan *signalUpdateMsg),
@@ -415,7 +420,15 @@ func NewChannelArbitrator(cfg ChannelArbitratorConfig,
 		cfg:              cfg,
 		quit:             make(chan struct{}),
 	}
+
+	// Mount the block consumer.
+	c.BeatConsumer = chainio.NewBeatConsumer(c.quit, c.Name())
+
+	return c
 }
+
+// Compile-time check for the chainio.Consumer interface.
+var _ chainio.Consumer = (*ChannelArbitrator)(nil)
 
 // chanArbStartState contains the information from disk that we need to start
 // up a channel arbitrator.
@@ -3102,6 +3115,13 @@ func (c *ChannelArbitrator) channelAttendant(bestHeight int32) {
 			return
 		}
 	}
+}
+
+// Name returns a human-readable string for this subsystem.
+//
+// NOTE: Part of chainio.Consumer interface.
+func (c *ChannelArbitrator) Name() string {
+	return fmt.Sprintf("ChannelArbitrator(%v)", c.cfg.ChanPoint)
 }
 
 // checkLegacyBreach returns StateFullyResolved if the channel was closed with

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -1598,8 +1598,8 @@ func (c *ChannelArbitrator) advanceState(
 	for {
 		priorState = c.state
 		log.Debugf("ChannelArbitrator(%v): attempting state step with "+
-			"trigger=%v from state=%v", c.cfg.ChanPoint, trigger,
-			priorState)
+			"trigger=%v from state=%v at height=%v",
+			c.cfg.ChanPoint, trigger, priorState, triggerHeight)
 
 		nextState, closeTx, err := c.stateStep(
 			triggerHeight, trigger, confCommitSet,
@@ -2795,14 +2795,12 @@ func (c *ChannelArbitrator) channelAttendant(bestHeight int32) {
 		// We have broadcasted our commitment, and it is now confirmed
 		// on-chain.
 		case closeInfo := <-c.cfg.ChainEvents.LocalUnilateralClosure:
-			log.Infof("ChannelArbitrator(%v): local on-chain "+
-				"channel close", c.cfg.ChanPoint)
-
 			if c.state != StateCommitmentBroadcasted {
 				log.Errorf("ChannelArbitrator(%v): unexpected "+
 					"local on-chain channel close",
 					c.cfg.ChanPoint)
 			}
+
 			closeTx := closeInfo.CloseTx
 
 			resolutions, err := closeInfo.ContractResolutions.
@@ -2829,6 +2827,10 @@ func (c *ChannelArbitrator) channelAttendant(bestHeight int32) {
 
 				return
 			}
+
+			log.Infof("ChannelArbitrator(%v): local force close "+
+				"tx=%v confirmed", c.cfg.ChanPoint,
+				closeTx.TxHash())
 
 			contractRes := &ContractResolutions{
 				CommitHash:       closeTx.TxHash(),

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -98,7 +98,7 @@ type ArbChannel interface {
 	// corresponding link, such that we won't accept any new updates. The
 	// returned summary contains all items needed to eventually resolve all
 	// outputs on chain.
-	ForceCloseChan() (*lnwallet.LocalForceCloseSummary, error)
+	ForceCloseChan() (*wire.MsgTx, error)
 
 	// NewAnchorResolutions returns the anchor resolutions for currently
 	// valid commitment transactions.
@@ -1098,7 +1098,7 @@ func (c *ChannelArbitrator) stateStep(
 		// We'll tell the switch that it should remove the link for
 		// this channel, in addition to fetching the force close
 		// summary needed to close this channel on chain.
-		closeSummary, err := c.cfg.Channel.ForceCloseChan()
+		forceCloseTx, err := c.cfg.Channel.ForceCloseChan()
 		if err != nil {
 			log.Errorf("ChannelArbitrator(%v): unable to "+
 				"force close: %v", c.cfg.ChanPoint, err)
@@ -1118,7 +1118,7 @@ func (c *ChannelArbitrator) stateStep(
 
 			return StateError, closeTx, err
 		}
-		closeTx = closeSummary.CloseTx
+		closeTx = forceCloseTx
 
 		// Before publishing the transaction, we store it to the
 		// database, such that we can re-publish later in case it
@@ -2812,11 +2812,36 @@ func (c *ChannelArbitrator) channelAttendant(bestHeight int32) {
 			}
 			closeTx := closeInfo.CloseTx
 
+			resolutions, err := closeInfo.ContractResolutions.
+				UnwrapOrErr(
+					fmt.Errorf("resolutions not found"),
+				)
+			if err != nil {
+				log.Errorf("ChannelArbitrator(%v): unable to "+
+					"get resolutions: %v", c.cfg.ChanPoint,
+					err)
+
+				return
+			}
+
+			// We make sure that the htlc resolutions are present
+			// otherwise we would panic dereferencing the pointer.
+			//
+			// TODO(ziggie): Refactor ContractResolutions to use
+			// options.
+			if resolutions.HtlcResolutions == nil {
+				log.Errorf("ChannelArbitrator(%v): htlc "+
+					"resolutions not found",
+					c.cfg.ChanPoint)
+
+				return
+			}
+
 			contractRes := &ContractResolutions{
 				CommitHash:       closeTx.TxHash(),
-				CommitResolution: closeInfo.CommitResolution,
-				HtlcResolutions:  *closeInfo.HtlcResolutions,
-				AnchorResolution: closeInfo.AnchorResolution,
+				CommitResolution: resolutions.CommitResolution,
+				HtlcResolutions:  *resolutions.HtlcResolutions,
+				AnchorResolution: resolutions.AnchorResolution,
 			}
 
 			// When processing a unilateral close event, we'll
@@ -2825,7 +2850,7 @@ func (c *ChannelArbitrator) channelAttendant(bestHeight int32) {
 			// available to fetch in that state, we'll also write
 			// the commit set so we can reconstruct our chain
 			// actions on restart.
-			err := c.log.LogContractResolutions(contractRes)
+			err = c.log.LogContractResolutions(contractRes)
 			if err != nil {
 				log.Errorf("Unable to write resolutions: %v",
 					err)

--- a/contractcourt/channel_arbitrator_test.go
+++ b/contractcourt/channel_arbitrator_test.go
@@ -295,7 +295,8 @@ func (c *chanArbTestCtx) Restart(restartClosure func(*chanArbTestCtx)) (*chanArb
 		restartClosure(newCtx)
 	}
 
-	if err := newCtx.chanArb.Start(nil); err != nil {
+	beat := newBeatFromHeight(0)
+	if err := newCtx.chanArb.Start(nil, beat); err != nil {
 		return nil, err
 	}
 
@@ -522,7 +523,8 @@ func TestChannelArbitratorCooperativeClose(t *testing.T) {
 	chanArbCtx, err := createTestChannelArbitrator(t, log)
 	require.NoError(t, err, "unable to create ChannelArbitrator")
 
-	if err := chanArbCtx.chanArb.Start(nil); err != nil {
+	beat := newBeatFromHeight(0)
+	if err := chanArbCtx.chanArb.Start(nil, beat); err != nil {
 		t.Fatalf("unable to start ChannelArbitrator: %v", err)
 	}
 	t.Cleanup(func() {
@@ -580,7 +582,8 @@ func TestChannelArbitratorRemoteForceClose(t *testing.T) {
 	require.NoError(t, err, "unable to create ChannelArbitrator")
 	chanArb := chanArbCtx.chanArb
 
-	if err := chanArb.Start(nil); err != nil {
+	beat := newBeatFromHeight(0)
+	if err := chanArb.Start(nil, beat); err != nil {
 		t.Fatalf("unable to start ChannelArbitrator: %v", err)
 	}
 	defer chanArb.Stop()
@@ -633,7 +636,8 @@ func TestChannelArbitratorLocalForceClose(t *testing.T) {
 	require.NoError(t, err, "unable to create ChannelArbitrator")
 	chanArb := chanArbCtx.chanArb
 
-	if err := chanArb.Start(nil); err != nil {
+	beat := newBeatFromHeight(0)
+	if err := chanArb.Start(nil, beat); err != nil {
 		t.Fatalf("unable to start ChannelArbitrator: %v", err)
 	}
 	defer chanArb.Stop()
@@ -745,7 +749,8 @@ func TestChannelArbitratorBreachClose(t *testing.T) {
 	chanArb.cfg.PreimageDB = newMockWitnessBeacon()
 	chanArb.cfg.Registry = &mockRegistry{}
 
-	if err := chanArb.Start(nil); err != nil {
+	beat := newBeatFromHeight(0)
+	if err := chanArb.Start(nil, beat); err != nil {
 		t.Fatalf("unable to start ChannelArbitrator: %v", err)
 	}
 	t.Cleanup(func() {
@@ -872,7 +877,8 @@ func TestChannelArbitratorLocalForceClosePendingHtlc(t *testing.T) {
 	chanArb.cfg.PreimageDB = newMockWitnessBeacon()
 	chanArb.cfg.Registry = &mockRegistry{}
 
-	if err := chanArb.Start(nil); err != nil {
+	beat := newBeatFromHeight(0)
+	if err := chanArb.Start(nil, beat); err != nil {
 		t.Fatalf("unable to start ChannelArbitrator: %v", err)
 	}
 	defer chanArb.Stop()
@@ -1153,7 +1159,8 @@ func TestChannelArbitratorLocalForceCloseRemoteConfirmed(t *testing.T) {
 	require.NoError(t, err, "unable to create ChannelArbitrator")
 	chanArb := chanArbCtx.chanArb
 
-	if err := chanArb.Start(nil); err != nil {
+	beat := newBeatFromHeight(0)
+	if err := chanArb.Start(nil, beat); err != nil {
 		t.Fatalf("unable to start ChannelArbitrator: %v", err)
 	}
 	defer chanArb.Stop()
@@ -1260,7 +1267,8 @@ func TestChannelArbitratorLocalForceDoubleSpend(t *testing.T) {
 	require.NoError(t, err, "unable to create ChannelArbitrator")
 	chanArb := chanArbCtx.chanArb
 
-	if err := chanArb.Start(nil); err != nil {
+	beat := newBeatFromHeight(0)
+	if err := chanArb.Start(nil, beat); err != nil {
 		t.Fatalf("unable to start ChannelArbitrator: %v", err)
 	}
 	defer chanArb.Stop()
@@ -1366,7 +1374,8 @@ func TestChannelArbitratorPersistence(t *testing.T) {
 	require.NoError(t, err, "unable to create ChannelArbitrator")
 
 	chanArb := chanArbCtx.chanArb
-	if err := chanArb.Start(nil); err != nil {
+	beat := newBeatFromHeight(0)
+	if err := chanArb.Start(nil, beat); err != nil {
 		t.Fatalf("unable to start ChannelArbitrator: %v", err)
 	}
 
@@ -1484,7 +1493,8 @@ func TestChannelArbitratorForceCloseBreachedChannel(t *testing.T) {
 	require.NoError(t, err, "unable to create ChannelArbitrator")
 
 	chanArb := chanArbCtx.chanArb
-	if err := chanArb.Start(nil); err != nil {
+	beat := newBeatFromHeight(0)
+	if err := chanArb.Start(nil, beat); err != nil {
 		t.Fatalf("unable to start ChannelArbitrator: %v", err)
 	}
 
@@ -1671,7 +1681,8 @@ func TestChannelArbitratorCommitFailure(t *testing.T) {
 		}
 
 		chanArb := chanArbCtx.chanArb
-		if err := chanArb.Start(nil); err != nil {
+		beat := newBeatFromHeight(0)
+		if err := chanArb.Start(nil, beat); err != nil {
 			t.Fatalf("unable to start ChannelArbitrator: %v", err)
 		}
 
@@ -1755,7 +1766,8 @@ func TestChannelArbitratorEmptyResolutions(t *testing.T) {
 	chanArb.cfg.ClosingHeight = 100
 	chanArb.cfg.CloseType = channeldb.RemoteForceClose
 
-	if err := chanArb.Start(nil); err != nil {
+	beat := newBeatFromHeight(100)
+	if err := chanArb.Start(nil, beat); err != nil {
 		t.Fatalf("unable to start ChannelArbitrator: %v", err)
 	}
 
@@ -1785,7 +1797,8 @@ func TestChannelArbitratorAlreadyForceClosed(t *testing.T) {
 	chanArbCtx, err := createTestChannelArbitrator(t, log)
 	require.NoError(t, err, "unable to create ChannelArbitrator")
 	chanArb := chanArbCtx.chanArb
-	if err := chanArb.Start(nil); err != nil {
+	beat := newBeatFromHeight(0)
+	if err := chanArb.Start(nil, beat); err != nil {
 		t.Fatalf("unable to start ChannelArbitrator: %v", err)
 	}
 	defer chanArb.Stop()
@@ -1883,9 +1896,10 @@ func TestChannelArbitratorDanglingCommitForceClose(t *testing.T) {
 				t.Fatalf("unable to create ChannelArbitrator: %v", err)
 			}
 			chanArb := chanArbCtx.chanArb
-			if err := chanArb.Start(nil); err != nil {
-				t.Fatalf("unable to start ChannelArbitrator: %v", err)
-			}
+			beat := newBeatFromHeight(0)
+			err = chanArb.Start(nil, beat)
+			require.NoError(t, err)
+
 			defer chanArb.Stop()
 
 			// Now that our channel arb has started, we'll set up
@@ -2079,7 +2093,8 @@ func TestChannelArbitratorPendingExpiredHTLC(t *testing.T) {
 		return false
 	}
 
-	if err := chanArb.Start(nil); err != nil {
+	beat := newBeatFromHeight(0)
+	if err := chanArb.Start(nil, beat); err != nil {
 		t.Fatalf("unable to start ChannelArbitrator: %v", err)
 	}
 	t.Cleanup(func() {
@@ -2113,7 +2128,7 @@ func TestChannelArbitratorPendingExpiredHTLC(t *testing.T) {
 	// We will advance the uptime to 10 seconds which should be still within
 	// the grace period and should not trigger going to chain.
 	testClock.SetTime(startTime.Add(time.Second * 10))
-	beat := newBeatFromHeight(5)
+	beat = newBeatFromHeight(5)
 	chanArbCtx.chanArb.BlockbeatChan <- beat
 	chanArbCtx.AssertState(StateDefault)
 
@@ -2234,8 +2249,8 @@ func TestRemoteCloseInitiator(t *testing.T) {
 					"ChannelArbitrator: %v", err)
 			}
 			chanArb := chanArbCtx.chanArb
-
-			if err := chanArb.Start(nil); err != nil {
+			beat := newBeatFromHeight(0)
+			if err := chanArb.Start(nil, beat); err != nil {
 				t.Fatalf("unable to start "+
 					"ChannelArbitrator: %v", err)
 			}
@@ -2786,7 +2801,9 @@ func TestChannelArbitratorAnchors(t *testing.T) {
 			},
 		}
 
-	if err := chanArb.Start(nil); err != nil {
+	heightHint := uint32(1000)
+	beat := newBeatFromHeight(int32(heightHint))
+	if err := chanArb.Start(nil, beat); err != nil {
 		t.Fatalf("unable to start ChannelArbitrator: %v", err)
 	}
 	t.Cleanup(func() {
@@ -2799,8 +2816,7 @@ func TestChannelArbitratorAnchors(t *testing.T) {
 	chanArb.UpdateContractSignals(signals)
 
 	// Set current block height.
-	heightHint := uint32(1000)
-	beat := newBeatFromHeight(int32(heightHint))
+	beat = newBeatFromHeight(int32(heightHint))
 	chanArbCtx.chanArb.BlockbeatChan <- beat
 
 	htlcAmt := lnwire.MilliSatoshi(1_000_000)
@@ -3076,7 +3092,8 @@ func TestChannelArbitratorStartForceCloseFail(t *testing.T) {
 				return test.broadcastErr
 			}
 
-			err = chanArb.Start(nil)
+			beat := newBeatFromHeight(0)
+			err = chanArb.Start(nil, beat)
 
 			if !test.expectedStartup {
 				require.ErrorIs(t, err, test.broadcastErr)

--- a/contractcourt/channel_arbitrator_test.go
+++ b/contractcourt/channel_arbitrator_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/chainio"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/channeldb/models"
@@ -224,6 +225,15 @@ func (c *chanArbTestCtx) CleanUp() {
 	if c.cleanUp != nil {
 		c.cleanUp()
 	}
+}
+
+// receiveBlockbeat mocks the behavior of a blockbeat being sent by the
+// BlockbeatDispatcher, which essentially mocks the method `ProcessBlock`.
+func (c *chanArbTestCtx) receiveBlockbeat(height int) {
+	go func() {
+		beat := newBeatFromHeight(int32(height))
+		c.chanArb.BlockbeatChan <- beat
+	}()
 }
 
 // AssertStateTransitions asserts that the state machine steps through the
@@ -1036,7 +1046,7 @@ func TestChannelArbitratorLocalForceClosePendingHtlc(t *testing.T) {
 	}
 	require.Equal(t, expectedFinalHtlcs, chanArbCtx.finalHtlcs)
 
-	// We'll no re-create the resolver, notice that we use the existing
+	// We'll now re-create the resolver, notice that we use the existing
 	// arbLog so it carries over the same on-disk state.
 	chanArbCtxNew, err := chanArbCtx.Restart(nil)
 	require.NoError(t, err, "unable to create ChannelArbitrator")
@@ -1074,7 +1084,12 @@ func TestChannelArbitratorLocalForceClosePendingHtlc(t *testing.T) {
 	}
 
 	// Send a notification that the expiry height has been reached.
+	//
+	// TODO(yy): remove the EpochChan and use the blockbeat below once
+	// resolvers are hooked with the blockbeat.
 	oldNotifier.EpochChan <- &chainntnfs.BlockEpoch{Height: 10}
+	// beat := chainio.NewBlockbeatFromHeight(10)
+	// chanArb.BlockbeatChan <- beat
 
 	// htlcOutgoingContestResolver is now transforming into a
 	// htlcTimeoutResolver and should send the contract off for incubation.
@@ -1914,7 +1929,8 @@ func TestChannelArbitratorDanglingCommitForceClose(t *testing.T) {
 			// now mine a block (height 5), which is 5 blocks away
 			// (our grace delta) from the expiry of that HTLC.
 			case testCase.htlcExpired:
-				chanArbCtx.chanArb.blocks <- 5
+				beat := newBeatFromHeight(5)
+				chanArbCtx.chanArb.BlockbeatChan <- beat
 
 			// Otherwise, we'll just trigger a regular force close
 			// request.
@@ -2026,8 +2042,7 @@ func TestChannelArbitratorDanglingCommitForceClose(t *testing.T) {
 			// so instead, we'll mine another block which'll cause
 			// it to re-examine its state and realize there're no
 			// more HTLCs.
-			chanArbCtx.chanArb.blocks <- 6
-			chanArbCtx.AssertStateTransitions(StateFullyResolved)
+			chanArbCtx.receiveBlockbeat(6)
 		})
 	}
 }
@@ -2098,13 +2113,15 @@ func TestChannelArbitratorPendingExpiredHTLC(t *testing.T) {
 	// We will advance the uptime to 10 seconds which should be still within
 	// the grace period and should not trigger going to chain.
 	testClock.SetTime(startTime.Add(time.Second * 10))
-	chanArbCtx.chanArb.blocks <- 5
+	beat := newBeatFromHeight(5)
+	chanArbCtx.chanArb.BlockbeatChan <- beat
 	chanArbCtx.AssertState(StateDefault)
 
 	// We will advance the uptime to 16 seconds which should trigger going
 	// to chain.
 	testClock.SetTime(startTime.Add(time.Second * 16))
-	chanArbCtx.chanArb.blocks <- 6
+	beat = newBeatFromHeight(6)
+	chanArbCtx.chanArb.BlockbeatChan <- beat
 	chanArbCtx.AssertStateTransitions(
 		StateBroadcastCommit,
 		StateCommitmentBroadcasted,
@@ -2472,7 +2489,7 @@ func TestSweepAnchors(t *testing.T) {
 
 	// Set current block height.
 	heightHint := uint32(1000)
-	chanArbCtx.chanArb.blocks <- int32(heightHint)
+	chanArbCtx.receiveBlockbeat(int(heightHint))
 
 	htlcIndexBase := uint64(99)
 	deadlineDelta := uint32(10)
@@ -2635,7 +2652,7 @@ func TestSweepLocalAnchor(t *testing.T) {
 
 	// Set current block height.
 	heightHint := uint32(1000)
-	chanArbCtx.chanArb.blocks <- int32(heightHint)
+	chanArbCtx.receiveBlockbeat(int(heightHint))
 
 	htlcIndex := uint64(99)
 	deadlineDelta := uint32(10)
@@ -2783,7 +2800,8 @@ func TestChannelArbitratorAnchors(t *testing.T) {
 
 	// Set current block height.
 	heightHint := uint32(1000)
-	chanArbCtx.chanArb.blocks <- int32(heightHint)
+	beat := newBeatFromHeight(int32(heightHint))
+	chanArbCtx.chanArb.BlockbeatChan <- beat
 
 	htlcAmt := lnwire.MilliSatoshi(1_000_000)
 
@@ -2951,9 +2969,13 @@ func TestChannelArbitratorAnchors(t *testing.T) {
 	require.Equal(t, 2, len(chanArbCtx.sweeper.deadlines))
 	require.EqualValues(t,
 		heightHint+deadlinePreimageDelta/2,
+		chanArbCtx.sweeper.deadlines[0], "want %d, got %d",
+		heightHint+deadlinePreimageDelta/2,
 		chanArbCtx.sweeper.deadlines[0],
 	)
 	require.EqualValues(t,
+		heightHint+deadlinePreimageDelta/2,
+		chanArbCtx.sweeper.deadlines[1], "want %d, got %d",
 		heightHint+deadlinePreimageDelta/2,
 		chanArbCtx.sweeper.deadlines[1],
 	)
@@ -3132,4 +3154,12 @@ func (m *mockChannel) ForceCloseChan() (*wire.MsgTx, error) {
 	}
 
 	return &wire.MsgTx{}, nil
+}
+
+func newBeatFromHeight(height int32) *chainio.Beat {
+	epoch := chainntnfs.BlockEpoch{
+		Height: height,
+	}
+
+	return chainio.NewBeat(epoch)
 }

--- a/contractcourt/channel_arbitrator_test.go
+++ b/contractcourt/channel_arbitrator_test.go
@@ -693,11 +693,15 @@ func TestChannelArbitratorLocalForceClose(t *testing.T) {
 	chanArbCtx.AssertState(StateCommitmentBroadcasted)
 
 	// Now notify about the local force close getting confirmed.
+	//
+	//nolint:lll
 	chanArb.cfg.ChainEvents.LocalUnilateralClosure <- &LocalUnilateralCloseInfo{
 		SpendDetail: &chainntnfs.SpendDetail{},
 		LocalForceCloseSummary: &lnwallet.LocalForceCloseSummary{
-			CloseTx:         &wire.MsgTx{},
-			HtlcResolutions: &lnwallet.HtlcResolutions{},
+			CloseTx: &wire.MsgTx{},
+			ContractResolutions: fn.Some(lnwallet.ContractResolutions{
+				HtlcResolutions: &lnwallet.HtlcResolutions{},
+			}),
 		},
 		ChannelCloseSummary: &channeldb.ChannelCloseSummary{},
 	}
@@ -987,15 +991,18 @@ func TestChannelArbitratorLocalForceClosePendingHtlc(t *testing.T) {
 		},
 	}
 
+	//nolint:lll
 	chanArb.cfg.ChainEvents.LocalUnilateralClosure <- &LocalUnilateralCloseInfo{
 		SpendDetail: &chainntnfs.SpendDetail{},
 		LocalForceCloseSummary: &lnwallet.LocalForceCloseSummary{
 			CloseTx: closeTx,
-			HtlcResolutions: &lnwallet.HtlcResolutions{
-				OutgoingHTLCs: []lnwallet.OutgoingHtlcResolution{
-					outgoingRes,
+			ContractResolutions: fn.Some(lnwallet.ContractResolutions{
+				HtlcResolutions: &lnwallet.HtlcResolutions{
+					OutgoingHTLCs: []lnwallet.OutgoingHtlcResolution{
+						outgoingRes,
+					},
 				},
-			},
+			}),
 		},
 		ChannelCloseSummary: &channeldb.ChannelCloseSummary{},
 		CommitSet: CommitSet{
@@ -1613,12 +1620,15 @@ func TestChannelArbitratorCommitFailure(t *testing.T) {
 		},
 		{
 			closeType: channeldb.LocalForceClose,
+			//nolint:lll
 			sendEvent: func(chanArb *ChannelArbitrator) {
 				chanArb.cfg.ChainEvents.LocalUnilateralClosure <- &LocalUnilateralCloseInfo{
 					SpendDetail: &chainntnfs.SpendDetail{},
 					LocalForceCloseSummary: &lnwallet.LocalForceCloseSummary{
-						CloseTx:         &wire.MsgTx{},
-						HtlcResolutions: &lnwallet.HtlcResolutions{},
+						CloseTx: &wire.MsgTx{},
+						ContractResolutions: fn.Some(lnwallet.ContractResolutions{
+							HtlcResolutions: &lnwallet.HtlcResolutions{},
+						}),
 					},
 					ChannelCloseSummary: &channeldb.ChannelCloseSummary{},
 				}
@@ -1946,11 +1956,15 @@ func TestChannelArbitratorDanglingCommitForceClose(t *testing.T) {
 			// being canalled back. Also note that there're no HTLC
 			// resolutions sent since we have none on our
 			// commitment transaction.
+			//
+			//nolint:lll
 			uniCloseInfo := &LocalUnilateralCloseInfo{
 				SpendDetail: &chainntnfs.SpendDetail{},
 				LocalForceCloseSummary: &lnwallet.LocalForceCloseSummary{
-					CloseTx:         closeTx,
-					HtlcResolutions: &lnwallet.HtlcResolutions{},
+					CloseTx: closeTx,
+					ContractResolutions: fn.Some(lnwallet.ContractResolutions{
+						HtlcResolutions: &lnwallet.HtlcResolutions{},
+					}),
 				},
 				ChannelCloseSummary: &channeldb.ChannelCloseSummary{},
 				CommitSet: CommitSet{
@@ -2870,12 +2884,15 @@ func TestChannelArbitratorAnchors(t *testing.T) {
 		},
 	}
 
+	//nolint:lll
 	chanArb.cfg.ChainEvents.LocalUnilateralClosure <- &LocalUnilateralCloseInfo{
 		SpendDetail: &chainntnfs.SpendDetail{},
 		LocalForceCloseSummary: &lnwallet.LocalForceCloseSummary{
-			CloseTx:          closeTx,
-			HtlcResolutions:  &lnwallet.HtlcResolutions{},
-			AnchorResolution: anchorResolution,
+			CloseTx: closeTx,
+			ContractResolutions: fn.Some(lnwallet.ContractResolutions{
+				HtlcResolutions:  &lnwallet.HtlcResolutions{},
+				AnchorResolution: anchorResolution,
+			}),
 		},
 		ChannelCloseSummary: &channeldb.ChannelCloseSummary{},
 		CommitSet: CommitSet{
@@ -3109,14 +3126,10 @@ func (m *mockChannel) NewAnchorResolutions() (*lnwallet.AnchorResolutions,
 	return &lnwallet.AnchorResolutions{}, nil
 }
 
-func (m *mockChannel) ForceCloseChan() (*lnwallet.LocalForceCloseSummary, error) {
+func (m *mockChannel) ForceCloseChan() (*wire.MsgTx, error) {
 	if m.forceCloseErr != nil {
 		return nil, m.forceCloseErr
 	}
 
-	summary := &lnwallet.LocalForceCloseSummary{
-		CloseTx:         &wire.MsgTx{},
-		HtlcResolutions: &lnwallet.HtlcResolutions{},
-	}
-	return summary, nil
+	return &wire.MsgTx{}, nil
 }

--- a/contractcourt/commit_sweep_resolver.go
+++ b/contractcourt/commit_sweep_resolver.go
@@ -165,9 +165,7 @@ func (c *commitSweepResolver) getCommitTxConfHeight() (uint32, error) {
 // returned.
 //
 // NOTE: This function MUST be run as a goroutine.
-//
-//nolint:funlen
-func (c *commitSweepResolver) Resolve(_ bool) (ContractResolver, error) {
+func (c *commitSweepResolver) Resolve() (ContractResolver, error) {
 	// If we're already resolved, then we can exit early.
 	if c.resolved {
 		return nil, nil

--- a/contractcourt/commit_sweep_resolver.go
+++ b/contractcourt/commit_sweep_resolver.go
@@ -165,6 +165,10 @@ func (c *commitSweepResolver) getCommitTxConfHeight() (uint32, error) {
 // returned.
 //
 // NOTE: This function MUST be run as a goroutine.
+
+// TODO(yy): fix the funlen in the next PR.
+//
+//nolint:funlen
 func (c *commitSweepResolver) Resolve() (ContractResolver, error) {
 	// If we're already resolved, then we can exit early.
 	if c.resolved {

--- a/contractcourt/commit_sweep_resolver_test.go
+++ b/contractcourt/commit_sweep_resolver_test.go
@@ -90,12 +90,6 @@ func (i *commitSweepResolverTestContext) resolve() {
 	}()
 }
 
-func (i *commitSweepResolverTestContext) notifyEpoch(height int32) {
-	i.notifier.EpochChan <- &chainntnfs.BlockEpoch{
-		Height: height,
-	}
-}
-
 func (i *commitSweepResolverTestContext) waitForResult() {
 	i.t.Helper()
 
@@ -292,22 +286,10 @@ func testCommitSweepResolverDelay(t *testing.T, sweepErr error) {
 		t.Fatal("report maturity height incorrect")
 	}
 
-	// Notify initial block height. The csv lock is still in effect, so we
-	// don't expect any sweep to happen yet.
-	ctx.notifyEpoch(testInitialBlockHeight)
-
-	select {
-	case <-ctx.sweeper.sweptInputs:
-		t.Fatal("no sweep expected")
-	case <-time.After(sweepProcessInterval):
-	}
-
-	// A new block arrives. The commit tx confirmed at height -1 and the csv
-	// is 3, so a spend will be valid in the first block after height +1.
-	ctx.notifyEpoch(testInitialBlockHeight + 1)
-
-	<-ctx.sweeper.sweptInputs
-
+	// Notify initial block height. Although the csv lock is still in
+	// effect, we expect the input being sent to the sweeper before the csv
+	// lock expires.
+	//
 	// Set the resolution report outcome based on whether our sweep
 	// succeeded.
 	outcome := channeldb.ResolverOutcomeClaimed

--- a/contractcourt/commit_sweep_resolver_test.go
+++ b/contractcourt/commit_sweep_resolver_test.go
@@ -82,7 +82,7 @@ func (i *commitSweepResolverTestContext) resolve() {
 	// Start resolver.
 	i.resolverResultChan = make(chan resolveResult, 1)
 	go func() {
-		nextResolver, err := i.resolver.Resolve(false)
+		nextResolver, err := i.resolver.Resolve()
 		i.resolverResultChan <- resolveResult{
 			nextResolver: nextResolver,
 			err:          err,

--- a/contractcourt/contract_resolver.go
+++ b/contractcourt/contract_resolver.go
@@ -43,7 +43,7 @@ type ContractResolver interface {
 	// resolution, then another resolve is returned.
 	//
 	// NOTE: This function MUST be run as a goroutine.
-	Resolve(immediate bool) (ContractResolver, error)
+	Resolve() (ContractResolver, error)
 
 	// SupplementState allows the user of a ContractResolver to supplement
 	// it with state required for the proper resolution of a contract.

--- a/contractcourt/htlc_incoming_contest_resolver.go
+++ b/contractcourt/htlc_incoming_contest_resolver.go
@@ -90,9 +90,7 @@ func (h *htlcIncomingContestResolver) processFinalHtlcFail() error {
 //     as we have no remaining actions left at our disposal.
 //
 // NOTE: Part of the ContractResolver interface.
-func (h *htlcIncomingContestResolver) Resolve(
-	_ bool) (ContractResolver, error) {
-
+func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 	// If we're already full resolved, then we don't have anything further
 	// to do.
 	if h.resolved {

--- a/contractcourt/htlc_incoming_contest_resolver_test.go
+++ b/contractcourt/htlc_incoming_contest_resolver_test.go
@@ -395,7 +395,7 @@ func (i *incomingResolverTestContext) resolve() {
 	i.resolveErr = make(chan error, 1)
 	go func() {
 		var err error
-		i.nextResolver, err = i.resolver.Resolve(false)
+		i.nextResolver, err = i.resolver.Resolve()
 		i.resolveErr <- err
 	}()
 

--- a/contractcourt/htlc_lease_resolver.go
+++ b/contractcourt/htlc_lease_resolver.go
@@ -57,10 +57,10 @@ func (h *htlcLeaseResolver) makeSweepInput(op *wire.OutPoint,
 	signDesc *input.SignDescriptor, csvDelay, broadcastHeight uint32,
 	payHash [32]byte, resBlob fn.Option[tlv.Blob]) *input.BaseInput {
 
-	if h.hasCLTV() {
-		log.Infof("%T(%x): CSV and CLTV locks expired, offering "+
-			"second-layer output to sweeper: %v", h, payHash, op)
+	log.Infof("%T(%x): offering second-layer output to sweeper: %v", h,
+		payHash, op)
 
+	if h.hasCLTV() {
 		return input.NewCsvInputWithCltv(
 			op, cltvWtype, signDesc,
 			broadcastHeight, csvDelay,

--- a/contractcourt/htlc_outgoing_contest_resolver.go
+++ b/contractcourt/htlc_outgoing_contest_resolver.go
@@ -49,9 +49,7 @@ func newOutgoingContestResolver(res lnwallet.OutgoingHtlcResolution,
 // When either of these two things happens, we'll create a new resolver which
 // is able to handle the final resolution of the contract. We're only the pivot
 // point.
-func (h *htlcOutgoingContestResolver) Resolve(
-	_ bool) (ContractResolver, error) {
-
+func (h *htlcOutgoingContestResolver) Resolve() (ContractResolver, error) {
 	// If we're already full resolved, then we don't have anything further
 	// to do.
 	if h.resolved {

--- a/contractcourt/htlc_outgoing_contest_resolver_test.go
+++ b/contractcourt/htlc_outgoing_contest_resolver_test.go
@@ -209,7 +209,7 @@ func (i *outgoingResolverTestContext) resolve() {
 	// Start resolver.
 	i.resolverResultChan = make(chan resolveResult, 1)
 	go func() {
-		nextResolver, err := i.resolver.Resolve(false)
+		nextResolver, err := i.resolver.Resolve()
 		i.resolverResultChan <- resolveResult{
 			nextResolver: nextResolver,
 			err:          err,

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -359,30 +359,6 @@ func (h *htlcSuccessResolver) broadcastReSignedSuccessTx(immediate bool) (
 			"height %v", h, h.htlc.RHash[:], waitHeight)
 	}
 
-	// Deduct one block so this input is offered to the sweeper one block
-	// earlier since the sweeper will wait for one block to trigger the
-	// sweeping.
-	//
-	// TODO(yy): this is done so the outputs can be aggregated
-	// properly. Suppose CSV locks of five 2nd-level outputs all
-	// expire at height 840000, there is a race in block digestion
-	// between contractcourt and sweeper:
-	// - G1: block 840000 received in contractcourt, it now offers
-	//   the outputs to the sweeper.
-	// - G2: block 840000 received in sweeper, it now starts to
-	//   sweep the received outputs - there's no guarantee all
-	//   fives have been received.
-	// To solve this, we either offer the outputs earlier, or
-	// implement `blockbeat`, and force contractcourt and sweeper
-	// to consume each block sequentially.
-	waitHeight--
-
-	// TODO(yy): let sweeper handles the wait?
-	err := waitForHeight(waitHeight, h.Notifier, h.quit)
-	if err != nil {
-		return nil, err
-	}
-
 	// We'll use this input index to determine the second-level output
 	// index on the transaction, as the signatures requires the indexes to
 	// be the same. We don't look for the second-level output script
@@ -421,7 +397,7 @@ func (h *htlcSuccessResolver) broadcastReSignedSuccessTx(immediate bool) (
 		h.htlc.RHash[:], budget, waitHeight)
 
 	// TODO(roasbeef): need to update above for leased types
-	_, err = h.Sweeper.SweepInput(
+	_, err := h.Sweeper.SweepInput(
 		inp,
 		sweep.Params{
 			Budget: budget,

--- a/contractcourt/htlc_success_resolver_test.go
+++ b/contractcourt/htlc_success_resolver_test.go
@@ -134,7 +134,7 @@ func (i *htlcResolverTestContext) resolve() {
 	// Start resolver.
 	i.resolverResultChan = make(chan resolveResult, 1)
 	go func() {
-		nextResolver, err := i.resolver.Resolve(false)
+		nextResolver, err := i.resolver.Resolve()
 		i.resolverResultChan <- resolveResult{
 			nextResolver: nextResolver,
 			err:          err,

--- a/contractcourt/htlc_success_resolver_test.go
+++ b/contractcourt/htlc_success_resolver_test.go
@@ -437,10 +437,6 @@ func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 					}
 				}
 
-				ctx.notifier.EpochChan <- &chainntnfs.BlockEpoch{
-					Height: 13,
-				}
-
 				// We expect it to sweep the second-level
 				// transaction we notfied about above.
 				resolver := ctx.resolver.(*htlcSuccessResolver)

--- a/contractcourt/htlc_timeout_resolver_test.go
+++ b/contractcourt/htlc_timeout_resolver_test.go
@@ -1120,11 +1120,6 @@ func TestHtlcTimeoutSecondStageSweeper(t *testing.T) {
 					t.Fatalf("resolution not sent")
 				}
 
-				// Mimic CSV lock expiring.
-				ctx.notifier.EpochChan <- &chainntnfs.BlockEpoch{
-					Height: 13,
-				}
-
 				// The timeout tx output should now be given to
 				// the sweeper.
 				resolver := ctx.resolver.(*htlcTimeoutResolver)

--- a/contractcourt/htlc_timeout_resolver_test.go
+++ b/contractcourt/htlc_timeout_resolver_test.go
@@ -390,7 +390,7 @@ func testHtlcTimeoutResolver(t *testing.T, testCase htlcTimeoutTestCase) {
 	go func() {
 		defer wg.Done()
 
-		_, err := resolver.Resolve(false)
+		_, err := resolver.Resolve()
 		if err != nil {
 			resolveErr <- err
 		}

--- a/contractcourt/utxonursery.go
+++ b/contractcourt/utxonursery.go
@@ -793,7 +793,7 @@ func (u *UtxoNursery) graduateClass(classHeight uint32) error {
 		return err
 	}
 
-	utxnLog.Infof("Attempting to graduate height=%v: num_kids=%v, "+
+	utxnLog.Debugf("Attempting to graduate height=%v: num_kids=%v, "+
 		"num_babies=%v", classHeight, len(kgtnOutputs), len(cribOutputs))
 
 	// Offer the outputs to the sweeper and set up notifications that will

--- a/docs/release-notes/release-notes-0.18.4.md
+++ b/docs/release-notes/release-notes-0.18.4.md
@@ -35,6 +35,7 @@ types in a series of changes:
   * https://github.com/lightningnetwork/lnd/pull/9095
   * https://github.com/lightningnetwork/lnd/pull/8960
   * https://github.com/lightningnetwork/lnd/pull/9194
+  * https://github.com/lightningnetwork/lnd/pull/9288
 
 ## Functional Enhancements
 

--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -56,6 +56,9 @@
 
 * [Fixed a case](https://github.com/lightningnetwork/lnd/pull/9258) where the
   confirmation notification may be missed.
+  
+* [Make the contract resolutions for the channel arbitrator optional](
+  https://github.com/lightningnetwork/lnd/pull/9253)
 
 # New Features
 ## Functional Enhancements

--- a/fn/go.mod
+++ b/fn/go.mod
@@ -1,4 +1,4 @@
-module github.com/lightningnetwork/lnd/fn
+module github.com/lightningnetwork/lnd/fn/v2
 
 go 1.19
 

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -1605,7 +1605,7 @@ out:
 				}
 			}
 
-			log.Infof("Received outside contract resolution, "+
+			log.Debugf("Received outside contract resolution, "+
 				"mapping to: %v", spew.Sdump(pkt))
 
 			// We don't check the error, as the only failure we can

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -7852,6 +7852,18 @@ type LocalForceCloseSummary struct {
 	// commitment state.
 	CloseTx *wire.MsgTx
 
+	// ChanSnapshot is a snapshot of the final state of the channel at the
+	// time the summary was created.
+	ChanSnapshot channeldb.ChannelSnapshot
+
+	// ContractResolutions contains all the data required for resolving the
+	// different output types of a commitment transaction.
+	ContractResolutions fn.Option[ContractResolutions]
+}
+
+// ContractResolutions contains all the data required for resolving the
+// different output types of a commitment transaction.
+type ContractResolutions struct {
 	// CommitResolution contains all the data required to sweep the output
 	// to ourselves. Since this is our commitment transaction, we'll need
 	// to wait a time delay before we can sweep the output.
@@ -7860,19 +7872,38 @@ type LocalForceCloseSummary struct {
 	// then this will be nil.
 	CommitResolution *CommitOutputResolution
 
-	// HtlcResolutions contains all the data required to sweep any outgoing
-	// HTLC's and incoming HTLc's we know the preimage to. For each of these
-	// HTLC's, we'll need to go to the second level to sweep them fully.
-	HtlcResolutions *HtlcResolutions
-
-	// ChanSnapshot is a snapshot of the final state of the channel at the
-	// time the summary was created.
-	ChanSnapshot channeldb.ChannelSnapshot
-
 	// AnchorResolution contains the data required to sweep the anchor
 	// output. If the channel type doesn't include anchors, the value of
 	// this field will be nil.
 	AnchorResolution *AnchorResolution
+
+	// HtlcResolutions contains all the data required to sweep any outgoing
+	// HTLC's and incoming HTLc's we know the preimage to. For each of these
+	// HTLC's, we'll need to go to the second level to sweep them fully.
+	HtlcResolutions *HtlcResolutions
+}
+
+// ForceCloseOpt is a functional option argument for the ForceClose method.
+type ForceCloseOpt func(*forceCloseConfig)
+
+// forceCloseConfig holds the configuration options for force closing a channel.
+type forceCloseConfig struct {
+	// skipResolution if true will skip creating the contract resolutions
+	// when generating the force close summary.
+	skipResolution bool
+}
+
+// defaultForceCloseConfig returns the default force close configuration.
+func defaultForceCloseConfig() *forceCloseConfig {
+	return &forceCloseConfig{}
+}
+
+// WithSkipContractResolutions creates an option to skip the contract
+// resolutions from the returned summary.
+func WithSkipContractResolutions() ForceCloseOpt {
+	return func(cfg *forceCloseConfig) {
+		cfg.skipResolution = true
+	}
 }
 
 // ForceClose executes a unilateral closure of the transaction at the current
@@ -7883,9 +7914,16 @@ type LocalForceCloseSummary struct {
 // outputs within the commitment transaction.
 //
 // TODO(roasbeef): all methods need to abort if in dispute state
-func (lc *LightningChannel) ForceClose() (*LocalForceCloseSummary, error) {
+func (lc *LightningChannel) ForceClose(opts ...ForceCloseOpt) (
+	*LocalForceCloseSummary, error) {
+
 	lc.Lock()
 	defer lc.Unlock()
+
+	cfg := defaultForceCloseConfig()
+	for _, opt := range opts {
+		opt(cfg)
+	}
 
 	// If we've detected local data loss for this channel, then we won't
 	// allow a force close, as it may be the case that we have a dated
@@ -7899,6 +7937,14 @@ func (lc *LightningChannel) ForceClose() (*LocalForceCloseSummary, error) {
 	commitTx, err := lc.getSignedCommitTx()
 	if err != nil {
 		return nil, err
+	}
+
+	if cfg.skipResolution {
+		return &LocalForceCloseSummary{
+			ChanPoint:    lc.channelState.FundingOutpoint,
+			ChanSnapshot: *lc.channelState.Snapshot(),
+			CloseTx:      commitTx,
+		}, nil
 	}
 
 	localCommitment := lc.channelState.LocalCommitment
@@ -8107,12 +8153,14 @@ func NewLocalForceCloseSummary(chanState *channeldb.OpenChannel,
 	}
 
 	return &LocalForceCloseSummary{
-		ChanPoint:        chanState.FundingOutpoint,
-		CloseTx:          commitTx,
-		CommitResolution: commitResolution,
-		HtlcResolutions:  htlcResolutions,
-		ChanSnapshot:     *chanState.Snapshot(),
-		AnchorResolution: anchorResolution,
+		ChanPoint:    chanState.FundingOutpoint,
+		CloseTx:      commitTx,
+		ChanSnapshot: *chanState.Snapshot(),
+		ContractResolutions: fn.Some(ContractResolutions{
+			CommitResolution: commitResolution,
+			HtlcResolutions:  htlcResolutions,
+			AnchorResolution: anchorResolution,
+		}),
 	}, nil
 }
 

--- a/lnwallet/transactions_test.go
+++ b/lnwallet/transactions_test.go
@@ -406,6 +406,8 @@ func testVectors(t *testing.T, chanType channeldb.ChannelType, test testCase) {
 		hex.EncodeToString(txBytes.Bytes()),
 	)
 
+	resolutions := forceCloseSum.ContractResolutions.UnwrapOrFail(t)
+
 	// Obtain the second level transactions that the local node's channel
 	// state machine has produced. Store them in a map indexed by commit tx
 	// output index. Also complete the second level transaction with the
@@ -419,7 +421,8 @@ func testVectors(t *testing.T, chanType channeldb.ChannelType, test testCase) {
 		secondLevelTxes[index] = tx
 	}
 
-	for _, r := range forceCloseSum.HtlcResolutions.IncomingHTLCs {
+	htlcResolutions := resolutions.HtlcResolutions
+	for _, r := range htlcResolutions.IncomingHTLCs {
 		successTx := r.SignedSuccessTx
 		witnessScript := successTx.TxIn[0].Witness[4]
 		var hash160 [20]byte
@@ -428,7 +431,7 @@ func testVectors(t *testing.T, chanType channeldb.ChannelType, test testCase) {
 		successTx.TxIn[0].Witness[3] = preimage[:]
 		storeTx(r.HtlcPoint().Index, successTx)
 	}
-	for _, r := range forceCloseSum.HtlcResolutions.OutgoingHTLCs {
+	for _, r := range htlcResolutions.OutgoingHTLCs {
 		storeTx(r.HtlcPoint().Index, r.SignedTimeoutTx)
 	}
 

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -733,7 +733,7 @@ func (l *LightningWallet) RegisterFundingIntent(expectedID [32]byte,
 	}
 
 	if _, ok := l.fundingIntents[expectedID]; ok {
-		return fmt.Errorf("%w: already has intent registered: %v",
+		return fmt.Errorf("%w: already has intent registered: %x",
 			ErrDuplicatePendingChanID, expectedID[:])
 	}
 

--- a/log.go
+++ b/log.go
@@ -9,6 +9,7 @@ import (
 	sphinx "github.com/lightningnetwork/lightning-onion"
 	"github.com/lightningnetwork/lnd/autopilot"
 	"github.com/lightningnetwork/lnd/build"
+	"github.com/lightningnetwork/lnd/chainio"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/chainreg"
 	"github.com/lightningnetwork/lnd/chanacceptor"
@@ -192,6 +193,7 @@ func SetupLoggers(root *build.SubLoggerManager, interceptor signal.Interceptor) 
 	AddSubLogger(
 		root, blindedpath.Subsystem, interceptor, blindedpath.UseLogger,
 	)
+	AddSubLogger(root, chainio.Subsystem, interceptor, chainio.UseLogger)
 }
 
 // AddSubLogger is a helper method to conveniently create and register the

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2739,6 +2739,14 @@ func (r *rpcServer) CloseChannel(in *lnrpc.CloseChannelRequest,
 			return err
 		}
 
+		// Safety check which should never happen.
+		//
+		// TODO(ziggie): remove pointer as return value from
+		// ForceCloseContract.
+		if closingTx == nil {
+			return fmt.Errorf("force close transaction is nil")
+		}
+
 		closingTxid := closingTx.TxHash()
 
 		// With the transaction broadcast, we send our first update to

--- a/server.go
+++ b/server.go
@@ -28,6 +28,7 @@ import (
 	"github.com/lightningnetwork/lnd/aliasmgr"
 	"github.com/lightningnetwork/lnd/autopilot"
 	"github.com/lightningnetwork/lnd/brontide"
+	"github.com/lightningnetwork/lnd/chainio"
 	"github.com/lightningnetwork/lnd/chainreg"
 	"github.com/lightningnetwork/lnd/chanacceptor"
 	"github.com/lightningnetwork/lnd/chanbackup"
@@ -2047,6 +2048,12 @@ func (c cleaner) run() {
 //
 //nolint:funlen
 func (s *server) Start() error {
+	// Get the current blockbeat.
+	beat, err := s.getStartingBeat()
+	if err != nil {
+		return err
+	}
+
 	var startErr error
 
 	// If one sub system fails to start, the following code ensures that the
@@ -2141,13 +2148,13 @@ func (s *server) Start() error {
 		}
 
 		cleanup = cleanup.add(s.txPublisher.Stop)
-		if err := s.txPublisher.Start(); err != nil {
+		if err := s.txPublisher.Start(beat); err != nil {
 			startErr = err
 			return
 		}
 
 		cleanup = cleanup.add(s.sweeper.Stop)
-		if err := s.sweeper.Start(); err != nil {
+		if err := s.sweeper.Start(beat); err != nil {
 			startErr = err
 			return
 		}
@@ -2192,7 +2199,7 @@ func (s *server) Start() error {
 		}
 
 		cleanup = cleanup.add(s.chainArb.Stop)
-		if err := s.chainArb.Start(); err != nil {
+		if err := s.chainArb.Start(beat); err != nil {
 			startErr = err
 			return
 		}
@@ -5114,4 +5121,36 @@ func (s *server) fetchClosedChannelSCIDs() map[lnwire.ShortChannelID]struct{} {
 	}
 
 	return closedSCIDs
+}
+
+// getStartingBeat returns the current beat. This is used during the startup to
+// initialize blockbeat consumers.
+func (s *server) getStartingBeat() (*chainio.Beat, error) {
+	// beat is the current blockbeat.
+	var beat *chainio.Beat
+
+	// We should get a notification with the current best block immediately
+	// by passing a nil block.
+	blockEpochs, err := s.cc.ChainNotifier.RegisterBlockEpochNtfn(nil)
+	if err != nil {
+		return beat, fmt.Errorf("register block epoch ntfn: %w", err)
+	}
+	defer blockEpochs.Cancel()
+
+	// We registered for the block epochs with a nil request. The notifier
+	// should send us the current best block immediately. So we need to
+	// wait for it here because we need to know the current best height.
+	select {
+	case bestBlock := <-blockEpochs.Epochs:
+		srvrLog.Infof("Received initial block %v at height %d",
+			bestBlock.Hash, bestBlock.Height)
+
+		// Update the current blockbeat.
+		beat = chainio.NewBeat(*bestBlock)
+
+	case <-s.quit:
+		srvrLog.Debug("LND shutting down")
+	}
+
+	return beat, nil
 }

--- a/server.go
+++ b/server.go
@@ -2481,6 +2481,9 @@ func (s *server) Stop() error {
 		if err := s.chanRouter.Stop(); err != nil {
 			srvrLog.Warnf("failed to stop chanRouter: %v", err)
 		}
+		if err := s.graphBuilder.Stop(); err != nil {
+			srvrLog.Warnf("failed to stop graphBuilder %v", err)
+		}
 		if err := s.chainArb.Stop(); err != nil {
 			srvrLog.Warnf("failed to stop chainArb: %v", err)
 		}

--- a/sweep/fee_bumper.go
+++ b/sweep/fee_bumper.go
@@ -376,40 +376,52 @@ func (t *TxPublisher) isNeutrinoBackend() bool {
 	return t.cfg.Wallet.BackEnd() == "neutrino"
 }
 
-// Broadcast is used to publish the tx created from the given inputs. It will,
-// 1. init a fee function based on the given strategy.
-// 2. create an RBF-compliant tx and monitor it for confirmation.
-// 3. notify the initial broadcast result back to the caller.
-// The initial broadcast is guaranteed to be RBF-compliant unless the budget
-// specified cannot cover the fee.
+// Broadcast is used to publish the tx created from the given inputs. It will
+// register the broadcast request and return a chan to the caller to subscribe
+// the broadcast result. The initial broadcast is guaranteed to be
+// RBF-compliant unless the budget specified cannot cover the fee.
 //
 // NOTE: part of the Bumper interface.
 func (t *TxPublisher) Broadcast(req *BumpRequest) (<-chan *BumpResult, error) {
 	log.Tracef("Received broadcast request: %s", lnutils.SpewLogClosure(
 		req))
 
-	// Attempt an initial broadcast which is guaranteed to comply with the
-	// RBF rules.
-	result, err := t.initialBroadcast(req)
-	if err != nil {
-		log.Errorf("Initial broadcast failed: %v", err)
-
-		return nil, err
-	}
+	// Store the request.
+	requestID, record := t.storeInitialRecord(req)
 
 	// Create a chan to send the result to the caller.
 	subscriber := make(chan *BumpResult, 1)
-	t.subscriberChans.Store(result.requestID, subscriber)
+	t.subscriberChans.Store(requestID, subscriber)
 
-	// Send the initial broadcast result to the caller.
-	t.handleResult(result)
+	// Publish the tx immediately if specified.
+	if req.Immediate {
+		t.handleInitialBroadcast(record, requestID)
+	}
 
 	return subscriber, nil
 }
 
+// storeInitialRecord initializes a monitor record and saves it in the map.
+func (t *TxPublisher) storeInitialRecord(req *BumpRequest) (
+	uint64, *monitorRecord) {
+
+	// Increase the request counter.
+	//
+	// NOTE: this is the only place where we increase the counter.
+	requestID := t.requestCounter.Add(1)
+
+	// Register the record.
+	record := &monitorRecord{req: req}
+	t.records.Store(requestID, record)
+
+	return requestID, record
+}
+
 // initialBroadcast initializes a fee function, creates an RBF-compliant tx and
 // broadcasts it.
-func (t *TxPublisher) initialBroadcast(req *BumpRequest) (*BumpResult, error) {
+func (t *TxPublisher) initialBroadcast(requestID uint64,
+	req *BumpRequest) (*BumpResult, error) {
+
 	// Create a fee bumping algorithm to be used for future RBF.
 	feeAlgo, err := t.initializeFeeFunction(req)
 	if err != nil {
@@ -418,7 +430,7 @@ func (t *TxPublisher) initialBroadcast(req *BumpRequest) (*BumpResult, error) {
 
 	// Create the initial tx to be broadcasted. This tx is guaranteed to
 	// comply with the RBF restrictions.
-	requestID, err := t.createRBFCompliantTx(req, feeAlgo)
+	err = t.createRBFCompliantTx(requestID, req, feeAlgo)
 	if err != nil {
 		return nil, fmt.Errorf("create RBF-compliant tx: %w", err)
 	}
@@ -465,8 +477,8 @@ func (t *TxPublisher) initializeFeeFunction(
 // so by creating a tx, validate it using `TestMempoolAccept`, and bump its fee
 // and redo the process until the tx is valid, or return an error when non-RBF
 // related errors occur or the budget has been used up.
-func (t *TxPublisher) createRBFCompliantTx(req *BumpRequest,
-	f FeeFunction) (uint64, error) {
+func (t *TxPublisher) createRBFCompliantTx(requestID uint64, req *BumpRequest,
+	f FeeFunction) error {
 
 	for {
 		// Create a new tx with the given fee rate and check its
@@ -475,18 +487,19 @@ func (t *TxPublisher) createRBFCompliantTx(req *BumpRequest,
 
 		switch {
 		case err == nil:
-			// The tx is valid, return the request ID.
-			requestID := t.storeRecord(
-				sweepCtx.tx, req, f, sweepCtx.fee,
+			// The tx is valid, store it.
+			t.storeRecord(
+				requestID, sweepCtx.tx, req, f, sweepCtx.fee,
 				sweepCtx.outpointToTxIndex,
 			)
 
-			log.Infof("Created tx %v for %v inputs: feerate=%v, "+
-				"fee=%v, inputs=%v", sweepCtx.tx.TxHash(),
-				len(req.Inputs), f.FeeRate(), sweepCtx.fee,
+			log.Infof("Created initial sweep tx=%v for %v inputs: "+
+				"feerate=%v, fee=%v, inputs:\n%v",
+				sweepCtx.tx.TxHash(), len(req.Inputs),
+				f.FeeRate(), sweepCtx.fee,
 				inputTypeSummary(req.Inputs))
 
-			return requestID, nil
+			return nil
 
 		// If the error indicates the fees paid is not enough, we will
 		// ask the fee function to increase the fee rate and retry.
@@ -517,7 +530,7 @@ func (t *TxPublisher) createRBFCompliantTx(req *BumpRequest,
 				// cluster these inputs differetly.
 				increased, err = f.Increment()
 				if err != nil {
-					return 0, err
+					return err
 				}
 			}
 
@@ -527,21 +540,15 @@ func (t *TxPublisher) createRBFCompliantTx(req *BumpRequest,
 		// mempool acceptance.
 		default:
 			log.Debugf("Failed to create RBF-compliant tx: %v", err)
-			return 0, err
+			return err
 		}
 	}
 }
 
 // storeRecord stores the given record in the records map.
-func (t *TxPublisher) storeRecord(tx *wire.MsgTx, req *BumpRequest,
-	f FeeFunction, fee btcutil.Amount,
-	outpointToTxIndex map[wire.OutPoint]int) uint64 {
-
-	// Increase the request counter.
-	//
-	// NOTE: this is the only place where we increase the
-	// counter.
-	requestID := t.requestCounter.Add(1)
+func (t *TxPublisher) storeRecord(requestID uint64, tx *wire.MsgTx,
+	req *BumpRequest, f FeeFunction, fee btcutil.Amount,
+	outpointToTxIndex map[wire.OutPoint]int) {
 
 	// Register the record.
 	t.records.Store(requestID, &monitorRecord{
@@ -551,8 +558,6 @@ func (t *TxPublisher) storeRecord(tx *wire.MsgTx, req *BumpRequest,
 		fee:               fee,
 		outpointToTxIndex: outpointToTxIndex,
 	})
-
-	return requestID
 }
 
 // createAndCheckTx creates a tx based on the given inputs, change output
@@ -852,18 +857,27 @@ func (t *TxPublisher) processRecords() {
 	// confirmed.
 	confirmedRecords := make(map[uint64]*monitorRecord)
 
-	// feeBumpRecords stores a map of the records which need to be bumped.
+	// feeBumpRecords stores a map of records which need to be bumped.
 	feeBumpRecords := make(map[uint64]*monitorRecord)
 
-	// failedRecords stores a map of the records which has inputs being
-	// spent by a third party.
+	// failedRecords stores a map of records which has inputs being spent
+	// by a third party.
 	//
 	// NOTE: this is only used for neutrino backend.
 	failedRecords := make(map[uint64]*monitorRecord)
 
+	// initialRecords stores a map of records which are being created and
+	// published for the first time.
+	initialRecords := make(map[uint64]*monitorRecord)
+
 	// visitor is a helper closure that visits each record and divides them
 	// into two groups.
 	visitor := func(requestID uint64, r *monitorRecord) error {
+		if r.tx == nil {
+			initialRecords[requestID] = r
+			return nil
+		}
+
 		log.Tracef("Checking monitor recordID=%v for tx=%v", requestID,
 			r.tx.TxHash())
 
@@ -891,8 +905,13 @@ func (t *TxPublisher) processRecords() {
 		return nil
 	}
 
-	// Iterate through all the records and divide them into two groups.
+	// Iterate through all the records and divide them into four groups.
 	t.records.ForEach(visitor)
+
+	// Handle the initial broadcast.
+	for requestID, r := range initialRecords {
+		t.handleInitialBroadcast(r, requestID)
+	}
 
 	// For records that are confirmed, we'll notify the caller about this
 	// result.
@@ -946,6 +965,69 @@ func (t *TxPublisher) handleTxConfirmed(r *monitorRecord, requestID uint64) {
 	}
 
 	// Notify that this tx is confirmed and remove the record from the map.
+	t.handleResult(result)
+}
+
+// handleInitialBroadcast is called when a new request is received. It will
+// handle the initial tx creation and broadcast. In details,
+// 1. init a fee function based on the given strategy.
+// 2. create an RBF-compliant tx and monitor it for confirmation.
+// 3. notify the initial broadcast result back to the caller.
+func (t *TxPublisher) handleInitialBroadcast(r *monitorRecord,
+	requestID uint64) {
+
+	log.Debugf("Initial broadcast for requestID=%v", requestID)
+
+	var (
+		result *BumpResult
+		err    error
+	)
+
+	// Attempt an initial broadcast which is guaranteed to comply with the
+	// RBF rules.
+	result, err = t.initialBroadcast(requestID, r.req)
+	if err != nil {
+		log.Errorf("Initial broadcast failed: %v", err)
+
+		// We now decide what type of event to send.
+		var event BumpEvent
+
+		switch {
+		// When the error is due to a dust output, we'll send a
+		// TxFailed so these inputs can be retried with a different
+		// group in the next block.
+		case errors.Is(err, ErrTxNoOutput):
+			event = TxFailed
+
+		// When the error is due to budget being used up, we'll send a
+		// TxFailed so these inputs can be retried with a different
+		// group in the next block.
+		case errors.Is(err, ErrMaxPosition):
+			event = TxFailed
+
+		// When the error is due to zero fee rate delta, we'll send a
+		// TxFailed so these inputs can be retried in the next block.
+		case errors.Is(err, ErrZeroFeeRateDelta):
+			event = TxFailed
+
+		// Otherwise this is not a fee-related error and the tx cannot
+		// be retried. In that case we will fail ALL the inputs in this
+		// tx, which means they will be removed from the sweeper and
+		// never be tried again.
+		//
+		// TODO(yy): Find out which input is causing the failure and
+		// fail that one only.
+		default:
+			event = TxFatal
+		}
+
+		result = &BumpResult{
+			Event:     event,
+			Err:       err,
+			requestID: requestID,
+		}
+	}
+
 	t.handleResult(result)
 }
 

--- a/sweep/fee_bumper.go
+++ b/sweep/fee_bumper.go
@@ -916,11 +916,9 @@ func (t *TxPublisher) processRecords() {
 	// For records that are confirmed, we'll notify the caller about this
 	// result.
 	for requestID, r := range confirmedRecords {
-		rec := r
-
 		log.Debugf("Tx=%v is confirmed", r.tx.TxHash())
 		t.wg.Add(1)
-		go t.handleTxConfirmed(rec, requestID)
+		go t.handleTxConfirmed(r, requestID)
 	}
 
 	// Get the current height to be used in the following goroutines.
@@ -928,22 +926,18 @@ func (t *TxPublisher) processRecords() {
 
 	// For records that are not confirmed, we perform a fee bump if needed.
 	for requestID, r := range feeBumpRecords {
-		rec := r
-
 		log.Debugf("Attempting to fee bump Tx=%v", r.tx.TxHash())
 		t.wg.Add(1)
-		go t.handleFeeBumpTx(requestID, rec, currentHeight)
+		go t.handleFeeBumpTx(requestID, r, currentHeight)
 	}
 
 	// For records that are failed, we'll notify the caller about this
 	// result.
 	for requestID, r := range failedRecords {
-		rec := r
-
 		log.Debugf("Tx=%v has inputs been spent by a third party, "+
 			"failing it now", r.tx.TxHash())
 		t.wg.Add(1)
-		go t.handleThirdPartySpent(rec, requestID)
+		go t.handleThirdPartySpent(r, requestID)
 	}
 }
 

--- a/sweep/fee_bumper.go
+++ b/sweep/fee_bumper.go
@@ -84,6 +84,11 @@ const (
 	// TxConfirmed is sent when the tx is confirmed.
 	TxConfirmed
 
+	// TxFatal is sent when the inputs in this tx cannot be retried. Txns
+	// will end up in this state if they have encountered a non-fee related
+	// error, which means they cannot be retried with increased budget.
+	TxFatal
+
 	// sentinalEvent is used to check if an event is unknown.
 	sentinalEvent
 )
@@ -99,6 +104,8 @@ func (e BumpEvent) String() string {
 		return "Replaced"
 	case TxConfirmed:
 		return "Confirmed"
+	case TxFatal:
+		return "Fatal"
 	default:
 		return "Unknown"
 	}
@@ -246,10 +253,20 @@ type BumpResult struct {
 	requestID uint64
 }
 
+// String returns a human-readable string for the result.
+func (b *BumpResult) String() string {
+	desc := fmt.Sprintf("Event=%v", b.Event)
+	if b.Tx != nil {
+		desc += fmt.Sprintf(", Tx=%v", b.Tx.TxHash())
+	}
+
+	return fmt.Sprintf("[%s]", desc)
+}
+
 // Validate validates the BumpResult so it's safe to use.
 func (b *BumpResult) Validate() error {
-	// Every result must have a tx.
-	if b.Tx == nil {
+	// Every result must have a tx except the fatal or failed case.
+	if b.Tx == nil && b.Event != TxFatal {
 		return fmt.Errorf("%w: nil tx", ErrInvalidBumpResult)
 	}
 
@@ -263,9 +280,11 @@ func (b *BumpResult) Validate() error {
 		return fmt.Errorf("%w: nil replacing tx", ErrInvalidBumpResult)
 	}
 
-	// If it's a failed event, it must have an error.
-	if b.Event == TxFailed && b.Err == nil {
-		return fmt.Errorf("%w: nil error", ErrInvalidBumpResult)
+	// If it's a failed or fatal event, it must have an error.
+	if b.Event == TxFatal || b.Event == TxFailed {
+		if b.Err == nil {
+			return fmt.Errorf("%w: nil error", ErrInvalidBumpResult)
+		}
 	}
 
 	// If it's a confirmed event, it must have a fee rate and fee.
@@ -659,8 +678,7 @@ func (t *TxPublisher) notifyResult(result *BumpResult) {
 		return
 	}
 
-	log.Debugf("Sending result for requestID=%v, tx=%v", id,
-		result.Tx.TxHash())
+	log.Debugf("Sending result %v for requestID=%v", result, id)
 
 	select {
 	// Send the result to the subscriber.
@@ -678,20 +696,31 @@ func (t *TxPublisher) notifyResult(result *BumpResult) {
 func (t *TxPublisher) removeResult(result *BumpResult) {
 	id := result.requestID
 
-	// Remove the record from the maps if there's an error. This means this
-	// tx has failed its broadcast and cannot be retried. There are two
-	// cases,
-	// - when the budget cannot cover the fee.
-	// - when a non-RBF related error occurs.
+	var txid chainhash.Hash
+	if result.Tx != nil {
+		txid = result.Tx.TxHash()
+	}
+
+	// Remove the record from the maps if there's an error or the tx is
+	// confirmed. When there's an error, it means this tx has failed its
+	// broadcast and cannot be retried. There are two cases it may fail,
+	// - when the budget cannot cover the increased fee calculated by the
+	//   fee function, hence the budget is used up.
+	// - when a non-fee related error returned from PublishTransaction.
 	switch result.Event {
 	case TxFailed:
 		log.Errorf("Removing monitor record=%v, tx=%v, due to err: %v",
-			id, result.Tx.TxHash(), result.Err)
+			id, txid, result.Err)
 
 	case TxConfirmed:
-		// Remove the record is the tx is confirmed.
+		// Remove the record if the tx is confirmed.
 		log.Debugf("Removing confirmed monitor record=%v, tx=%v", id,
-			result.Tx.TxHash())
+			txid)
+
+	case TxFatal:
+		// Remove the record if there's an error.
+		log.Debugf("Removing monitor record=%v due to fatal err: %v",
+			id, result.Err)
 
 	// Do nothing if it's neither failed or confirmed.
 	default:

--- a/sweep/fee_bumper.go
+++ b/sweep/fee_bumper.go
@@ -65,7 +65,7 @@ type Bumper interface {
 	// and monitors its confirmation status for potential fee bumping. It
 	// returns a chan that the caller can use to receive updates about the
 	// broadcast result and potential RBF attempts.
-	Broadcast(req *BumpRequest) (<-chan *BumpResult, error)
+	Broadcast(req *BumpRequest) <-chan *BumpResult
 }
 
 // BumpEvent represents the event of a fee bumping attempt.
@@ -382,9 +382,9 @@ func (t *TxPublisher) isNeutrinoBackend() bool {
 // RBF-compliant unless the budget specified cannot cover the fee.
 //
 // NOTE: part of the Bumper interface.
-func (t *TxPublisher) Broadcast(req *BumpRequest) (<-chan *BumpResult, error) {
-	log.Tracef("Received broadcast request: %s", lnutils.SpewLogClosure(
-		req))
+func (t *TxPublisher) Broadcast(req *BumpRequest) <-chan *BumpResult {
+	log.Tracef("Received broadcast request: %s",
+		lnutils.SpewLogClosure(req))
 
 	// Store the request.
 	requestID, record := t.storeInitialRecord(req)
@@ -398,7 +398,7 @@ func (t *TxPublisher) Broadcast(req *BumpRequest) (<-chan *BumpResult, error) {
 		t.handleInitialBroadcast(record, requestID)
 	}
 
-	return subscriber, nil
+	return subscriber
 }
 
 // storeInitialRecord initializes a monitor record and saves it in the map.

--- a/sweep/fee_bumper.go
+++ b/sweep/fee_bumper.go
@@ -143,6 +143,10 @@ type BumpRequest struct {
 	// ExtraTxOut tracks if this bump request has an optional set of extra
 	// outputs to add to the transaction.
 	ExtraTxOut fn.Option[SweepOutput]
+
+	// Immediate is used to specify that the tx should be broadcast
+	// immediately.
+	Immediate bool
 }
 
 // MaxFeeRateAllowed returns the maximum fee rate allowed for the given

--- a/sweep/fee_bumper.go
+++ b/sweep/fee_bumper.go
@@ -795,12 +795,15 @@ type monitorRecord struct {
 
 // Start starts the publisher by subscribing to block epoch updates and kicking
 // off the monitor loop.
-func (t *TxPublisher) Start() error {
+func (t *TxPublisher) Start(beat chainio.Blockbeat) error {
 	log.Info("TxPublisher starting...")
 
 	if t.started.Swap(true) {
 		return fmt.Errorf("TxPublisher started more than once")
 	}
+
+	// Set the current height.
+	t.currentHeight.Store(beat.Height())
 
 	t.wg.Add(1)
 	go t.monitor()

--- a/sweep/fee_bumper_test.go
+++ b/sweep/fee_bumper_test.go
@@ -978,8 +978,7 @@ func TestBroadcast(t *testing.T) {
 	}
 
 	// Send the req and expect no error.
-	resultChan, err := tp.Broadcast(req)
-	require.NoError(t, err)
+	resultChan := tp.Broadcast(req)
 	require.NotNil(t, resultChan)
 
 	// Validate the record was stored.
@@ -1029,8 +1028,7 @@ func TestBroadcastImmediate(t *testing.T) {
 		chainfee.SatPerKWeight(0), errDummy).Once()
 
 	// Send the req and expect no error.
-	resultChan, err := tp.Broadcast(req)
-	require.NoError(t, err)
+	resultChan := tp.Broadcast(req)
 	require.NotNil(t, resultChan)
 
 	// Validate the record was removed due to an error returned in initial
@@ -1541,8 +1539,7 @@ func TestHandleInitialBroadcastSuccess(t *testing.T) {
 	}
 
 	// Register the testing record use `Broadcast`.
-	resultChan, err := tp.Broadcast(req)
-	require.NoError(t, err)
+	resultChan := tp.Broadcast(req)
 
 	// Grab the monitor record from the map.
 	rid := tp.requestCounter.Load()
@@ -1613,8 +1610,7 @@ func TestHandleInitialBroadcastFail(t *testing.T) {
 		mock.Anything).Return(errDummy).Once()
 
 	// Register the testing record use `Broadcast`.
-	resultChan, err := tp.Broadcast(req)
-	require.NoError(t, err)
+	resultChan := tp.Broadcast(req)
 
 	// Grab the monitor record from the map.
 	rid := tp.requestCounter.Load()
@@ -1647,8 +1643,7 @@ func TestHandleInitialBroadcastFail(t *testing.T) {
 		mock.Anything, mock.Anything).Return(errDummy).Once()
 
 	// Register the testing record use `Broadcast`.
-	resultChan, err = tp.Broadcast(req)
-	require.NoError(t, err)
+	resultChan = tp.Broadcast(req)
 
 	// Grab the monitor record from the map.
 	rid = tp.requestCounter.Load()

--- a/sweep/fee_bumper_test.go
+++ b/sweep/fee_bumper_test.go
@@ -91,6 +91,19 @@ func TestBumpResultValidate(t *testing.T) {
 	}
 	require.ErrorIs(t, b.Validate(), ErrInvalidBumpResult)
 
+	// A failed event without a tx will give an error.
+	b = BumpResult{
+		Event: TxFailed,
+		Err:   errDummy,
+	}
+	require.ErrorIs(t, b.Validate(), ErrInvalidBumpResult)
+
+	// A fatal event without a failure reason will give an error.
+	b = BumpResult{
+		Event: TxFailed,
+	}
+	require.ErrorIs(t, b.Validate(), ErrInvalidBumpResult)
+
 	// A confirmed event without fee info will give an error.
 	b = BumpResult{
 		Tx:    &wire.MsgTx{},
@@ -102,6 +115,13 @@ func TestBumpResultValidate(t *testing.T) {
 	b = BumpResult{
 		Tx:    &wire.MsgTx{},
 		Event: TxPublished,
+	}
+	require.NoError(t, b.Validate())
+
+	// Tx is allowed to be nil in a TxFatal event.
+	b = BumpResult{
+		Event: TxFatal,
+		Err:   errDummy,
 	}
 	require.NoError(t, b.Validate())
 }

--- a/sweep/fee_bumper_test.go
+++ b/sweep/fee_bumper_test.go
@@ -91,13 +91,6 @@ func TestBumpResultValidate(t *testing.T) {
 	}
 	require.ErrorIs(t, b.Validate(), ErrInvalidBumpResult)
 
-	// A failed event without a tx will give an error.
-	b = BumpResult{
-		Event: TxFailed,
-		Err:   errDummy,
-	}
-	require.ErrorIs(t, b.Validate(), ErrInvalidBumpResult)
-
 	// A fatal event without a failure reason will give an error.
 	b = BumpResult{
 		Event: TxFailed,
@@ -115,6 +108,13 @@ func TestBumpResultValidate(t *testing.T) {
 	b = BumpResult{
 		Tx:    &wire.MsgTx{},
 		Event: TxPublished,
+	}
+	require.NoError(t, b.Validate())
+
+	// Tx is allowed to be nil in a TxFailed event.
+	b = BumpResult{
+		Event: TxFailed,
+		Err:   errDummy,
 	}
 	require.NoError(t, b.Validate())
 

--- a/sweep/fee_bumper_test.go
+++ b/sweep/fee_bumper_test.go
@@ -352,13 +352,10 @@ func TestStoreRecord(t *testing.T) {
 	}
 
 	// Call the method under test.
-	requestID := tp.storeRecord(tx, req, feeFunc, fee, utxoIndex)
-
-	// Check the request ID is as expected.
-	require.Equal(t, initialCounter+1, requestID)
+	tp.storeRecord(initialCounter, tx, req, feeFunc, fee, utxoIndex)
 
 	// Read the saved record and compare.
-	record, ok := tp.records.Load(requestID)
+	record, ok := tp.records.Load(initialCounter)
 	require.True(t, ok)
 	require.Equal(t, tx, record.tx)
 	require.Equal(t, feeFunc, record.feeFunction)
@@ -655,23 +652,19 @@ func TestCreateRBFCompliantTx(t *testing.T) {
 		},
 	}
 
+	var requestCounter atomic.Uint64
 	for _, tc := range testCases {
 		tc := tc
 
+		rid := requestCounter.Add(1)
 		t.Run(tc.name, func(t *testing.T) {
 			tc.setupMock()
 
 			// Call the method under test.
-			id, err := tp.createRBFCompliantTx(req, m.feeFunc)
+			err := tp.createRBFCompliantTx(rid, req, m.feeFunc)
 
 			// Check the result is as expected.
 			require.ErrorIs(t, err, tc.expectedErr)
-
-			// If there's an error, expect the requestID to be
-			// empty.
-			if tc.expectedErr != nil {
-				require.Zero(t, id)
-			}
 		})
 	}
 }
@@ -704,7 +697,8 @@ func TestTxPublisherBroadcast(t *testing.T) {
 
 	// Create a testing record and put it in the map.
 	fee := btcutil.Amount(1000)
-	requestID := tp.storeRecord(tx, req, m.feeFunc, fee, utxoIndex)
+	requestID := uint64(1)
+	tp.storeRecord(requestID, tx, req, m.feeFunc, fee, utxoIndex)
 
 	// Quickly check when the requestID cannot be found, an error is
 	// returned.
@@ -799,6 +793,9 @@ func TestRemoveResult(t *testing.T) {
 		op: 0,
 	}
 
+	// Create a test request ID counter.
+	requestCounter := atomic.Uint64{}
+
 	testCases := []struct {
 		name        string
 		setupRecord func() uint64
@@ -810,12 +807,13 @@ func TestRemoveResult(t *testing.T) {
 			// removed.
 			name: "remove on TxConfirmed",
 			setupRecord: func() uint64 {
-				id := tp.storeRecord(
-					tx, req, m.feeFunc, fee, utxoIndex,
+				rid := requestCounter.Add(1)
+				tp.storeRecord(
+					rid, tx, req, m.feeFunc, fee, utxoIndex,
 				)
-				tp.subscriberChans.Store(id, nil)
+				tp.subscriberChans.Store(rid, nil)
 
-				return id
+				return rid
 			},
 			result: &BumpResult{
 				Event: TxConfirmed,
@@ -827,12 +825,13 @@ func TestRemoveResult(t *testing.T) {
 			// When the tx is failed, the records will be removed.
 			name: "remove on TxFailed",
 			setupRecord: func() uint64 {
-				id := tp.storeRecord(
-					tx, req, m.feeFunc, fee, utxoIndex,
+				rid := requestCounter.Add(1)
+				tp.storeRecord(
+					rid, tx, req, m.feeFunc, fee, utxoIndex,
 				)
-				tp.subscriberChans.Store(id, nil)
+				tp.subscriberChans.Store(rid, nil)
 
-				return id
+				return rid
 			},
 			result: &BumpResult{
 				Event: TxFailed,
@@ -845,12 +844,13 @@ func TestRemoveResult(t *testing.T) {
 			// Noop when the tx is neither confirmed or failed.
 			name: "noop when tx is not confirmed or failed",
 			setupRecord: func() uint64 {
-				id := tp.storeRecord(
-					tx, req, m.feeFunc, fee, utxoIndex,
+				rid := requestCounter.Add(1)
+				tp.storeRecord(
+					rid, tx, req, m.feeFunc, fee, utxoIndex,
 				)
-				tp.subscriberChans.Store(id, nil)
+				tp.subscriberChans.Store(rid, nil)
 
-				return id
+				return rid
 			},
 			result: &BumpResult{
 				Event: TxPublished,
@@ -905,7 +905,8 @@ func TestNotifyResult(t *testing.T) {
 
 	// Create a testing record and put it in the map.
 	fee := btcutil.Amount(1000)
-	requestID := tp.storeRecord(tx, req, m.feeFunc, fee, utxoIndex)
+	requestID := uint64(1)
+	tp.storeRecord(requestID, tx, req, m.feeFunc, fee, utxoIndex)
 
 	// Create a subscription to the event.
 	subscriber := make(chan *BumpResult, 1)
@@ -953,40 +954,16 @@ func TestNotifyResult(t *testing.T) {
 	}
 }
 
-// TestBroadcastSuccess checks the public `Broadcast` method can successfully
-// broadcast a tx based on the request.
-func TestBroadcastSuccess(t *testing.T) {
+// TestBroadcast checks the public `Broadcast` method can successfully register
+// a broadcast request.
+func TestBroadcast(t *testing.T) {
 	t.Parallel()
 
 	// Create a publisher using the mocks.
-	tp, m := createTestPublisher(t)
+	tp, _ := createTestPublisher(t)
 
 	// Create a test feerate.
 	feerate := chainfee.SatPerKWeight(1000)
-
-	// Mock the fee estimator to return the testing fee rate.
-	//
-	// We are not testing `NewLinearFeeFunction` here, so the actual params
-	// used are irrelevant.
-	m.estimator.On("EstimateFeePerKW", mock.Anything).Return(
-		feerate, nil).Once()
-	m.estimator.On("RelayFeePerKW").Return(chainfee.FeePerKwFloor).Once()
-
-	// Mock the signer to always return a valid script.
-	//
-	// NOTE: we are not testing the utility of creating valid txes here, so
-	// this is fine to be mocked. This behaves essentially as skipping the
-	// Signer check and alaways assume the tx has a valid sig.
-	script := &input.Script{}
-	m.signer.On("ComputeInputScript", mock.Anything,
-		mock.Anything).Return(script, nil)
-
-	// Mock the testmempoolaccept to pass.
-	m.wallet.On("CheckMempoolAcceptance", mock.Anything).Return(nil).Once()
-
-	// Mock the wallet to publish successfully.
-	m.wallet.On("PublishTransaction",
-		mock.Anything, mock.Anything).Return(nil).Once()
 
 	// Create a test request.
 	inp := createTestInput(1000, input.WitnessKeyHash)
@@ -1003,25 +980,23 @@ func TestBroadcastSuccess(t *testing.T) {
 	// Send the req and expect no error.
 	resultChan, err := tp.Broadcast(req)
 	require.NoError(t, err)
-
-	// Check the result is sent back.
-	select {
-	case <-time.After(time.Second):
-		t.Fatal("timeout waiting for subscriber to receive result")
-
-	case result := <-resultChan:
-		// We expect the first result to be TxPublished.
-		require.Equal(t, TxPublished, result.Event)
-	}
+	require.NotNil(t, resultChan)
 
 	// Validate the record was stored.
 	require.Equal(t, 1, tp.records.Len())
 	require.Equal(t, 1, tp.subscriberChans.Len())
+
+	// Validate the record.
+	rid := tp.requestCounter.Load()
+	record, found := tp.records.Load(rid)
+	require.True(t, found)
+	require.Equal(t, req, record.req)
 }
 
-// TestBroadcastFail checks the public `Broadcast` returns the error or a
-// failed result when the broadcast fails.
-func TestBroadcastFail(t *testing.T) {
+// TestBroadcastImmediate checks the public `Broadcast` method can successfully
+// register a broadcast request and publish the tx when `Immediate` flag is
+// set.
+func TestBroadcastImmediate(t *testing.T) {
 	t.Parallel()
 
 	// Create a publisher using the mocks.
@@ -1040,64 +1015,28 @@ func TestBroadcastFail(t *testing.T) {
 		Budget:          btcutil.Amount(1000),
 		MaxFeeRate:      feerate * 10,
 		DeadlineHeight:  10,
+		Immediate:       true,
 	}
 
-	// Mock the fee estimator to return the testing fee rate.
+	// Mock the fee estimator to return an error.
 	//
-	// We are not testing `NewLinearFeeFunction` here, so the actual params
-	// used are irrelevant.
+	// NOTE: We are not testing `handleInitialBroadcast` here, but only
+	// interested in checking that this method is indeed called when
+	// `Immediate` is true. Thus we mock the method to return an error to
+	// quickly abort. As long as this mocked method is called, we know the
+	// `Immediate` flag works.
 	m.estimator.On("EstimateFeePerKW", mock.Anything).Return(
-		feerate, nil).Twice()
-	m.estimator.On("RelayFeePerKW").Return(chainfee.FeePerKwFloor).Twice()
+		chainfee.SatPerKWeight(0), errDummy).Once()
 
-	// Mock the signer to always return a valid script.
-	//
-	// NOTE: we are not testing the utility of creating valid txes here, so
-	// this is fine to be mocked. This behaves essentially as skipping the
-	// Signer check and alaways assume the tx has a valid sig.
-	script := &input.Script{}
-	m.signer.On("ComputeInputScript", mock.Anything,
-		mock.Anything).Return(script, nil)
-
-	// Mock the testmempoolaccept to return an error.
-	m.wallet.On("CheckMempoolAcceptance",
-		mock.Anything).Return(errDummy).Once()
-
-	// Send the req and expect an error returned.
+	// Send the req and expect no error.
 	resultChan, err := tp.Broadcast(req)
-	require.ErrorIs(t, err, errDummy)
-	require.Nil(t, resultChan)
-
-	// Validate the record was NOT stored.
-	require.Equal(t, 0, tp.records.Len())
-	require.Equal(t, 0, tp.subscriberChans.Len())
-
-	// Mock the testmempoolaccept again, this time it passes.
-	m.wallet.On("CheckMempoolAcceptance", mock.Anything).Return(nil).Once()
-
-	// Mock the wallet to fail on publish.
-	m.wallet.On("PublishTransaction",
-		mock.Anything, mock.Anything).Return(errDummy).Once()
-
-	// Send the req and expect no error returned.
-	resultChan, err = tp.Broadcast(req)
 	require.NoError(t, err)
+	require.NotNil(t, resultChan)
 
-	// Check the result is sent back.
-	select {
-	case <-time.After(time.Second):
-		t.Fatal("timeout waiting for subscriber to receive result")
-
-	case result := <-resultChan:
-		// We expect the result to be TxFailed and the error is set in
-		// the result.
-		require.Equal(t, TxFailed, result.Event)
-		require.ErrorIs(t, result.Err, errDummy)
-	}
-
-	// Validate the record was removed.
-	require.Equal(t, 0, tp.records.Len())
-	require.Equal(t, 0, tp.subscriberChans.Len())
+	// Validate the record was removed due to an error returned in initial
+	// broadcast.
+	require.Empty(t, tp.records.Len())
+	require.Empty(t, tp.subscriberChans.Len())
 }
 
 // TestCreateAnPublishFail checks all the error cases are handled properly in
@@ -1270,7 +1209,8 @@ func TestHandleTxConfirmed(t *testing.T) {
 
 	// Create a testing record and put it in the map.
 	fee := btcutil.Amount(1000)
-	requestID := tp.storeRecord(tx, req, m.feeFunc, fee, utxoIndex)
+	requestID := uint64(1)
+	tp.storeRecord(requestID, tx, req, m.feeFunc, fee, utxoIndex)
 	record, ok := tp.records.Load(requestID)
 	require.True(t, ok)
 
@@ -1350,7 +1290,8 @@ func TestHandleFeeBumpTx(t *testing.T) {
 
 	// Create a testing record and put it in the map.
 	fee := btcutil.Amount(1000)
-	requestID := tp.storeRecord(tx, req, m.feeFunc, fee, utxoIndex)
+	requestID := uint64(1)
+	tp.storeRecord(requestID, tx, req, m.feeFunc, fee, utxoIndex)
 
 	// Create a subscription to the event.
 	subscriber := make(chan *BumpResult, 1)
@@ -1550,4 +1491,187 @@ func TestProcessRecords(t *testing.T) {
 		require.Nil(t, result.Err)
 		require.Equal(t, requestID2, result.requestID)
 	}
+}
+
+// TestHandleInitialBroadcastSuccess checks `handleInitialBroadcast` method can
+// successfully broadcast a tx based on the request.
+func TestHandleInitialBroadcastSuccess(t *testing.T) {
+	t.Parallel()
+
+	// Create a publisher using the mocks.
+	tp, m := createTestPublisher(t)
+
+	// Create a test feerate.
+	feerate := chainfee.SatPerKWeight(1000)
+
+	// Mock the fee estimator to return the testing fee rate.
+	//
+	// We are not testing `NewLinearFeeFunction` here, so the actual params
+	// used are irrelevant.
+	m.estimator.On("EstimateFeePerKW", mock.Anything).Return(
+		feerate, nil).Once()
+	m.estimator.On("RelayFeePerKW").Return(chainfee.FeePerKwFloor).Once()
+
+	// Mock the signer to always return a valid script.
+	//
+	// NOTE: we are not testing the utility of creating valid txes here, so
+	// this is fine to be mocked. This behaves essentially as skipping the
+	// Signer check and alaways assume the tx has a valid sig.
+	script := &input.Script{}
+	m.signer.On("ComputeInputScript", mock.Anything,
+		mock.Anything).Return(script, nil)
+
+	// Mock the testmempoolaccept to pass.
+	m.wallet.On("CheckMempoolAcceptance", mock.Anything).Return(nil).Once()
+
+	// Mock the wallet to publish successfully.
+	m.wallet.On("PublishTransaction",
+		mock.Anything, mock.Anything).Return(nil).Once()
+
+	// Create a test request.
+	inp := createTestInput(1000, input.WitnessKeyHash)
+
+	// Create a testing bump request.
+	req := &BumpRequest{
+		DeliveryAddress: changePkScript,
+		Inputs:          []input.Input{&inp},
+		Budget:          btcutil.Amount(1000),
+		MaxFeeRate:      feerate * 10,
+		DeadlineHeight:  10,
+	}
+
+	// Register the testing record use `Broadcast`.
+	resultChan, err := tp.Broadcast(req)
+	require.NoError(t, err)
+
+	// Grab the monitor record from the map.
+	rid := tp.requestCounter.Load()
+	rec, ok := tp.records.Load(rid)
+	require.True(t, ok)
+
+	// Call the method under test.
+	tp.wg.Add(1)
+	tp.handleInitialBroadcast(rec, rid)
+
+	// Check the result is sent back.
+	select {
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for subscriber to receive result")
+
+	case result := <-resultChan:
+		// We expect the first result to be TxPublished.
+		require.Equal(t, TxPublished, result.Event)
+	}
+
+	// Validate the record was stored.
+	require.Equal(t, 1, tp.records.Len())
+	require.Equal(t, 1, tp.subscriberChans.Len())
+}
+
+// TestHandleInitialBroadcastFail checks `handleInitialBroadcast` returns the
+// error or a failed result when the broadcast fails.
+func TestHandleInitialBroadcastFail(t *testing.T) {
+	t.Parallel()
+
+	// Create a publisher using the mocks.
+	tp, m := createTestPublisher(t)
+
+	// Create a test feerate.
+	feerate := chainfee.SatPerKWeight(1000)
+
+	// Create a test request.
+	inp := createTestInput(1000, input.WitnessKeyHash)
+
+	// Create a testing bump request.
+	req := &BumpRequest{
+		DeliveryAddress: changePkScript,
+		Inputs:          []input.Input{&inp},
+		Budget:          btcutil.Amount(1000),
+		MaxFeeRate:      feerate * 10,
+		DeadlineHeight:  10,
+	}
+
+	// Mock the fee estimator to return the testing fee rate.
+	//
+	// We are not testing `NewLinearFeeFunction` here, so the actual params
+	// used are irrelevant.
+	m.estimator.On("EstimateFeePerKW", mock.Anything).Return(
+		feerate, nil).Twice()
+	m.estimator.On("RelayFeePerKW").Return(chainfee.FeePerKwFloor).Twice()
+
+	// Mock the signer to always return a valid script.
+	//
+	// NOTE: we are not testing the utility of creating valid txes here, so
+	// this is fine to be mocked. This behaves essentially as skipping the
+	// Signer check and alaways assume the tx has a valid sig.
+	script := &input.Script{}
+	m.signer.On("ComputeInputScript", mock.Anything,
+		mock.Anything).Return(script, nil)
+
+	// Mock the testmempoolaccept to return an error.
+	m.wallet.On("CheckMempoolAcceptance",
+		mock.Anything).Return(errDummy).Once()
+
+	// Register the testing record use `Broadcast`.
+	resultChan, err := tp.Broadcast(req)
+	require.NoError(t, err)
+
+	// Grab the monitor record from the map.
+	rid := tp.requestCounter.Load()
+	rec, ok := tp.records.Load(rid)
+	require.True(t, ok)
+
+	// Call the method under test and expect an error returned.
+	tp.wg.Add(1)
+	tp.handleInitialBroadcast(rec, rid)
+
+	// Check the result is sent back.
+	select {
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for subscriber to receive result")
+
+	case result := <-resultChan:
+		// We expect the first result to be TxFatal.
+		require.Equal(t, TxFatal, result.Event)
+	}
+
+	// Validate the record was NOT stored.
+	require.Equal(t, 0, tp.records.Len())
+	require.Equal(t, 0, tp.subscriberChans.Len())
+
+	// Mock the testmempoolaccept again, this time it passes.
+	m.wallet.On("CheckMempoolAcceptance", mock.Anything).Return(nil).Once()
+
+	// Mock the wallet to fail on publish.
+	m.wallet.On("PublishTransaction",
+		mock.Anything, mock.Anything).Return(errDummy).Once()
+
+	// Register the testing record use `Broadcast`.
+	resultChan, err = tp.Broadcast(req)
+	require.NoError(t, err)
+
+	// Grab the monitor record from the map.
+	rid = tp.requestCounter.Load()
+	rec, ok = tp.records.Load(rid)
+	require.True(t, ok)
+
+	// Call the method under test.
+	tp.wg.Add(1)
+	tp.handleInitialBroadcast(rec, rid)
+
+	// Check the result is sent back.
+	select {
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for subscriber to receive result")
+
+	case result := <-resultChan:
+		// We expect the result to be TxFailed and the error is set in
+		// the result.
+		require.Equal(t, TxFailed, result.Event)
+		require.ErrorIs(t, result.Err, errDummy)
+	}
+
+	// Validate the record was removed.
+	require.Equal(t, 0, tp.records.Len())
+	require.Equal(t, 0, tp.subscriberChans.Len())
 }

--- a/sweep/fee_function.go
+++ b/sweep/fee_function.go
@@ -14,6 +14,9 @@ var (
 	// ErrMaxPosition is returned when trying to increase the position of
 	// the fee function while it's already at its max.
 	ErrMaxPosition = errors.New("position already at max")
+
+	// ErrZeroFeeRateDelta is returned when the fee rate delta is zero.
+	ErrZeroFeeRateDelta = errors.New("fee rate delta is zero")
 )
 
 // mSatPerKWeight represents a fee rate in msat/kw.
@@ -169,7 +172,7 @@ func NewLinearFeeFunction(maxFeeRate chainfee.SatPerKWeight,
 			"endingFeeRate=%v, width=%v, delta=%v", start, end,
 			l.width, l.deltaFeeRate)
 
-		return nil, fmt.Errorf("fee rate delta is zero")
+		return nil, ErrZeroFeeRateDelta
 	}
 
 	// Attach the calculated values to the fee function.

--- a/sweep/mock_test.go
+++ b/sweep/mock_test.go
@@ -268,6 +268,13 @@ func (m *MockInputSet) StartingFeeRate() fn.Option[chainfee.SatPerKWeight] {
 	return args.Get(0).(fn.Option[chainfee.SatPerKWeight])
 }
 
+// Immediate returns whether the inputs should be swept immediately.
+func (m *MockInputSet) Immediate() bool {
+	args := m.Called()
+
+	return args.Bool(0)
+}
+
 // MockBumper is a mock implementation of the interface Bumper.
 type MockBumper struct {
 	mock.Mock

--- a/sweep/mock_test.go
+++ b/sweep/mock_test.go
@@ -284,14 +284,14 @@ type MockBumper struct {
 var _ Bumper = (*MockBumper)(nil)
 
 // Broadcast broadcasts the transaction to the network.
-func (m *MockBumper) Broadcast(req *BumpRequest) (<-chan *BumpResult, error) {
+func (m *MockBumper) Broadcast(req *BumpRequest) <-chan *BumpResult {
 	args := m.Called(req)
 
 	if args.Get(0) == nil {
-		return nil, args.Error(1)
+		return nil
 	}
 
-	return args.Get(0).(chan *BumpResult), args.Error(1)
+	return args.Get(0).(chan *BumpResult)
 }
 
 // MockFeeFunction is a mock implementation of the FeeFunction interface.

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -10,6 +10,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/davecgh/go-spew/spew"
+	"github.com/lightningnetwork/lnd/chainio"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/input"
@@ -308,6 +309,10 @@ type UtxoSweeper struct {
 	started uint32 // To be used atomically.
 	stopped uint32 // To be used atomically.
 
+	// Embed the blockbeat consumer struct to get access to the method
+	// `NotifyBlockProcessed` and the `BlockbeatChan`.
+	chainio.BeatConsumer
+
 	cfg *UtxoSweeperConfig
 
 	newInputs chan *sweepInputMessage
@@ -341,6 +346,9 @@ type UtxoSweeper struct {
 	// TxPublisher.
 	bumpRespChan chan *bumpResp
 }
+
+// Compile-time check for the chainio.Consumer interface.
+var _ chainio.Consumer = (*UtxoSweeper)(nil)
 
 // UtxoSweeperConfig contains dependencies of UtxoSweeper.
 type UtxoSweeperConfig struct {
@@ -415,7 +423,7 @@ type sweepInputMessage struct {
 
 // New returns a new Sweeper instance.
 func New(cfg *UtxoSweeperConfig) *UtxoSweeper {
-	return &UtxoSweeper{
+	s := &UtxoSweeper{
 		cfg:               cfg,
 		newInputs:         make(chan *sweepInputMessage),
 		spendChan:         make(chan *chainntnfs.SpendDetail),
@@ -425,6 +433,11 @@ func New(cfg *UtxoSweeperConfig) *UtxoSweeper {
 		inputs:            make(InputsMap),
 		bumpRespChan:      make(chan *bumpResp, 100),
 	}
+
+	// Mount the block consumer.
+	s.BeatConsumer = chainio.NewBeatConsumer(s.quit, s.Name())
+
+	return s
 }
 
 // Start starts the process of constructing and publish sweep txes.
@@ -506,6 +519,11 @@ func (s *UtxoSweeper) Stop() error {
 	s.wg.Wait()
 
 	return nil
+}
+
+// NOTE: part of the `chainio.Consumer` interface.
+func (s *UtxoSweeper) Name() string {
+	return "UtxoSweeper"
 }
 
 // SweepInput sweeps inputs back into the wallet. The inputs will be batched and

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -441,7 +441,7 @@ func New(cfg *UtxoSweeperConfig) *UtxoSweeper {
 }
 
 // Start starts the process of constructing and publish sweep txes.
-func (s *UtxoSweeper) Start() error {
+func (s *UtxoSweeper) Start(beat chainio.Blockbeat) error {
 	if !atomic.CompareAndSwapUint32(&s.started, 0, 1) {
 		return nil
 	}
@@ -451,6 +451,9 @@ func (s *UtxoSweeper) Start() error {
 	// Retrieve relay fee for dust limit calculation. Assume that this will
 	// not change from here on.
 	s.relayFeeRate = s.cfg.FeeEstimator.RelayFeePerKW()
+
+	// Set the current height.
+	s.currentHeight = beat.Height()
 
 	// Start sweeper main loop.
 	s.wg.Add(1)

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -827,6 +827,7 @@ func (s *UtxoSweeper) sweep(set InputSet) error {
 		DeliveryAddress: sweepAddr,
 		MaxFeeRate:      s.cfg.MaxFeeRate.FeePerKWeight(),
 		StartingFeeRate: set.StartingFeeRate(),
+		Immediate:       set.Immediate(),
 		// TODO(yy): pass the strategy here.
 	}
 

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -1669,6 +1669,14 @@ func (s *UtxoSweeper) monitorFeeBumpResult(set InputSet,
 			// in sweeper and rely solely on this event to mark
 			// inputs as Swept?
 			if r.Event == TxConfirmed || r.Event == TxFailed {
+				// Exit if the tx is failed to be created.
+				if r.Tx == nil {
+					log.Debugf("Received %v for nil tx, "+
+						"exit monitor", r.Event)
+
+					return
+				}
+
 				log.Debugf("Received %v for sweep tx %v, exit "+
 					"fee bump monitor", r.Event,
 					r.Tx.TxHash())
@@ -1694,7 +1702,10 @@ func (s *UtxoSweeper) handleBumpEventTxFailed(resp *bumpResp) {
 	r := resp.result
 	tx, err := r.Tx, r.Err
 
-	log.Warnf("Fee bump attempt failed for tx=%v: %v", tx.TxHash(), err)
+	if tx != nil {
+		log.Warnf("Fee bump attempt failed for tx=%v: %v", tx.TxHash(),
+			err)
+	}
 
 	// NOTE: When marking the inputs as failed, we are using the input set
 	// instead of the inputs found in the tx. This is fine for current

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -1441,11 +1441,6 @@ func (s *UtxoSweeper) markInputFailed(pi *SweeperInput, err error) {
 
 	pi.state = Failed
 
-	// Remove all other inputs in this exclusive group.
-	if pi.params.ExclusiveGroup != nil {
-		s.removeExclusiveGroup(*pi.params.ExclusiveGroup)
-	}
-
 	s.signalResult(pi, Result{Err: err})
 }
 
@@ -1728,6 +1723,62 @@ func (s *UtxoSweeper) handleBumpEventTxPublished(resp *bumpResp) error {
 	return nil
 }
 
+// handleBumpEventTxFatal handles the case where there's an unexpected error
+// when creating or publishing the sweeping tx. In this case, the tx will be
+// removed from the sweeper store and the inputs will be marked as `Failed`,
+// which means they will not be retried.
+func (s *UtxoSweeper) handleBumpEventTxFatal(resp *bumpResp) error {
+	r := resp.result
+
+	// Remove the tx from the sweeper store if there is one. Since this is
+	// a broadcast error, it's likely there isn't a tx here.
+	if r.Tx != nil {
+		txid := r.Tx.TxHash()
+		log.Infof("Tx=%v failed with unexpected error: %v", txid, r.Err)
+
+		// Remove the tx from the sweeper db if it exists.
+		if err := s.cfg.Store.DeleteTx(txid); err != nil {
+			return fmt.Errorf("delete tx record for %v: %w", txid,
+				err)
+		}
+	}
+
+	// Mark the inputs as failed.
+	s.markInputsFailed(resp.set, r.Err)
+
+	return nil
+}
+
+// markInputsFailed marks all inputs found in the tx as failed. It will also
+// notify all the subscribers of these inputs.
+func (s *UtxoSweeper) markInputsFailed(set InputSet, err error) {
+	for _, inp := range set.Inputs() {
+		outpoint := inp.OutPoint()
+
+		input, ok := s.inputs[outpoint]
+		if !ok {
+			// It's very likely that a spending tx contains inputs
+			// that we don't know.
+			log.Tracef("Skipped marking input as failed: %v not "+
+				"found in pending inputs", outpoint)
+
+			continue
+		}
+
+		// If the input is already in a terminal state, we don't want
+		// to rewrite it, which also indicates an error as we only get
+		// an error event during the initial broadcast.
+		if input.terminated() {
+			log.Errorf("Skipped marking input=%v as failed due to "+
+				"unexpected state=%v", outpoint, input.state)
+
+			continue
+		}
+
+		s.markInputFailed(input, err)
+	}
+}
+
 // handleBumpEvent handles the result sent from the bumper based on its event
 // type.
 //
@@ -1752,8 +1803,10 @@ func (s *UtxoSweeper) handleBumpEvent(r *bumpResp) error {
 	case TxReplaced:
 		return s.handleBumpEventTxReplaced(r)
 
+	// There's a fatal error in creating the tx, we will remove the tx from
+	// the sweeper db and mark the inputs as failed.
 	case TxFatal:
-		// TODO(yy): create a method to remove this input.
+		return s.handleBumpEventTxFatal(r)
 	}
 
 	return nil

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -838,16 +838,7 @@ func (s *UtxoSweeper) sweep(set InputSet) error {
 
 	// Broadcast will return a read-only chan that we will listen to for
 	// this publish result and future RBF attempt.
-	resp, err := s.cfg.Publisher.Broadcast(req)
-	if err != nil {
-		log.Errorf("Initial broadcast failed: %v, inputs=\n%v", err,
-			inputTypeSummary(set.Inputs()))
-
-		// TODO(yy): find out which input is causing the failure.
-		s.markInputsPublishFailed(set)
-
-		return err
-	}
+	resp := s.cfg.Publisher.Broadcast(req)
 
 	// Successfully sent the broadcast attempt, we now handle the result by
 	// subscribing to the result chan and listen for future updates about

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -1729,7 +1729,7 @@ func (s *UtxoSweeper) handleBumpEventTxPublished(r *BumpResult) error {
 // NOTE: TxConfirmed event is not handled, since we already subscribe to the
 // input's spending event, we don't need to do anything here.
 func (s *UtxoSweeper) handleBumpEvent(r *BumpResult) error {
-	log.Debugf("Received bump event [%v] for tx %v", r.Event, r.Tx.TxHash())
+	log.Debugf("Received bump result %v", r)
 
 	switch r.Event {
 	// The tx has been published, we update the inputs' state and create a
@@ -1745,6 +1745,9 @@ func (s *UtxoSweeper) handleBumpEvent(r *BumpResult) error {
 	// with the new one.
 	case TxReplaced:
 		return s.handleBumpEventTxReplaced(r)
+
+	case TxFatal:
+		// TODO(yy): create a method to remove this input.
 	}
 
 	return nil

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -242,8 +242,9 @@ func (p *SweeperInput) isMature(currentHeight uint32) (bool, uint32) {
 	// currentHeight plus one.
 	locktime = p.BlocksToMaturity() + p.HeightHint()
 	if currentHeight+1 < locktime {
-		log.Debugf("Input %v has CSV expiry=%v, current height is %v",
-			p.OutPoint(), locktime, currentHeight)
+		log.Debugf("Input %v has CSV expiry=%v, current height is %v, "+
+			"skipped sweeping", p.OutPoint(), locktime,
+			currentHeight)
 
 		return false, locktime
 	}
@@ -1197,8 +1198,8 @@ func (s *UtxoSweeper) calculateDefaultDeadline(pi *SweeperInput) int32 {
 	if !matured {
 		defaultDeadline = int32(locktime + s.cfg.NoDeadlineConfTarget)
 		log.Debugf("Input %v is immature, using locktime=%v instead "+
-			"of current height=%d", pi.OutPoint(), locktime,
-			s.currentHeight)
+			"of current height=%d as starting height",
+			pi.OutPoint(), locktime, s.currentHeight)
 	}
 
 	return defaultDeadline
@@ -1210,7 +1211,8 @@ func (s *UtxoSweeper) handleNewInput(input *sweepInputMessage) error {
 	outpoint := input.input.OutPoint()
 	pi, pending := s.inputs[outpoint]
 	if pending {
-		log.Debugf("Already has pending input %v received", outpoint)
+		log.Infof("Already has pending input %v received, old params: "+
+			"%v, new params %v", outpoint, pi.params, input.params)
 
 		s.handleExistingInput(input, pi)
 
@@ -1492,6 +1494,8 @@ func (s *UtxoSweeper) updateSweeperInputs() InputsMap {
 	// turn this inputs map into a SyncMap in case we wanna add concurrent
 	// access to the map in the future.
 	for op, input := range s.inputs {
+		log.Tracef("Checking input: %s, state=%v", input, input.state)
+
 		// If the input has reached a final state, that it's either
 		// been swept, or failed, or excluded, we will remove it from
 		// our sweeper.
@@ -1521,7 +1525,7 @@ func (s *UtxoSweeper) updateSweeperInputs() InputsMap {
 		// skip this input and wait for the locktime to be reached.
 		mature, locktime := input.isMature(uint32(s.currentHeight))
 		if !mature {
-			log.Infof("Skipping input %v due to locktime=%v not "+
+			log.Debugf("Skipping input %v due to locktime=%v not "+
 				"reached, current height is %v", op, locktime,
 				s.currentHeight)
 

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -443,6 +443,7 @@ func TestUpdateSweeperInputs(t *testing.T) {
 	// returned.
 	inp2.On("RequiredLockTime").Return(
 		uint32(s.currentHeight+1), true).Once()
+	inp2.On("OutPoint").Return(wire.OutPoint{Index: 2}).Maybe()
 	input7 := &SweeperInput{state: Init, Input: inp2}
 
 	// Mock the input to have a CSV expiry in the future so it will NOT be
@@ -451,6 +452,7 @@ func TestUpdateSweeperInputs(t *testing.T) {
 		uint32(s.currentHeight), false).Once()
 	inp3.On("BlocksToMaturity").Return(uint32(2)).Once()
 	inp3.On("HeightHint").Return(uint32(s.currentHeight)).Once()
+	inp3.On("OutPoint").Return(wire.OutPoint{Index: 3}).Maybe()
 	input8 := &SweeperInput{state: Init, Input: inp3}
 
 	// Add the inputs to the sweeper. After the update, we should see the

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -739,7 +739,7 @@ func TestHandleBumpEventTxFailed(t *testing.T) {
 
 	// Call the method under test.
 	err := s.handleBumpEvent(resp)
-	require.ErrorIs(t, err, errDummy)
+	require.NoError(t, err)
 
 	// Assert the states of the first two inputs are updated.
 	require.Equal(t, PublishFailed, s.inputs[op1].state)

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -673,13 +673,8 @@ func TestSweepPendingInputs(t *testing.T) {
 		setNeedWallet, normalSet,
 	})
 
-	// Mock `Broadcast` to return an error. This should cause the
-	// `createSweepTx` inside `sweep` to fail. This is done so we can
-	// terminate the method early as we are only interested in testing the
-	// workflow in `sweepPendingInputs`. We don't need to test `sweep` here
-	// as it should be tested in its own unit test.
-	dummyErr := errors.New("dummy error")
-	publisher.On("Broadcast", mock.Anything).Return(nil, dummyErr).Twice()
+	// Mock `Broadcast` to return a result.
+	publisher.On("Broadcast", mock.Anything).Return(nil).Twice()
 
 	// Call the method under test.
 	s.sweepPendingInputs(pis)

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -704,11 +704,13 @@ func TestSweepPendingInputs(t *testing.T) {
 	setNeedWallet.On("Budget").Return(btcutil.Amount(1)).Once()
 	setNeedWallet.On("StartingFeeRate").Return(
 		fn.None[chainfee.SatPerKWeight]()).Once()
+	setNeedWallet.On("Immediate").Return(false).Once()
 	normalSet.On("Inputs").Return(nil).Maybe()
 	normalSet.On("DeadlineHeight").Return(testHeight).Once()
 	normalSet.On("Budget").Return(btcutil.Amount(1)).Once()
 	normalSet.On("StartingFeeRate").Return(
 		fn.None[chainfee.SatPerKWeight]()).Once()
+	normalSet.On("Immediate").Return(false).Once()
 
 	// Make pending inputs for testing. We don't need real values here as
 	// the returned clusters are mocked.

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -1,6 +1,7 @@
 package sweep
 
 import (
+	"crypto/rand"
 	"errors"
 	"testing"
 	"time"
@@ -12,6 +13,7 @@ import (
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 	"github.com/stretchr/testify/mock"
@@ -33,6 +35,41 @@ var (
 	})
 )
 
+// createMockInput creates a mock input and saves it to the sweeper's inputs
+// map. The created input has the specified state and a random outpoint. It
+// will assert the method `OutPoint` is called at least once.
+func createMockInput(t *testing.T, s *UtxoSweeper,
+	state SweepState) *input.MockInput {
+
+	inp := &input.MockInput{}
+	t.Cleanup(func() {
+		inp.AssertExpectations(t)
+	})
+
+	randBuf := make([]byte, lntypes.HashSize)
+	_, err := rand.Read(randBuf)
+	require.NoError(t, err, "internal error, cannot generate random bytes")
+
+	randHash, err := chainhash.NewHash(randBuf)
+	require.NoError(t, err)
+
+	inp.On("OutPoint").Return(wire.OutPoint{
+		Hash:  *randHash,
+		Index: 0,
+	})
+
+	// We don't do branch switches based on the witness type here so we
+	// just mock it.
+	inp.On("WitnessType").Return(input.CommitmentTimeLock).Maybe()
+
+	s.inputs[inp.OutPoint()] = &SweeperInput{
+		Input: inp,
+		state: state,
+	}
+
+	return inp
+}
+
 // TestMarkInputsPendingPublish checks that given a list of inputs with
 // different states, only the non-terminal state will be marked as `Published`.
 func TestMarkInputsPendingPublish(t *testing.T) {
@@ -47,50 +84,21 @@ func TestMarkInputsPendingPublish(t *testing.T) {
 	set := &MockInputSet{}
 	defer set.AssertExpectations(t)
 
-	// Create three testing inputs.
-	//
-	// inputNotExist specifies an input that's not found in the sweeper's
-	// `pendingInputs` map.
-	inputNotExist := &input.MockInput{}
-	defer inputNotExist.AssertExpectations(t)
-
-	inputNotExist.On("OutPoint").Return(wire.OutPoint{Index: 0})
-
-	// inputInit specifies a newly created input.
-	inputInit := &input.MockInput{}
-	defer inputInit.AssertExpectations(t)
-
-	inputInit.On("OutPoint").Return(wire.OutPoint{Index: 1})
-
-	s.inputs[inputInit.OutPoint()] = &SweeperInput{
-		state: Init,
-	}
-
-	// inputPendingPublish specifies an input that's about to be published.
-	inputPendingPublish := &input.MockInput{}
-	defer inputPendingPublish.AssertExpectations(t)
-
-	inputPendingPublish.On("OutPoint").Return(wire.OutPoint{Index: 2})
-
-	s.inputs[inputPendingPublish.OutPoint()] = &SweeperInput{
-		state: PendingPublish,
-	}
-
-	// inputTerminated specifies an input that's terminated.
-	inputTerminated := &input.MockInput{}
-	defer inputTerminated.AssertExpectations(t)
-
-	inputTerminated.On("OutPoint").Return(wire.OutPoint{Index: 3})
-
-	s.inputs[inputTerminated.OutPoint()] = &SweeperInput{
-		state: Excluded,
-	}
+	// Create three inputs with different states.
+	// - inputInit specifies a newly created input.
+	// - inputPendingPublish specifies an input about to be published.
+	// - inputTerminated specifies an input that's terminated.
+	var (
+		inputInit           = createMockInput(t, s, Init)
+		inputPendingPublish = createMockInput(t, s, PendingPublish)
+		inputTerminated     = createMockInput(t, s, Excluded)
+	)
 
 	// Mark the test inputs. We expect the non-exist input and the
 	// inputTerminated to be skipped, and the rest to be marked as pending
 	// publish.
 	set.On("Inputs").Return([]input.Input{
-		inputNotExist, inputInit, inputPendingPublish, inputTerminated,
+		inputInit, inputPendingPublish, inputTerminated,
 	})
 	s.markInputsPendingPublish(set)
 
@@ -122,36 +130,22 @@ func TestMarkInputsPublished(t *testing.T) {
 	dummyTR := &TxRecord{}
 	dummyErr := errors.New("dummy error")
 
+	// Create a mock input set.
+	set := &MockInputSet{}
+	defer set.AssertExpectations(t)
+
 	// Create a test sweeper.
 	s := New(&UtxoSweeperConfig{
 		Store: mockStore,
 	})
 
-	// Create three testing inputs.
-	//
-	// inputNotExist specifies an input that's not found in the sweeper's
-	// `inputs` map.
-	inputNotExist := &wire.TxIn{
-		PreviousOutPoint: wire.OutPoint{Index: 1},
-	}
-
-	// inputInit specifies a newly created input. When marking this as
-	// published, we should see an error log as this input hasn't been
-	// published yet.
-	inputInit := &wire.TxIn{
-		PreviousOutPoint: wire.OutPoint{Index: 2},
-	}
-	s.inputs[inputInit.PreviousOutPoint] = &SweeperInput{
-		state: Init,
-	}
-
-	// inputPendingPublish specifies an input that's about to be published.
-	inputPendingPublish := &wire.TxIn{
-		PreviousOutPoint: wire.OutPoint{Index: 3},
-	}
-	s.inputs[inputPendingPublish.PreviousOutPoint] = &SweeperInput{
-		state: PendingPublish,
-	}
+	// Create two inputs with different states.
+	// - inputInit specifies a newly created input.
+	// - inputPendingPublish specifies an input about to be published.
+	var (
+		inputInit           = createMockInput(t, s, Init)
+		inputPendingPublish = createMockInput(t, s, PendingPublish)
+	)
 
 	// First, check that when an error is returned from db, it's properly
 	// returned here.
@@ -171,9 +165,9 @@ func TestMarkInputsPublished(t *testing.T) {
 	// Mark the test inputs. We expect the non-exist input and the
 	// inputInit to be skipped, and the final input to be marked as
 	// published.
-	err = s.markInputsPublished(dummyTR, []*wire.TxIn{
-		inputNotExist, inputInit, inputPendingPublish,
-	})
+	set.On("Inputs").Return([]input.Input{inputInit, inputPendingPublish})
+
+	err = s.markInputsPublished(dummyTR, set)
 	require.NoError(err)
 
 	// We expect unchanged number of pending inputs.
@@ -181,11 +175,11 @@ func TestMarkInputsPublished(t *testing.T) {
 
 	// We expect the init input's state to stay unchanged.
 	require.Equal(Init,
-		s.inputs[inputInit.PreviousOutPoint].state)
+		s.inputs[inputInit.OutPoint()].state)
 
 	// We expect the pending-publish input's is now marked as published.
 	require.Equal(Published,
-		s.inputs[inputPendingPublish.PreviousOutPoint].state)
+		s.inputs[inputPendingPublish.OutPoint()].state)
 
 	// Assert mocked statements are executed as expected.
 	mockStore.AssertExpectations(t)
@@ -202,117 +196,75 @@ func TestMarkInputsPublishFailed(t *testing.T) {
 	// Create a mock sweeper store.
 	mockStore := NewMockSweeperStore()
 
+	// Create a mock input set.
+	set := &MockInputSet{}
+	defer set.AssertExpectations(t)
+
 	// Create a test sweeper.
 	s := New(&UtxoSweeperConfig{
 		Store: mockStore,
 	})
 
-	// Create testing inputs for each state.
-	//
-	// inputNotExist specifies an input that's not found in the sweeper's
-	// `inputs` map.
-	inputNotExist := &wire.TxIn{
-		PreviousOutPoint: wire.OutPoint{Index: 1},
-	}
+	// Create inputs with different states.
+	// - inputInit specifies a newly created input. When marking this as
+	//   published, we should see an error log as this input hasn't been
+	//   published yet.
+	// - inputPendingPublish specifies an input about to be published.
+	// - inputPublished specifies an input that's published.
+	// - inputPublishFailed specifies an input that's failed to be
+	//   published.
+	// - inputSwept specifies an input that's swept.
+	// - inputExcluded specifies an input that's excluded.
+	// - inputFailed specifies an input that's failed.
+	var (
+		inputInit           = createMockInput(t, s, Init)
+		inputPendingPublish = createMockInput(t, s, PendingPublish)
+		inputPublished      = createMockInput(t, s, Published)
+		inputPublishFailed  = createMockInput(t, s, PublishFailed)
+		inputSwept          = createMockInput(t, s, Swept)
+		inputExcluded       = createMockInput(t, s, Excluded)
+		inputFailed         = createMockInput(t, s, Failed)
+	)
 
-	// inputInit specifies a newly created input. When marking this as
-	// published, we should see an error log as this input hasn't been
-	// published yet.
-	inputInit := &wire.TxIn{
-		PreviousOutPoint: wire.OutPoint{Index: 2},
-	}
-	s.inputs[inputInit.PreviousOutPoint] = &SweeperInput{
-		state: Init,
-	}
-
-	// inputPendingPublish specifies an input that's about to be published.
-	inputPendingPublish := &wire.TxIn{
-		PreviousOutPoint: wire.OutPoint{Index: 3},
-	}
-	s.inputs[inputPendingPublish.PreviousOutPoint] = &SweeperInput{
-		state: PendingPublish,
-	}
-
-	// inputPublished specifies an input that's published.
-	inputPublished := &wire.TxIn{
-		PreviousOutPoint: wire.OutPoint{Index: 4},
-	}
-	s.inputs[inputPublished.PreviousOutPoint] = &SweeperInput{
-		state: Published,
-	}
-
-	// inputPublishFailed specifies an input that's failed to be published.
-	inputPublishFailed := &wire.TxIn{
-		PreviousOutPoint: wire.OutPoint{Index: 5},
-	}
-	s.inputs[inputPublishFailed.PreviousOutPoint] = &SweeperInput{
-		state: PublishFailed,
-	}
-
-	// inputSwept specifies an input that's swept.
-	inputSwept := &wire.TxIn{
-		PreviousOutPoint: wire.OutPoint{Index: 6},
-	}
-	s.inputs[inputSwept.PreviousOutPoint] = &SweeperInput{
-		state: Swept,
-	}
-
-	// inputExcluded specifies an input that's excluded.
-	inputExcluded := &wire.TxIn{
-		PreviousOutPoint: wire.OutPoint{Index: 7},
-	}
-	s.inputs[inputExcluded.PreviousOutPoint] = &SweeperInput{
-		state: Excluded,
-	}
-
-	// inputFailed specifies an input that's failed.
-	inputFailed := &wire.TxIn{
-		PreviousOutPoint: wire.OutPoint{Index: 8},
-	}
-	s.inputs[inputFailed.PreviousOutPoint] = &SweeperInput{
-		state: Failed,
-	}
-
-	// Gather all inputs' outpoints.
-	pendingOps := make([]wire.OutPoint, 0, len(s.inputs)+1)
-	for op := range s.inputs {
-		pendingOps = append(pendingOps, op)
-	}
-	pendingOps = append(pendingOps, inputNotExist.PreviousOutPoint)
+	// Gather all inputs.
+	set.On("Inputs").Return([]input.Input{
+		inputInit, inputPendingPublish, inputPublished,
+		inputPublishFailed, inputSwept, inputExcluded, inputFailed,
+	})
 
 	// Mark the test inputs. We expect the non-exist input and the
 	// inputInit to be skipped, and the final input to be marked as
 	// published.
-	s.markInputsPublishFailed(pendingOps)
+	s.markInputsPublishFailed(set)
 
 	// We expect unchanged number of pending inputs.
 	require.Len(s.inputs, 7)
 
 	// We expect the init input's state to stay unchanged.
 	require.Equal(Init,
-		s.inputs[inputInit.PreviousOutPoint].state)
+		s.inputs[inputInit.OutPoint()].state)
 
 	// We expect the pending-publish input's is now marked as publish
 	// failed.
 	require.Equal(PublishFailed,
-		s.inputs[inputPendingPublish.PreviousOutPoint].state)
+		s.inputs[inputPendingPublish.OutPoint()].state)
 
 	// We expect the published input's is now marked as publish failed.
 	require.Equal(PublishFailed,
-		s.inputs[inputPublished.PreviousOutPoint].state)
+		s.inputs[inputPublished.OutPoint()].state)
 
 	// We expect the publish failed input to stay unchanged.
 	require.Equal(PublishFailed,
-		s.inputs[inputPublishFailed.PreviousOutPoint].state)
+		s.inputs[inputPublishFailed.OutPoint()].state)
 
 	// We expect the swept input to stay unchanged.
-	require.Equal(Swept, s.inputs[inputSwept.PreviousOutPoint].state)
+	require.Equal(Swept, s.inputs[inputSwept.OutPoint()].state)
 
 	// We expect the excluded input to stay unchanged.
-	require.Equal(Excluded, s.inputs[inputExcluded.PreviousOutPoint].state)
+	require.Equal(Excluded, s.inputs[inputExcluded.OutPoint()].state)
 
 	// We expect the failed input to stay unchanged.
-	require.Equal(Failed, s.inputs[inputFailed.PreviousOutPoint].state)
+	require.Equal(Failed, s.inputs[inputFailed.OutPoint()].state)
 
 	// Assert mocked statements are executed as expected.
 	mockStore.AssertExpectations(t)
@@ -738,33 +690,33 @@ func TestSweepPendingInputs(t *testing.T) {
 func TestHandleBumpEventTxFailed(t *testing.T) {
 	t.Parallel()
 
+	// Create a mock input set.
+	set := &MockInputSet{}
+	defer set.AssertExpectations(t)
+
 	// Create a test sweeper.
 	s := New(&UtxoSweeperConfig{})
 
-	var (
-		// Create four testing outpoints.
-		op1        = wire.OutPoint{Hash: chainhash.Hash{1}}
-		op2        = wire.OutPoint{Hash: chainhash.Hash{2}}
-		op3        = wire.OutPoint{Hash: chainhash.Hash{3}}
-		opNotExist = wire.OutPoint{Hash: chainhash.Hash{4}}
-	)
+	// inputNotExist specifies an input that's not found in the sweeper's
+	// `pendingInputs` map.
+	inputNotExist := &input.MockInput{}
+	defer inputNotExist.AssertExpectations(t)
+	inputNotExist.On("OutPoint").Return(wire.OutPoint{Index: 0})
+	opNotExist := inputNotExist.OutPoint()
 
 	// Create three mock inputs.
-	input1 := &input.MockInput{}
-	defer input1.AssertExpectations(t)
+	var (
+		input1 = createMockInput(t, s, PendingPublish)
+		input2 = createMockInput(t, s, PendingPublish)
+		input3 = createMockInput(t, s, PendingPublish)
+	)
 
-	input2 := &input.MockInput{}
-	defer input2.AssertExpectations(t)
-
-	input3 := &input.MockInput{}
-	defer input3.AssertExpectations(t)
+	op1 := input1.OutPoint()
+	op2 := input2.OutPoint()
+	op3 := input3.OutPoint()
 
 	// Construct the initial state for the sweeper.
-	s.inputs = InputsMap{
-		op1: &SweeperInput{Input: input1, state: PendingPublish},
-		op2: &SweeperInput{Input: input2, state: PendingPublish},
-		op3: &SweeperInput{Input: input3, state: PendingPublish},
-	}
+	set.On("Inputs").Return([]input.Input{input1, input2, input3})
 
 	// Create a testing tx that spends the first two inputs.
 	tx := &wire.MsgTx{
@@ -782,16 +734,26 @@ func TestHandleBumpEventTxFailed(t *testing.T) {
 		Err:   errDummy,
 	}
 
+	// Create a testing bump response.
+	resp := &bumpResp{
+		result: br,
+		set:    set,
+	}
+
 	// Call the method under test.
-	err := s.handleBumpEvent(br)
+	err := s.handleBumpEvent(resp)
 	require.ErrorIs(t, err, errDummy)
 
 	// Assert the states of the first two inputs are updated.
 	require.Equal(t, PublishFailed, s.inputs[op1].state)
 	require.Equal(t, PublishFailed, s.inputs[op2].state)
 
-	// Assert the state of the third input is not updated.
-	require.Equal(t, PendingPublish, s.inputs[op3].state)
+	// Assert the state of the third input.
+	//
+	// NOTE: Although the tx doesn't spend it, we still mark this input as
+	// failed as we are treating the input set as the single source of
+	// truth.
+	require.Equal(t, PublishFailed, s.inputs[op3].state)
 
 	// Assert the non-existing input is not added to the pending inputs.
 	require.NotContains(t, s.inputs, opNotExist)
@@ -810,23 +772,21 @@ func TestHandleBumpEventTxReplaced(t *testing.T) {
 	wallet := &MockWallet{}
 	defer wallet.AssertExpectations(t)
 
+	// Create a mock input set.
+	set := &MockInputSet{}
+	defer set.AssertExpectations(t)
+
 	// Create a test sweeper.
 	s := New(&UtxoSweeperConfig{
 		Store:  store,
 		Wallet: wallet,
 	})
 
-	// Create a testing outpoint.
-	op := wire.OutPoint{Hash: chainhash.Hash{1}}
-
 	// Create a mock input.
-	inp := &input.MockInput{}
-	defer inp.AssertExpectations(t)
+	inp := createMockInput(t, s, PendingPublish)
+	set.On("Inputs").Return([]input.Input{inp})
 
-	// Construct the initial state for the sweeper.
-	s.inputs = InputsMap{
-		op: &SweeperInput{Input: inp, state: PendingPublish},
-	}
+	op := inp.OutPoint()
 
 	// Create a testing tx that spends the input.
 	tx := &wire.MsgTx{
@@ -851,12 +811,18 @@ func TestHandleBumpEventTxReplaced(t *testing.T) {
 		Event:      TxReplaced,
 	}
 
+	// Create a testing bump response.
+	resp := &bumpResp{
+		result: br,
+		set:    set,
+	}
+
 	// Mock the store to return an error.
 	dummyErr := errors.New("dummy error")
 	store.On("GetTx", tx.TxHash()).Return(nil, dummyErr).Once()
 
 	// Call the method under test and assert the error is returned.
-	err := s.handleBumpEventTxReplaced(br)
+	err := s.handleBumpEventTxReplaced(resp)
 	require.ErrorIs(t, err, dummyErr)
 
 	// Mock the store to return the old tx record.
@@ -871,7 +837,7 @@ func TestHandleBumpEventTxReplaced(t *testing.T) {
 	store.On("DeleteTx", tx.TxHash()).Return(dummyErr).Once()
 
 	// Call the method under test and assert the error is returned.
-	err = s.handleBumpEventTxReplaced(br)
+	err = s.handleBumpEventTxReplaced(resp)
 	require.ErrorIs(t, err, dummyErr)
 
 	// Mock the store to return the old tx record and delete it without
@@ -891,7 +857,7 @@ func TestHandleBumpEventTxReplaced(t *testing.T) {
 	wallet.On("CancelRebroadcast", tx.TxHash()).Once()
 
 	// Call the method under test.
-	err = s.handleBumpEventTxReplaced(br)
+	err = s.handleBumpEventTxReplaced(resp)
 	require.NoError(t, err)
 
 	// Assert the state of the input is updated.
@@ -907,22 +873,20 @@ func TestHandleBumpEventTxPublished(t *testing.T) {
 	store := &MockSweeperStore{}
 	defer store.AssertExpectations(t)
 
+	// Create a mock input set.
+	set := &MockInputSet{}
+	defer set.AssertExpectations(t)
+
 	// Create a test sweeper.
 	s := New(&UtxoSweeperConfig{
 		Store: store,
 	})
 
-	// Create a testing outpoint.
-	op := wire.OutPoint{Hash: chainhash.Hash{1}}
-
 	// Create a mock input.
-	inp := &input.MockInput{}
-	defer inp.AssertExpectations(t)
+	inp := createMockInput(t, s, PendingPublish)
+	set.On("Inputs").Return([]input.Input{inp})
 
-	// Construct the initial state for the sweeper.
-	s.inputs = InputsMap{
-		op: &SweeperInput{Input: inp, state: PendingPublish},
-	}
+	op := inp.OutPoint()
 
 	// Create a testing tx that spends the input.
 	tx := &wire.MsgTx{
@@ -938,6 +902,12 @@ func TestHandleBumpEventTxPublished(t *testing.T) {
 		Event: TxPublished,
 	}
 
+	// Create a testing bump response.
+	resp := &bumpResp{
+		result: br,
+		set:    set,
+	}
+
 	// Mock the store to save the new tx record.
 	store.On("StoreTx", &TxRecord{
 		Txid:      tx.TxHash(),
@@ -945,7 +915,7 @@ func TestHandleBumpEventTxPublished(t *testing.T) {
 	}).Return(nil).Once()
 
 	// Call the method under test.
-	err := s.handleBumpEventTxPublished(br)
+	err := s.handleBumpEventTxPublished(resp)
 	require.NoError(t, err)
 
 	// Assert the state of the input is updated.
@@ -963,25 +933,21 @@ func TestMonitorFeeBumpResult(t *testing.T) {
 	wallet := &MockWallet{}
 	defer wallet.AssertExpectations(t)
 
+	// Create a mock input set.
+	set := &MockInputSet{}
+	defer set.AssertExpectations(t)
+
 	// Create a test sweeper.
 	s := New(&UtxoSweeperConfig{
 		Store:  store,
 		Wallet: wallet,
 	})
 
-	// Create a testing outpoint.
-	op := wire.OutPoint{Hash: chainhash.Hash{1}}
-
 	// Create a mock input.
-	inp := &input.MockInput{}
-	defer inp.AssertExpectations(t)
-
-	// Construct the initial state for the sweeper.
-	s.inputs = InputsMap{
-		op: &SweeperInput{Input: inp, state: PendingPublish},
-	}
+	inp := createMockInput(t, s, PendingPublish)
 
 	// Create a testing tx that spends the input.
+	op := inp.OutPoint()
 	tx := &wire.MsgTx{
 		LockTime: 1,
 		TxIn: []*wire.TxIn{
@@ -1060,7 +1026,8 @@ func TestMonitorFeeBumpResult(t *testing.T) {
 				return resultChan
 			},
 			shouldExit: false,
-		}, {
+		},
+		{
 			// When the sweeper is shutting down, the monitor loop
 			// should exit.
 			name: "exit on sweeper shutdown",
@@ -1087,7 +1054,7 @@ func TestMonitorFeeBumpResult(t *testing.T) {
 
 			s.wg.Add(1)
 			go func() {
-				s.monitorFeeBumpResult(resultChan)
+				s.monitorFeeBumpResult(set, resultChan)
 				close(done)
 			}()
 

--- a/sweep/tx_input_set.go
+++ b/sweep/tx_input_set.go
@@ -64,6 +64,13 @@ type InputSet interface {
 	// StartingFeeRate returns the max starting fee rate found in the
 	// inputs.
 	StartingFeeRate() fn.Option[chainfee.SatPerKWeight]
+
+	// Immediate returns a boolean to indicate whether the tx made from
+	// this input set should be published immediately.
+	//
+	// TODO(yy): create a new method `Params` to combine the informational
+	// methods DeadlineHeight, Budget, StartingFeeRate and Immediate.
+	Immediate() bool
 }
 
 // createWalletTxInput converts a wallet utxo into an object that can be added
@@ -413,4 +420,19 @@ func (b *BudgetInputSet) StartingFeeRate() fn.Option[chainfee.SatPerKWeight] {
 	}
 
 	return startingFeeRate
+}
+
+// Immediate returns whether the inputs should be swept immediately.
+//
+// NOTE: part of the InputSet interface.
+func (b *BudgetInputSet) Immediate() bool {
+	for _, inp := range b.inputs {
+		// As long as one of the inputs is immediate, the whole set is
+		// immediate.
+		if inp.params.Immediate {
+			return true
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
This PR introduces a minimal version of the new service `Blockbeat` as described in #7952, to handle block syncronization among different subsystems.

During startup, blockbeat consumers are registered in the `BlockbeatDispatcher`, a subservice that's responsible for dispatching new blockbeats to its consumers and waiting for its consumers to finish processing the blocks. If any of the consumers failed to process the block under 30s, or encountered an error during block processing, the system will shut down as it's critical to handle blocks.

This PR focuses on implementing blockbeat `Consumer` interface for `ChainArb`, `UtxoSweeper` and `TxPublisher`, the following PR focuses on finalizing blockbeat processing in `ChainArb`'s subservices - `ChannelArbitrator`, `chainWatcher`, and `ContractResolver`.

### Overview

The flow of the blockbeat process is shown below, whenever a new block is arrived, it goes through the waterfall like this,
1. blockbeat dispatcher receives a new block epoch and makes a `blockbeat`, and sends it to its consumers **sequentially**.
2. `ChainArb` receives the blockbeat, processes it and signals back when done.
3. `UtxoSweeper` receives the blockbeat, processes it and signals back when done.
4. `TxPublisher` receives the blockbeat, processes it and signals back when done.
5. This new block is now considered processed by the blockbeat dispatcher.


```mermaid
sequenceDiagram
		autonumber
		participant bb as BlockBeat
		participant cc as ChainArb
		participant us as UtxoSweeper
		participant tp as TxPublisher
		
		note left of bb: 0. received block x,<br>dispatching...
		
    note over bb,cc: 1. send block x to ChainArb,<br>wait for its done signal
		bb->>cc: block x
		rect rgba(165, 0, 85, 0.8)
      critical signal processed
        cc->>bb: processed block
      option Process error or timeout
        bb->>bb: error and exit
      end
    end

    note over bb,us: 2. send block x to UtxoSweeper, wait for its done signal
		bb->>us: block x
		rect rgba(165, 0, 85, 0.8)
      critical signal processed
        us->>bb: processed block
      option Process error or timeout
        bb->>bb: error and exit
      end
    end

    note over bb,tp: 3. send block x to TxPublisher, wait for its done signal
		bb->>tp: block x
		rect rgba(165, 0, 85, 0.8)
      critical signal processed
        tp->>bb: processed block
      option Process error or timeout
        bb->>bb: error and exit
      end
    end
```

**NOTE:** itests are failing in this PR and is fixed in the final PR.

TODO
- [ ] add unit tests for new code
- [ ] add readme