### PR TITLE
itest: add a PoC for refilling channel balance

### DIFF
--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -630,4 +630,8 @@ var allTestCases = []*lntest.TestCase{
 		Name:     "coop close with external delivery",
 		TestFunc: testCoopCloseWithExternalDelivery,
 	},
+	{
+		Name:     "intercept and refill channel",
+		TestFunc: testInterceptAndRefillChannel,
+	},
 }


### PR DESCRIPTION
Suppose a route `Alice -> Bob -> Carol`. Bob doesn't have enough outgoing liquidity to forward a payment sent from Alice to Carol. This PR adds an itest to show that, with the help of htlc interceptor, Bob can make the payment when his outgoing channel is refilled. The test setup,
1. Channel setup: Alice -> Bob -> Carol.
2. Bob sends payment to Carol, so his outgoing liquidity is drained.
3. Alice sends a payment to Carol via Bob, with Bob intercepting the HTLC and putting the payment on hold.
4. Carol sends payment to Bob, which refills Bob's outgoing liquidity.
5. Bob releases the HTLC.
6. Alice's payment is now succeeded.

