### PR TITLE
Global idle timeout

### DIFF
--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -207,6 +207,9 @@ when running LND with an aux component injected (custom channels).
   the payment. This prevents payments from entering a path finding loop that
   would eventually timeout.
 
+* [Only send a `Ping`](https://github.com/lightningnetwork/lnd/pull/9805) if we
+  haven't received any messages from the peer for one minute.
+
 ## RPC Additions
 
 * [Add a new rpc endpoint](https://github.com/lightningnetwork/lnd/pull/8843)

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -2061,6 +2061,12 @@ out:
 			}
 		}
 
+		// Reset the ticker to delay sending the Ping. As long as we are
+		// receiving a message here, we know for sure the connection is
+		// alive, thus we can delay firing pings to check for the
+		// liveness.
+		p.pingManager.ResetPingTicker()
+
 		// If a message router is active, then we'll try to have it
 		// handle this message. If it can, then we're able to skip the
 		// rest of the message handling logic.

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -2681,6 +2681,18 @@ out:
 			}
 			idleTimer.Reset(idleTimeout)
 
+			// Reset the ticker to delay sending the Ping. Since
+			// we've successfully wriiten a msg to the connection,
+			// we know for sure the connection is alive, thus we can
+			// delay firing pings to check for the liveness.
+			//
+			// NOTE: This means if the connection is idle, the
+			// interval of pings is not strictly one minute as we
+			// will reset it here after a successful write. This
+			// offset should be negligible if the connection is
+			// healthy.
+			p.pingManager.ResetPingTicker()
+
 			// If the peer requested a synchronous write, respond
 			// with the error.
 			if outMsg.errChan != nil {

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -629,6 +629,11 @@ type Brontide struct {
 
 	// log is a peer-specific logging instance.
 	log btclog.Logger
+
+	// idleTimer is used to disconnect a stale connection. When there are no
+	// read/write after idleTimeout, the connection is considered stale and
+	// will be removed.
+	idleTimer *time.Timer
 }
 
 // A compile-time check to ensure that Brontide satisfies the lnpeer.Peer
@@ -889,6 +894,13 @@ func (p *Brontide) Start() error {
 	if err != nil {
 		return fmt.Errorf("could not start ping manager %w", err)
 	}
+
+	// Initialize a new idle timer to watch for read and write.
+	p.idleTimer = time.AfterFunc(idleTimeout, func() {
+		err := fmt.Errorf("peer %s no activity for %s -- disconnecting",
+			p, idleTimeout)
+		p.Disconnect(err)
+	})
 
 	p.cg.WgAdd(4)
 	go p.queueHandler()
@@ -1990,14 +2002,6 @@ func newDiscMsgStream(p *Brontide) *msgStream {
 func (p *Brontide) readHandler() {
 	defer p.cg.WgDone()
 
-	// We'll stop the timer after a new messages is received, and also
-	// reset it after we process the next message.
-	idleTimer := time.AfterFunc(idleTimeout, func() {
-		err := fmt.Errorf("peer %s no answer for %s -- disconnecting",
-			p, idleTimeout)
-		p.Disconnect(err)
-	})
-
 	// Initialize our negotiated gossip sync method before reading messages
 	// off the wire. When using gossip queries, this ensures a gossip
 	// syncer is active by the time query messages arrive.
@@ -2012,9 +2016,9 @@ func (p *Brontide) readHandler() {
 out:
 	for atomic.LoadInt32(&p.disconnect) == 0 {
 		nextMsg, err := p.readNextMessage()
-		if !idleTimer.Stop() {
+		if !p.idleTimer.Stop() {
 			select {
-			case <-idleTimer.C:
+			case <-p.idleTimer.C:
 			default:
 			}
 		}
@@ -2032,7 +2036,7 @@ out:
 			// compatible manner.
 			case *lnwire.UnknownMessage:
 				p.storeError(e)
-				idleTimer.Reset(idleTimeout)
+				p.idleTimer.Reset(idleTimeout)
 				continue
 
 			// If they sent us an address type that we don't yet
@@ -2041,7 +2045,7 @@ out:
 			// messages.
 			case *lnwire.ErrUnknownAddrType:
 				p.storeError(e)
-				idleTimer.Reset(idleTimeout)
+				p.idleTimer.Reset(idleTimeout)
 				continue
 
 			// If the NodeAnnouncement has an invalid alias, then
@@ -2050,7 +2054,7 @@ out:
 			// store this error because it is of little debugging
 			// value.
 			case *lnwire.ErrInvalidNodeAlias:
-				idleTimer.Reset(idleTimeout)
+				p.idleTimer.Reset(idleTimeout)
 				continue
 
 			// If the error we encountered wasn't just a message we
@@ -2204,7 +2208,7 @@ out:
 			p.sendLinkUpdateMsg(targetChan, nextMsg)
 		}
 
-		idleTimer.Reset(idleTimeout)
+		p.idleTimer.Reset(idleTimeout)
 	}
 
 	p.Disconnect(errors.New("read handler closed"))
@@ -2629,14 +2633,6 @@ func (p *Brontide) writeMessage(msg lnwire.Message) error {
 //
 // NOTE: This method MUST be run as a goroutine.
 func (p *Brontide) writeHandler() {
-	// We'll stop the timer after a new messages is sent, and also reset it
-	// after we process the next message.
-	idleTimer := time.AfterFunc(idleTimeout, func() {
-		err := fmt.Errorf("peer %s no write for %s -- disconnecting",
-			p, idleTimeout)
-		p.Disconnect(err)
-	})
-
 	var exitErr error
 
 out:
@@ -2673,13 +2669,13 @@ out:
 
 			// The write succeeded, reset the idle timer to prevent
 			// us from disconnecting the peer.
-			if !idleTimer.Stop() {
+			if !p.idleTimer.Stop() {
 				select {
-				case <-idleTimer.C:
+				case <-p.idleTimer.C:
 				default:
 				}
 			}
-			idleTimer.Reset(idleTimeout)
+			p.idleTimer.Reset(idleTimeout)
 
 			// Reset the ticker to delay sending the Ping. Since
 			// we've successfully wriiten a msg to the connection,

--- a/peer/ping_manager.go
+++ b/peer/ping_manager.go
@@ -108,6 +108,11 @@ func (m *PingManager) Start() error {
 	return err
 }
 
+// ResetPingTicker resets the internal `pingTicker`.
+func (m *PingManager) ResetPingTicker() {
+	m.pingTicker.Reset(m.cfg.IntervalDuration)
+}
+
 // pingHandler is the main goroutine responsible for enforcing the ping/pong
 // protocol.
 func (m *PingManager) pingHandler() {


### PR DESCRIPTION
Both read and write share the same idle timer, since we only care about whether the connection is idle or not but not the read or write process.