### PR TITLE
Demo replay resulted in sending fail malformed

### DIFF
--- a/htlcswitch/hop/iterator.go
+++ b/htlcswitch/hop/iterator.go
@@ -784,6 +784,8 @@ func (p *OnionProcessor) DecodeHopIterators(id []byte,
 				b.Val,
 			))
 		})
+
+		// TODO(yy): use `p.router.ProcessOnionPacket` instead.
 		err = tx.ProcessOnionPacket(
 			seqNum, onionPkt, req.RHash, req.IncomingCltv, opts...,
 		)

--- a/htlcswitch/hop/iterator.go
+++ b/htlcswitch/hop/iterator.go
@@ -745,7 +745,8 @@ func (r *DecodeHopIteratorResponse) Result() (Iterator, lnwire.FailCode) {
 // the presented readers and rhashes *NEVER* deviate across invocations for the
 // same id.
 func (p *OnionProcessor) DecodeHopIterators(id []byte,
-	reqs []DecodeHopIteratorRequest) ([]DecodeHopIteratorResponse, error) {
+	reqs []DecodeHopIteratorRequest,
+	reforward bool) ([]DecodeHopIteratorResponse, error) {
 
 	var (
 		batchSize = len(reqs)
@@ -864,11 +865,12 @@ func (p *OnionProcessor) DecodeHopIterators(id []byte,
 			continue
 		}
 
-		// If this index is contained in the replay set, mark it with a
-		// temporary channel failure error code. We infer that the
-		// offending error was due to a replayed packet because this
-		// index was found in the replay set.
-		if replays.Contains(uint16(i)) {
+		// If this index is contained in the replay set, and it is not a
+		// reforwarding on startup, mark it with a temporary channel
+		// failure error code. We infer that the offending error was due
+		// to a replayed packet because this index was found in the
+		// replay set.
+		if !reforward && replays.Contains(uint16(i)) {
 			log.Errorf("unable to process onion packet: %v",
 				sphinx.ErrReplayedPacket)
 

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -2196,6 +2196,9 @@ func (l *channelLink) handleUpstreamMsg(ctx context.Context,
 		go l.forwardBatch(false, settlePacket)
 
 	case *lnwire.UpdateFailMalformedHTLC:
+		l.log.Debugf("-----> received %v, holding the revoke for 10s", msg.MsgType())
+		time.Sleep(10 * time.Second)
+
 		// Convert the failure type encoded within the HTLC fail
 		// message to the proper generic lnwire error code.
 		var failure lnwire.FailureMessage
@@ -3791,6 +3794,7 @@ func (l *channelLink) processRemoteAdds(fwdPkg *channeldb.FwdPkg) {
 	// If the fwdPkg has already been processed, it means we are
 	// reforwarding the packets again, which happens only on a restart.
 	reforward := fwdPkg.State == channeldb.FwdStateProcessed
+	reforward = false
 
 	// Atomically decode the incoming htlcs, simultaneously checking for
 	// replay attempts. A particular index in the returned, spare list of

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -108,8 +108,10 @@ type ChannelLinkConfig struct {
 	// blobs, which are then used to inform how to forward an HTLC.
 	//
 	// NOTE: This function assumes the same set of readers and preimages
-	// are always presented for the same identifier.
-	DecodeHopIterators func([]byte, []hop.DecodeHopIteratorRequest) (
+	// are always presented for the same identifier. The last boolean is
+	// used to decide whether this is a reforwarding or not - when it's
+	// reforwarding, we skip the replay check enforced in our decaly log.
+	DecodeHopIterators func([]byte, []hop.DecodeHopIteratorRequest, bool) (
 		[]hop.DecodeHopIteratorResponse, error)
 
 	// ExtractErrorEncrypter function is responsible for decoding HTLC
@@ -3764,12 +3766,14 @@ func (l *channelLink) processRemoteAdds(fwdPkg *channeldb.FwdPkg) {
 		}
 	}
 
+	reforward := fwdPkg.State != channeldb.FwdStateLockedIn
+
 	// Atomically decode the incoming htlcs, simultaneously checking for
 	// replay attempts. A particular index in the returned, spare list of
 	// channel iterators should only be used if the failure code at the
 	// same index is lnwire.FailCodeNone.
 	decodeResps, sphinxErr := l.cfg.DecodeHopIterators(
-		fwdPkg.ID(), decodeReqs,
+		fwdPkg.ID(), decodeReqs, reforward,
 	)
 	if sphinxErr != nil {
 		l.failf(LinkFailureError{code: ErrInternalError},
@@ -4120,17 +4124,15 @@ func (l *channelLink) processRemoteAdds(fwdPkg *channeldb.FwdPkg) {
 		return
 	}
 
-	replay := fwdPkg.State != channeldb.FwdStateLockedIn
-
-	l.log.Debugf("forwarding %d packets to switch: replay=%v",
-		len(switchPackets), replay)
+	l.log.Debugf("forwarding %d packets to switch: reforward=%v",
+		len(switchPackets), reforward)
 
 	// NOTE: This call is made synchronous so that we ensure all circuits
 	// are committed in the exact order that they are processed in the link.
 	// Failing to do this could cause reorderings/gaps in the range of
 	// opened circuits, which violates assumptions made by the circuit
 	// trimming.
-	l.forwardBatch(replay, switchPackets...)
+	l.forwardBatch(reforward, switchPackets...)
 }
 
 // experimentalEndorsement returns the value to set for our outgoing

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -3740,6 +3740,11 @@ func (l *channelLink) processRemoteAdds(fwdPkg *channeldb.FwdPkg) {
 		return
 	}
 
+	// Exit early if the fwdPkg is already processed.
+	if fwdPkg.State == channeldb.FwdStateCompleted {
+		l.log.Debugf("skipped processing completed fwdPkg %v", fwdPkg)
+	}
+
 	l.log.Tracef("processing %d remote adds for height %d",
 		len(fwdPkg.Adds), fwdPkg.Height)
 
@@ -3766,7 +3771,9 @@ func (l *channelLink) processRemoteAdds(fwdPkg *channeldb.FwdPkg) {
 		}
 	}
 
-	reforward := fwdPkg.State != channeldb.FwdStateLockedIn
+	// If the fwdPkg has already been processed, it means we are
+	// reforwarding the packets again, which happens only on a restart.
+	reforward := fwdPkg.State == channeldb.FwdStateProcessed
 
 	// Atomically decode the incoming htlcs, simultaneously checking for
 	// replay attempts. A particular index in the returned, spare list of

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -3748,10 +3748,26 @@ func (l *channelLink) processRemoteAdds(fwdPkg *channeldb.FwdPkg) {
 	l.log.Tracef("processing %d remote adds for height %d",
 		len(fwdPkg.Adds), fwdPkg.Height)
 
-	decodeReqs := make(
-		[]hop.DecodeHopIteratorRequest, 0, len(fwdPkg.Adds),
-	)
-	for _, update := range fwdPkg.Adds {
+	// decodeReqs is a list of requests sent to the onion decoder. We expect
+	// the same length of responses to be returned.
+	decodeReqs := make([]hop.DecodeHopIteratorRequest, 0, len(fwdPkg.Adds))
+
+	// unackedAdds is a list of ADDs that's waiting for the remote's
+	// settle/fail update.
+	unackedAdds := make([]*lnwire.UpdateAddHTLC, 0, len(fwdPkg.Adds))
+
+	for i, update := range fwdPkg.Adds {
+		// If this index is already found in the ack filter, the
+		// response to this forwarding decision has already been
+		// committed by one of our commitment txns. ADDs in this state
+		// are waiting for the rest of the fwding package to get acked
+		// before being garbage collected.
+		if fwdPkg.State == channeldb.FwdStateProcessed &&
+			fwdPkg.AckFilter.Contains(uint16(i)) {
+
+			continue
+		}
+
 		if msg, ok := update.UpdateMsg.(*lnwire.UpdateAddHTLC); ok {
 			// Before adding the new htlc to the state machine,
 			// parse the onion object in order to obtain the
@@ -3768,6 +3784,7 @@ func (l *channelLink) processRemoteAdds(fwdPkg *channeldb.FwdPkg) {
 			}
 
 			decodeReqs = append(decodeReqs, req)
+			unackedAdds = append(unackedAdds, msg)
 		}
 	}
 
@@ -3790,23 +3807,10 @@ func (l *channelLink) processRemoteAdds(fwdPkg *channeldb.FwdPkg) {
 
 	var switchPackets []*htlcPacket
 
-	for i, update := range fwdPkg.Adds {
+	for i, update := range unackedAdds {
 		idx := uint16(i)
-
-		//nolint:forcetypeassert
-		add := *update.UpdateMsg.(*lnwire.UpdateAddHTLC)
 		sourceRef := fwdPkg.SourceRef(idx)
-
-		if fwdPkg.State == channeldb.FwdStateProcessed &&
-			fwdPkg.AckFilter.Contains(idx) {
-
-			// If this index is already found in the ack filter,
-			// the response to this forwarding decision has already
-			// been committed by one of our commitment txns. ADDs
-			// in this state are waiting for the rest of the fwding
-			// package to get acked before being garbage collected.
-			continue
-		}
+		add := *update
 
 		// An incoming HTLC add has been full-locked in. As a result we
 		// can now examine the forwarding details of the HTLC, and the
@@ -3826,8 +3830,10 @@ func (l *channelLink) processRemoteAdds(fwdPkg *channeldb.FwdPkg) {
 				add.ID, failureCode, add.OnionBlob, &sourceRef,
 			)
 
-			l.log.Errorf("unable to decode onion hop "+
-				"iterator: %v", failureCode)
+			l.log.Errorf("unable to decode onion hop iterator "+
+				"for htlc(id=%v, hash=%x): %v", add.ID,
+				add.PaymentHash, failureCode)
+
 			continue
 		}
 

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -522,7 +522,7 @@ func (p *mockIteratorDecoder) DecodeHopIterator(r io.Reader, rHash []byte,
 }
 
 func (p *mockIteratorDecoder) DecodeHopIterators(id []byte,
-	reqs []hop.DecodeHopIteratorRequest) (
+	reqs []hop.DecodeHopIteratorRequest, _ bool) (
 	[]hop.DecodeHopIteratorResponse, error) {
 
 	idHash := sha256.Sum256(id)

--- a/itest/lnd_switch_test.go
+++ b/itest/lnd_switch_test.go
@@ -32,8 +32,8 @@ func testSwitchCircuitPersistence(ht *lntest.HarnessTest) {
 
 	// Restart the intermediaries and the sender.
 	ht.RestartNode(s.dave)
-	ht.RestartNode(s.alice)
-	ht.RestartNode(s.bob)
+	// ht.RestartNode(s.alice)
+	// ht.RestartNode(s.bob)
 
 	// Ensure all of the intermediate links are reconnected.
 	ht.EnsureConnected(s.alice, s.dave)
@@ -45,6 +45,10 @@ func testSwitchCircuitPersistence(ht *lntest.HarnessTest) {
 	// Now restart carol without hodl mode, to settle back the outstanding
 	// payments.
 	s.carol.SetExtraArgs(nil)
+	ht.RestartNode(s.carol)
+
+	ht.EnsureConnected(s.dave, s.carol)
+
 	ht.RestartNode(s.carol)
 
 	ht.EnsureConnected(s.dave, s.carol)
@@ -358,7 +362,7 @@ type scenarioFourNodes struct {
 // topology. Dave will make a channel with Alice, and Carol with Dave. After
 // this setup, the network topology should now look like:
 //
-//	Carol -> Dave -> Alice -> Bob
+//	Carol <-> Dave <-> Alice <-> Bob
 //
 // Once the network is created, Carol will generate 5 invoices and Bob will pay
 // them using the above path.
@@ -385,7 +389,7 @@ func setupScenarioFourNodes(ht *lntest.HarnessTest) *scenarioFourNodes {
 	// such that we now have a 4 node, 3 channel topology. Dave will make
 	// a channel with Alice, and Carol with Dave. After this setup, the
 	// network topology should now look like:
-	//     Carol -> Dave -> Alice -> Bob
+	//     Carol <-> Dave <-> Alice <-> Bob
 	//
 	// First, we'll create Dave and establish a channel to Alice.
 	dave := ht.NewNode("Dave", nil)

--- a/lntest/node/harness_node.go
+++ b/lntest/node/harness_node.go
@@ -675,14 +675,14 @@ func (hn *HarnessNode) WaitForProcessExit() error {
 	// to verify that the node shut down correctly.
 	if hn.logFile != nil {
 		// Make sure log file is closed and renamed if necessary.
-		filename := finalizeLogfile(hn)
+		finalizeLogfile(hn)
 
 		// Assert the node has shut down from the log file.
-		err1 := assertNodeShutdown(filename)
-		if err1 != nil {
-			return fmt.Errorf("[%s]: assert shutdown failed in "+
-				"log[%s]: %w", hn.Name(), filename, err1)
-		}
+		// err1 := assertNodeShutdown(filename)
+		// if err1 != nil {
+		// 	return fmt.Errorf("[%s]: assert shutdown failed in "+
+		// 		"log[%s]: %w", hn.Name(), filename, err1)
+		// }
 	}
 
 	// Rename the etcd.log file if the node was running on embedded etcd.


### PR DESCRIPTION
Run `make itest icase=switch_circuit_persistence`, and observe the failure and the logs.


### Setup
- Carol created an invoice, Bob tried to pay Carol via link Bob->Alice->Dave->Carol.
- Dave replayed HTLCs for the first time, caught by Carol.
- Carol went through a restart.
- Carol didn't replay the HTLCs, instead, `UpdateFailMalformedHTLC` msgs were sent again.

Carol's log, replays detected, then ``UpdateFailMalformedHTLC` msgs were sent,
```
2025-06-12 06:12:33.481 [ERR] HSWC link.go:3837: ChannelLink([ChanPoint: Carol=>Dave]): unable to decode onion hop iterator for htlc(id=0, hash=9c60e7291a8244cd7e0e3c73a34e5e6c29ea4b631c978df08ae1c08aef29ba7e): InvalidOnionVersion
...
2025-06-12 06:12:33.482 [ERR] HSWC link.go:3837: ChannelLink([ChanPoint: Carol=>Dave]): unable to decode onion hop iterator for htlc(id=4, hash=69391270a4c4c0cc066336c6a52eb49c07b44b3937a07c8c1c9af96db3155d43): InvalidOnionVersion

2025-06-12 06:12:33.482 [DBG] PEER brontide.go:2554: Peer([Dave]): Sending UpdateFailMalformedHTLC(chan_id=06e170947fa5967d07a4bae24b082395de424d50a6833d63dc1d3105930cd1ec, id=0, fail_code=InvalidOnionVersion) to [Dave]@127.0.0.1:14865
...
2025-06-12 06:12:33.485 [DBG] PEER brontide.go:2554: Peer([Dave]): Sending UpdateFailMalformedHTLC(chan_id=06e170947fa5967d07a4bae24b082395de424d50a6833d63dc1d3105930cd1ec, id=4, fail_code=InvalidOnionVersion) to [Dave]@127.0.0.1:14865
```

Dave received the `UpdateFailMalformedHTLC`, but deliberately held them,
```
2025-06-12 06:12:33.485 [DBG] PEER brontide.go:2554: Peer([Carol]): Received UpdateFailMalformedHTLC(chan_id=06e170947fa5967d07a4bae24b082395de424d50a6833d63dc1d3105930cd1ec, id=0, fail_code=InvalidOnionVersion) from [Carol]@127.0.0.1:65378
2025-06-12 06:12:33.485 [DBG] HSWC link.go:2199: ChannelLink([ChanPoint: Carol=>Dave]): -----> received UpdateFailMalformedHTLC, holding the revoke for 10s
...
```

Dave caused Carol to restart her node, Carol went through the reestablishment,
```
2025-06-12 06:12:55.854 [INF] HSWC link.go:985: ChannelLink([ChanPoint: Carol=>Dave]): received re-establishment message from remote side
```

Carol detected she was missing a commitment,
```
2025-06-12 06:12:55.854 [DBG] LNWL channel.go:4475: ChannelPoint([ChanPoint: Carol=>Dave]): sync: remote's next commit height is 2, while we believe it is 3, we owe them a commitment
```

No reforwarding happened, instead, the fail msgs were sent again,
```
2025-06-12 06:12:55.890 [DBG] HSWC link.go:1045: ChannelLink([ChanPoint: Carol=>Dave]): loaded 0 fwd pks
...
2025-06-12 06:12:55.890 [DBG] PEER brontide.go:2554: Peer([Dave]): Sending UpdateFailMalformedHTLC(chan_id=06e170947fa5967d07a4bae24b082395de424d50a6833d63dc1d3105930cd1ec, id=0, fail_code=InvalidOnionVersion) to [Dave]@127.0.0.1:65418
...
```