### PR TITLE
contractcourt: persist resolver supplements for restart recovery

### DIFF
--- a/contractcourt/anchor_resolver.go
+++ b/contractcourt/anchor_resolver.go
@@ -32,9 +32,6 @@ type anchorResolver struct {
 	// chanPoint is the channel point of the original contract.
 	chanPoint wire.OutPoint
 
-	// chanType denotes the type of channel the contract belongs to.
-	chanType channeldb.ChannelType
-
 	// currentReport stores the current state of the resolver for reporting
 	// over the rpc interface.
 	currentReport ContractReport
@@ -155,12 +152,10 @@ func (c *anchorResolver) Stop() {
 	close(c.quit)
 }
 
-// SupplementState allows the user of a ContractResolver to supplement it with
-// state required for the proper resolution of a contract.
-//
-// NOTE: Part of the ContractResolver interface.
-func (c *anchorResolver) SupplementState(state *channeldb.OpenChannel) {
-	c.chanType = state.ChanType
+// ApplySupplement restores channel-scoped state required to resolve the
+// anchor.
+func (c *anchorResolver) ApplySupplement(supplement *ResolverSupplement) {
+	c.contractResolverKit.ApplySupplement(supplement)
 }
 
 // report returns a report on the resolution state of the contract.

--- a/contractcourt/breach_resolver.go
+++ b/contractcourt/breach_resolver.go
@@ -4,8 +4,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-
-	"github.com/lightningnetwork/lnd/channeldb"
 )
 
 // breachResolver is a resolver that will handle breached closes. In the
@@ -87,8 +85,9 @@ func (b *breachResolver) Stop() {
 	close(b.quit)
 }
 
-// SupplementState adds additional state to the breachResolver.
-func (b *breachResolver) SupplementState(_ *channeldb.OpenChannel) {
+// ApplySupplement adds additional shared state to the breachResolver.
+func (b *breachResolver) ApplySupplement(supplement *ResolverSupplement) {
+	b.contractResolverKit.ApplySupplement(supplement)
 }
 
 // Encode encodes the breachResolver to the passed writer.

--- a/contractcourt/briefcase.go
+++ b/contractcourt/briefcase.go
@@ -100,6 +100,12 @@ type ArbitratorLog interface {
 	// contract resolutions from persistent storage.
 	FetchContractResolutions() (*ContractResolutions, error)
 
+	// PersistResolverSupplement stores channel-scoped resolver restart data.
+	PersistResolverSupplement(*ResolverSupplement) error
+
+	// FetchResolverSupplement retrieves channel-scoped resolver restart data.
+	FetchResolverSupplement() (*ResolverSupplement, error)
+
 	// InsertConfirmedCommitSet stores the known set of active HTLCs at the
 	// time channel closure. We'll use this to reconstruct our set of chain
 	// actions anew based on the confirmed and pending commitment state.
@@ -377,6 +383,9 @@ var (
 	// taprootDataKey is the key we'll use to store taproot specific data
 	// for the set of channels we'll need to sweep/claim.
 	taprootDataKey = []byte("taproot-data")
+
+	// resolverSupplementKey stores channel-scoped resolver restart data.
+	resolverSupplementKey = []byte("resolver-supplement")
 )
 
 var (
@@ -400,6 +409,10 @@ var (
 	// This can happen if the channel hasn't closed yet, or a client is
 	// running an older version that didn't yet write this state.
 	errNoCommitSet = fmt.Errorf("no commit set exists")
+
+	// errNoResolverSupplement is returned when no resolver supplement has
+	// been stored for the arbitrator.
+	errNoResolverSupplement = fmt.Errorf("no resolver supplement exists")
 )
 
 // boltArbitratorLog is an implementation of the ArbitratorLog interface backed
@@ -1012,6 +1025,56 @@ func (b *boltArbitratorLog) FetchContractResolutions() (*ContractResolutions, er
 	return c, err
 }
 
+// PersistResolverSupplement stores channel-scoped resolver restart state.
+func (b *boltArbitratorLog) PersistResolverSupplement(
+	supplement *ResolverSupplement) error {
+
+	return kvdb.Batch(b.db, func(tx kvdb.RwTx) error {
+		scopeBucket, err := tx.CreateTopLevelBucket(b.scopeKey[:])
+		if err != nil {
+			return err
+		}
+
+		var buf bytes.Buffer
+		if err := encodeResolverSupplement(&buf, supplement); err != nil {
+			return err
+		}
+
+		return scopeBucket.Put(resolverSupplementKey, buf.Bytes())
+	})
+}
+
+// FetchResolverSupplement retrieves channel-scoped resolver restart state.
+func (b *boltArbitratorLog) FetchResolverSupplement() (*ResolverSupplement,
+	error) {
+
+	var supplement *ResolverSupplement
+	err := kvdb.View(b.db, func(tx kvdb.RTx) error {
+		scopeBucket := tx.ReadBucket(b.scopeKey[:])
+		if scopeBucket == nil {
+			return errScopeBucketNoExist
+		}
+
+		supplementBytes := scopeBucket.Get(resolverSupplementKey)
+		if supplementBytes == nil {
+			return errNoResolverSupplement
+		}
+
+		var err error
+		supplement, err = decodeResolverSupplement(
+			bytes.NewReader(supplementBytes),
+		)
+		return err
+	}, func() {
+		supplement = nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return supplement, nil
+}
+
 // FetchChainActions attempts to fetch the set of previously stored chain
 // actions. We'll use this upon restart to properly advance our state machine
 // forward.
@@ -1152,6 +1215,11 @@ func (b *boltArbitratorLog) WipeHistory() error {
 		}
 
 		err = scopeBucket.Delete(resolutionsSignDetailsKey)
+		if err != nil {
+			return err
+		}
+
+		err = scopeBucket.Delete(resolverSupplementKey)
 		if err != nil {
 			return err
 		}

--- a/contractcourt/briefcase_test.go
+++ b/contractcourt/briefcase_test.go
@@ -649,6 +649,39 @@ func TestContractResolutionsStorage(t *testing.T) {
 	}
 }
 
+// TestResolverSupplementStorage tests that resolver supplements are persisted
+// independently from contract resolutions.
+func TestResolverSupplementStorage(t *testing.T) {
+	t.Parallel()
+
+	testLog, err := newTestBoltArbLog(
+		t, testChainHash, testChanPoint1,
+	)
+	require.NoError(t, err, "unable to create test log")
+
+	_, err = testLog.FetchResolverSupplement()
+	require.ErrorIs(t, err, errScopeBucketNoExist)
+
+	supplement := &ResolverSupplement{
+		ChanType:           channeldb.AnchorOutputsBit,
+		ChannelInitiator:   true,
+		LeaseExpiry:        123,
+		LocalDelayPubKey:   [33]byte{1, 2, 3},
+		LocalPaymentPubKey: [33]byte{4, 5, 6},
+	}
+
+	require.NoError(t, testLog.PersistResolverSupplement(supplement))
+
+	diskSupplement, err := testLog.FetchResolverSupplement()
+	require.NoError(t, err)
+	require.Equal(t, supplement, diskSupplement)
+
+	require.NoError(t, testLog.WipeHistory())
+
+	_, err = testLog.FetchResolverSupplement()
+	require.ErrorIs(t, err, errScopeBucketNoExist)
+}
+
 // TestStateMutation tests that we're able to properly mutate the state of the
 // log, then retrieve that same mutated state from disk.
 func TestStateMutation(t *testing.T) {

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -664,6 +664,27 @@ func maybeAugmentTaprootResolvers(chanType channeldb.ChannelType,
 	}
 }
 
+// fetchHistoricalState attempts to load the channel's historical state. If the
+// state isn't available, then nil is returned.
+func (c *ChannelArbitrator) fetchHistoricalState() (*channeldb.OpenChannel,
+	error) {
+
+	chanState, err := c.cfg.FetchHistoricalChannel()
+	switch {
+	case err == channeldb.ErrNoHistoricalBucket:
+		fallthrough
+	case err == channeldb.ErrChannelNotFound:
+		log.Warnf("ChannelArbitrator(%v): unable to fetch historical "+
+			"state", c.cfg.ChanPoint)
+		return nil, nil
+
+	case err != nil:
+		return nil, err
+	}
+
+	return chanState, nil
+}
+
 // relauchResolvers relaunches the set of resolvers for unresolved contracts in
 // order to provide them with information that's not immediately available upon
 // starting the ChannelArbitrator. This information should ideally be stored in
@@ -732,23 +753,14 @@ func (c *ChannelArbitrator) relaunchResolvers(commitSet *CommitSet,
 		htlcMap[outpoint] = &htlc
 	}
 
-	// We'll also fetch the historical state of this channel, as it should
-	// have been marked as closed by now, and supplement it to each resolver
-	// such that we can properly resolve our pending contracts.
-	var chanState *channeldb.OpenChannel
-	chanState, err = c.cfg.FetchHistoricalChannel()
-	switch {
-	// If we don't find this channel, then it may be the case that it
-	// was closed before we started to retain the final state
-	// information for open channels.
-	case err == channeldb.ErrNoHistoricalBucket:
-		fallthrough
-	case err == channeldb.ErrChannelNotFound:
-		log.Warnf("ChannelArbitrator(%v): unable to fetch historical "+
-			"state", c.cfg.ChanPoint)
-
-	case err != nil:
+	chanState, err := c.fetchHistoricalState()
+	if err != nil {
 		return err
+	}
+
+	var supplement *ResolverSupplement
+	if chanState != nil {
+		supplement = deriveResolverSupplement(chanState)
 	}
 
 	log.Infof("ChannelArbitrator(%v): relaunching %v contract "+
@@ -757,14 +769,13 @@ func (c *ChannelArbitrator) relaunchResolvers(commitSet *CommitSet,
 	for i := range unresolvedContracts {
 		resolver := unresolvedContracts[i]
 
-		if chanState != nil {
-			resolver.SupplementState(chanState)
+		if supplement != nil {
+			resolver.ApplySupplement(supplement)
 
-			// For taproot channels, we'll need to also make sure
-			// the control block information was set properly.
+			// For taproot channels, we'll need to also make sure the
+			// control block information was set properly.
 			maybeAugmentTaprootResolvers(
-				chanState.ChanType, resolver,
-				contractResolutions,
+				supplement.ChanType, resolver, contractResolutions,
 			)
 		}
 
@@ -805,7 +816,9 @@ func (c *ChannelArbitrator) relaunchResolvers(commitSet *CommitSet,
 			},
 		)
 
-		anchorResolver.SupplementState(chanState)
+		if supplement != nil {
+			anchorResolver.ApplySupplement(supplement)
+		}
 
 		unresolvedContracts = append(unresolvedContracts, anchorResolver)
 
@@ -2361,23 +2374,13 @@ func (c *ChannelArbitrator) prepContractResolutions(
 	contractResolutions *ContractResolutions, height uint32,
 	htlcActions ChainActionMap) ([]ContractResolver, error) {
 
-	// We'll also fetch the historical state of this channel, as it should
-	// have been marked as closed by now, and supplement it to each resolver
-	// such that we can properly resolve our pending contracts.
-	var chanState *channeldb.OpenChannel
-	chanState, err := c.cfg.FetchHistoricalChannel()
-	switch {
-	// If we don't find this channel, then it may be the case that it
-	// was closed before we started to retain the final state
-	// information for open channels.
-	case err == channeldb.ErrNoHistoricalBucket:
-		fallthrough
-	case err == channeldb.ErrChannelNotFound:
-		log.Warnf("ChannelArbitrator(%v): unable to fetch historical "+
-			"state", c.cfg.ChanPoint)
-
-	case err != nil:
+	chanState, err := c.fetchHistoricalState()
+	if err != nil {
 		return nil, err
+	}
+	var supplement *ResolverSupplement
+	if chanState != nil {
+		supplement = deriveResolverSupplement(chanState)
 	}
 
 	incomingResolutions := contractResolutions.HtlcResolutions.IncomingHTLCs
@@ -2419,7 +2422,9 @@ func (c *ChannelArbitrator) prepContractResolutions(
 			contractResolutions.AnchorResolution.CommitAnchor,
 			height, c.cfg.ChanPoint, resolverCfg,
 		)
-		anchorResolver.SupplementState(chanState)
+		if supplement != nil {
+			anchorResolver.ApplySupplement(supplement)
+		}
 
 		htlcResolvers = append(htlcResolvers, anchorResolver)
 	}
@@ -2429,6 +2434,9 @@ func (c *ChannelArbitrator) prepContractResolutions(
 	// steps taken for non-breach-closes do not matter for breach-closes.
 	if contractResolutions.BreachResolution != nil {
 		breachResolver := newBreachResolver(resolverCfg)
+		if supplement != nil {
+			breachResolver.ApplySupplement(supplement)
+		}
 		htlcResolvers = append(htlcResolvers, breachResolver)
 
 		return htlcResolvers, nil
@@ -2462,8 +2470,8 @@ func (c *ChannelArbitrator) prepContractResolutions(
 				resolver := newSuccessResolver(
 					resolution, height, htlc, resolverCfg,
 				)
-				if chanState != nil {
-					resolver.SupplementState(chanState)
+				if supplement != nil {
+					resolver.ApplySupplement(supplement)
 				}
 				htlcResolvers = append(htlcResolvers, resolver)
 			}
@@ -2490,8 +2498,8 @@ func (c *ChannelArbitrator) prepContractResolutions(
 				resolver := newTimeoutResolver(
 					resolution, height, htlc, resolverCfg,
 				)
-				if chanState != nil {
-					resolver.SupplementState(chanState)
+				if supplement != nil {
+					resolver.ApplySupplement(supplement)
 				}
 
 				// For outgoing HTLCs, we will also need to
@@ -2531,8 +2539,8 @@ func (c *ChannelArbitrator) prepContractResolutions(
 					resolution, height, htlc,
 					resolverCfg,
 				)
-				if chanState != nil {
-					resolver.SupplementState(chanState)
+				if supplement != nil {
+					resolver.ApplySupplement(supplement)
 				}
 				htlcResolvers = append(htlcResolvers, resolver)
 			}
@@ -2562,8 +2570,8 @@ func (c *ChannelArbitrator) prepContractResolutions(
 				resolver := newOutgoingContestResolver(
 					resolution, height, htlc, resolverCfg,
 				)
-				if chanState != nil {
-					resolver.SupplementState(chanState)
+				if supplement != nil {
+					resolver.ApplySupplement(supplement)
 				}
 
 				// For outgoing HTLCs, we will also need to
@@ -2586,8 +2594,8 @@ func (c *ChannelArbitrator) prepContractResolutions(
 			*contractResolutions.CommitResolution, height,
 			c.cfg.ChanPoint, resolverCfg,
 		)
-		if chanState != nil {
-			resolver.SupplementState(chanState)
+		if supplement != nil {
+			resolver.ApplySupplement(supplement)
 		}
 		htlcResolvers = append(htlcResolvers, resolver)
 	}

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -685,6 +685,41 @@ func (c *ChannelArbitrator) fetchHistoricalState() (*channeldb.OpenChannel,
 	return chanState, nil
 }
 
+// loadOrBackfillResolverSupplement loads the persisted resolver supplement.
+// For older logs that don't have it yet, the supplement is derived from the
+// historical channel state and then written back to the arbitrator log.
+func (c *ChannelArbitrator) loadOrBackfillResolverSupplement() (
+	*ResolverSupplement, error) {
+
+	supplement, err := c.log.FetchResolverSupplement()
+	switch {
+	case err == nil:
+		return supplement, nil
+
+	case err != errNoResolverSupplement && err != errScopeBucketNoExist:
+		return nil, err
+	}
+
+	chanState, err := c.fetchHistoricalState()
+	if err != nil {
+		return nil, err
+	}
+	if chanState == nil {
+		return nil, fmt.Errorf("missing resolver supplement and historical channel state")
+	}
+
+	supplement = deriveResolverSupplement(chanState)
+	if supplement == nil {
+		return nil, fmt.Errorf("unable to derive resolver supplement")
+	}
+
+	if err := c.log.PersistResolverSupplement(supplement); err != nil {
+		return nil, err
+	}
+
+	return supplement, nil
+}
+
 // relauchResolvers relaunches the set of resolvers for unresolved contracts in
 // order to provide them with information that's not immediately available upon
 // starting the ChannelArbitrator. This information should ideally be stored in
@@ -753,14 +788,9 @@ func (c *ChannelArbitrator) relaunchResolvers(commitSet *CommitSet,
 		htlcMap[outpoint] = &htlc
 	}
 
-	chanState, err := c.fetchHistoricalState()
+	supplement, err := c.loadOrBackfillResolverSupplement()
 	if err != nil {
 		return err
-	}
-
-	var supplement *ResolverSupplement
-	if chanState != nil {
-		supplement = deriveResolverSupplement(chanState)
 	}
 
 	log.Infof("ChannelArbitrator(%v): relaunching %v contract "+
@@ -769,15 +799,13 @@ func (c *ChannelArbitrator) relaunchResolvers(commitSet *CommitSet,
 	for i := range unresolvedContracts {
 		resolver := unresolvedContracts[i]
 
-		if supplement != nil {
-			resolver.ApplySupplement(supplement)
+		resolver.ApplySupplement(supplement)
 
-			// For taproot channels, we'll need to also make sure the
-			// control block information was set properly.
-			maybeAugmentTaprootResolvers(
-				supplement.ChanType, resolver, contractResolutions,
-			)
-		}
+		// For taproot channels, we'll need to also make sure the control
+		// block information was set properly.
+		maybeAugmentTaprootResolvers(
+			supplement.ChanType, resolver, contractResolutions,
+		)
 
 		unresolvedContracts[i] = resolver
 
@@ -816,9 +844,7 @@ func (c *ChannelArbitrator) relaunchResolvers(commitSet *CommitSet,
 			},
 		)
 
-		if supplement != nil {
-			anchorResolver.ApplySupplement(supplement)
-		}
+		anchorResolver.ApplySupplement(supplement)
 
 		unresolvedContracts = append(unresolvedContracts, anchorResolver)
 
@@ -2378,12 +2404,17 @@ func (c *ChannelArbitrator) prepContractResolutions(
 	if err != nil {
 		return nil, err
 	}
-	var supplement *ResolverSupplement
-	if chanState != nil {
-		supplement = deriveResolverSupplement(chanState)
-		if err := c.log.PersistResolverSupplement(supplement); err != nil {
-			return nil, err
-		}
+	if chanState == nil {
+		return nil, fmt.Errorf("missing historical channel state for resolver supplement")
+	}
+
+	supplement := deriveResolverSupplement(chanState)
+	if supplement == nil {
+		return nil, fmt.Errorf("unable to derive resolver supplement")
+	}
+
+	if err := c.log.PersistResolverSupplement(supplement); err != nil {
+		return nil, err
 	}
 
 	incomingResolutions := contractResolutions.HtlcResolutions.IncomingHTLCs
@@ -2425,9 +2456,7 @@ func (c *ChannelArbitrator) prepContractResolutions(
 			contractResolutions.AnchorResolution.CommitAnchor,
 			height, c.cfg.ChanPoint, resolverCfg,
 		)
-		if supplement != nil {
-			anchorResolver.ApplySupplement(supplement)
-		}
+		anchorResolver.ApplySupplement(supplement)
 
 		htlcResolvers = append(htlcResolvers, anchorResolver)
 	}
@@ -2437,9 +2466,7 @@ func (c *ChannelArbitrator) prepContractResolutions(
 	// steps taken for non-breach-closes do not matter for breach-closes.
 	if contractResolutions.BreachResolution != nil {
 		breachResolver := newBreachResolver(resolverCfg)
-		if supplement != nil {
-			breachResolver.ApplySupplement(supplement)
-		}
+		breachResolver.ApplySupplement(supplement)
 		htlcResolvers = append(htlcResolvers, breachResolver)
 
 		return htlcResolvers, nil
@@ -2473,9 +2500,7 @@ func (c *ChannelArbitrator) prepContractResolutions(
 				resolver := newSuccessResolver(
 					resolution, height, htlc, resolverCfg,
 				)
-				if supplement != nil {
-					resolver.ApplySupplement(supplement)
-				}
+				resolver.ApplySupplement(supplement)
 				htlcResolvers = append(htlcResolvers, resolver)
 			}
 
@@ -2501,9 +2526,7 @@ func (c *ChannelArbitrator) prepContractResolutions(
 				resolver := newTimeoutResolver(
 					resolution, height, htlc, resolverCfg,
 				)
-				if supplement != nil {
-					resolver.ApplySupplement(supplement)
-				}
+				resolver.ApplySupplement(supplement)
 
 				// For outgoing HTLCs, we will also need to
 				// supplement the resolver with the expiry
@@ -2542,9 +2565,7 @@ func (c *ChannelArbitrator) prepContractResolutions(
 					resolution, height, htlc,
 					resolverCfg,
 				)
-				if supplement != nil {
-					resolver.ApplySupplement(supplement)
-				}
+				resolver.ApplySupplement(supplement)
 				htlcResolvers = append(htlcResolvers, resolver)
 			}
 
@@ -2573,9 +2594,7 @@ func (c *ChannelArbitrator) prepContractResolutions(
 				resolver := newOutgoingContestResolver(
 					resolution, height, htlc, resolverCfg,
 				)
-				if supplement != nil {
-					resolver.ApplySupplement(supplement)
-				}
+				resolver.ApplySupplement(supplement)
 
 				// For outgoing HTLCs, we will also need to
 				// supplement the resolver with the expiry
@@ -2597,9 +2616,7 @@ func (c *ChannelArbitrator) prepContractResolutions(
 			*contractResolutions.CommitResolution, height,
 			c.cfg.ChanPoint, resolverCfg,
 		)
-		if supplement != nil {
-			resolver.ApplySupplement(supplement)
-		}
+		resolver.ApplySupplement(supplement)
 		htlcResolvers = append(htlcResolvers, resolver)
 	}
 

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -2381,6 +2381,9 @@ func (c *ChannelArbitrator) prepContractResolutions(
 	var supplement *ResolverSupplement
 	if chanState != nil {
 		supplement = deriveResolverSupplement(chanState)
+		if err := c.log.PersistResolverSupplement(supplement); err != nil {
+			return nil, err
+		}
 	}
 
 	incomingResolutions := contractResolutions.HtlcResolutions.IncomingHTLCs

--- a/contractcourt/channel_arbitrator_test.go
+++ b/contractcourt/channel_arbitrator_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/tlv"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1054,10 +1055,6 @@ func TestChannelArbitratorLocalForceClosePendingHtlc(t *testing.T) {
 		StateWaitingFullResolution,
 	)
 
-	supplement, err := chanArbCtx.log.FetchResolverSupplement()
-	require.NoError(t, err)
-	require.NotNil(t, supplement)
-
 	// We'll grab the old notifier here as our resolvers are still holding
 	// a reference to this instance, and a new one will be created when we
 	// restart the channel arb below.
@@ -1077,8 +1074,16 @@ func TestChannelArbitratorLocalForceClosePendingHtlc(t *testing.T) {
 	require.Equal(t, expectedFinalHtlcs, chanArbCtx.finalHtlcs)
 
 	// We'll now re-create the resolver, notice that we use the existing
-	// arbLog so it carries over the same on-disk state.
-	chanArbCtxNew, err := chanArbCtx.Restart(nil)
+	// arbLog so it carries over the same on-disk state. Historical channel
+	// state is intentionally unavailable here so restart recovery must rely
+	// on the persisted resolver supplement.
+	chanArbCtxNew, err := chanArbCtx.Restart(func(c *chanArbTestCtx) {
+		c.chanArb.cfg.FetchHistoricalChannel = func() (*channeldb.OpenChannel,
+			error) {
+
+			return nil, channeldb.ErrChannelNotFound
+		}
+	})
 	require.NoError(t, err, "unable to create ChannelArbitrator")
 	chanArb = chanArbCtxNew.chanArb
 	defer chanArbCtxNew.CleanUp()
@@ -1180,6 +1185,194 @@ func TestChannelArbitratorLocalForceClosePendingHtlc(t *testing.T) {
 	case <-time.After(defaultTimeout):
 		t.Fatalf("contract was not resolved")
 	}
+}
+
+func TestChannelArbitratorRelaunchAnchorFromResolverSupplement(t *testing.T) {
+	t.Parallel()
+
+	taprootChanType := channeldb.AnchorOutputsBit |
+		channeldb.SimpleTaprootFeatureBit
+	taprootPkScript := append([]byte{0x51, 0x20}, make([]byte, 32)...)
+
+	log := &mockArbitratorLog{
+		newStates: make(chan ArbitratorState, 1),
+		resolutions: &ContractResolutions{
+			AnchorResolution: &lnwallet.AnchorResolution{
+				CommitAnchor: testChanPoint1,
+				AnchorSignDescriptor: input.SignDescriptor{
+					Output: &wire.TxOut{
+						Value:    330,
+						PkScript: taprootPkScript,
+					},
+				},
+			},
+		},
+		resolverSupplement: &ResolverSupplement{
+			ChanType: taprootChanType,
+		},
+	}
+
+	chanArbCtx, err := createTestChannelArbitrator(t, log)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, chanArbCtx.chanArb.Stop())
+	})
+
+	fetches := 0
+	chanArbCtx.chanArb.cfg.FetchHistoricalChannel = func() (*channeldb.OpenChannel,
+		error) {
+
+		fetches++
+		return nil, channeldb.ErrChannelNotFound
+	}
+
+	require.NoError(t, chanArbCtx.chanArb.relaunchResolvers(nil, 1))
+	require.Zero(t, fetches)
+
+	select {
+	case sweptInput := <-chanArbCtx.sweeper.sweptInputs:
+		require.Equal(t, input.TaprootAnchorSweepSpend,
+			sweptInput.WitnessType())
+	case <-time.After(defaultTimeout):
+		t.Fatal("anchor resolver did not sweep input")
+	}
+}
+
+func TestChannelArbitratorBackfillsResolverSupplement(t *testing.T) {
+	t.Parallel()
+
+	taprootChanType := channeldb.AnchorOutputsBit |
+		channeldb.SimpleTaprootFeatureBit
+	taprootPkScript := append([]byte{0x51, 0x20}, make([]byte, 32)...)
+
+	log := &mockArbitratorLog{
+		newStates: make(chan ArbitratorState, 1),
+		resolutions: &ContractResolutions{
+			AnchorResolution: &lnwallet.AnchorResolution{
+				CommitAnchor: testChanPoint1,
+				AnchorSignDescriptor: input.SignDescriptor{
+					Output: &wire.TxOut{
+						Value:    330,
+						PkScript: taprootPkScript,
+					},
+				},
+			},
+		},
+	}
+
+	chanArbCtx, err := createTestChannelArbitrator(t, log)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, chanArbCtx.chanArb.Stop())
+	})
+
+	fetches := 0
+	chanArbCtx.chanArb.cfg.FetchHistoricalChannel = func() (*channeldb.OpenChannel,
+		error) {
+
+		fetches++
+		return &channeldb.OpenChannel{
+			ChanType: taprootChanType,
+		}, nil
+	}
+
+	require.NoError(t, chanArbCtx.chanArb.relaunchResolvers(nil, 1))
+	require.Equal(t, 1, fetches)
+	require.NotNil(t, log.resolverSupplement)
+	require.Equal(t, taprootChanType, log.resolverSupplement.ChanType)
+
+	select {
+	case sweptInput := <-chanArbCtx.sweeper.sweptInputs:
+		require.Equal(t, input.TaprootAnchorSweepSpend,
+			sweptInput.WitnessType())
+	case <-time.After(defaultTimeout):
+		t.Fatal("anchor resolver did not sweep input")
+	}
+}
+
+func TestChannelArbitratorRelaunchTaprootHtlcUsesResolverSupplement(
+	t *testing.T) {
+
+	t.Parallel()
+
+	taprootChanType := channeldb.AnchorOutputsBit |
+		channeldb.SimpleTaprootFeatureBit
+	commitHash := chainhash.Hash{1, 2, 3}
+	htlcPoint := wire.OutPoint{Hash: commitHash, Index: 0}
+	htlc := channeldb.HTLC{
+		Amt:         1000,
+		HtlcIndex:   11,
+		OutputIndex: 0,
+	}
+
+	oldResolution := lnwallet.OutgoingHtlcResolution{
+		Expiry:        20,
+		ClaimOutpoint: htlcPoint,
+		SweepSignDesc: input.SignDescriptor{
+			Output: &wire.TxOut{PkScript: []byte{0x51, 0x20}},
+		},
+	}
+
+	newBlob := tlv.Blob{1, 2, 3}
+	updatedResolution := oldResolution
+	updatedResolution.ResolutionBlob = fn.Some(newBlob)
+
+	log := &mockArbitratorLog{
+		newStates: make(chan ArbitratorState, 1),
+		resolutions: &ContractResolutions{
+			CommitHash: commitHash,
+			HtlcResolutions: lnwallet.HtlcResolutions{
+				OutgoingHTLCs: []lnwallet.OutgoingHtlcResolution{
+					updatedResolution,
+				},
+			},
+		},
+		resolverSupplement: &ResolverSupplement{
+			ChanType: taprootChanType,
+		},
+		resolvers: make(map[ContractResolver]struct{}),
+	}
+
+	chanArbCtx, err := createTestChannelArbitrator(t, log)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, chanArbCtx.chanArb.Stop())
+	})
+
+	resolverCfg := ResolverConfig{
+		ChannelArbitratorConfig: chanArbCtx.chanArb.cfg,
+		Checkpoint: func(ContractResolver,
+			...*channeldb.ResolverReport) error {
+
+			return nil
+		},
+	}
+	resolver := newTimeoutResolver(oldResolution, 1, htlc, resolverCfg)
+	resolver.markResolved()
+	log.resolvers[resolver] = struct{}{}
+
+	fetches := 0
+	chanArbCtx.chanArb.cfg.FetchHistoricalChannel = func() (*channeldb.OpenChannel,
+		error) {
+
+		fetches++
+		return nil, channeldb.ErrChannelNotFound
+	}
+
+	commitSet := &CommitSet{
+		ConfCommitKey: fn.Some(LocalHtlcSet),
+		HtlcSets: map[HtlcSetKey][]channeldb.HTLC{
+			LocalHtlcSet: {htlc},
+		},
+	}
+
+	require.NoError(t, chanArbCtx.chanArb.relaunchResolvers(commitSet, 1))
+	require.Zero(t, fetches)
+	require.True(t, resolver.htlcResolution.ResolutionBlob.IsSome())
+	require.Equal(
+		t, newBlob,
+		resolver.htlcResolution.ResolutionBlob.UnwrapOrFail(t),
+	)
 }
 
 // TestChannelArbitratorLocalForceCloseRemoteConfiremd tests that the

--- a/contractcourt/channel_arbitrator_test.go
+++ b/contractcourt/channel_arbitrator_test.go
@@ -1054,6 +1054,10 @@ func TestChannelArbitratorLocalForceClosePendingHtlc(t *testing.T) {
 		StateWaitingFullResolution,
 	)
 
+	supplement, err := chanArbCtx.log.FetchResolverSupplement()
+	require.NoError(t, err)
+	require.NotNil(t, supplement)
+
 	// We'll grab the old notifier here as our resolvers are still holding
 	// a reference to this instance, and a new one will be created when we
 	// restart the channel arb below.

--- a/contractcourt/channel_arbitrator_test.go
+++ b/contractcourt/channel_arbitrator_test.go
@@ -37,14 +37,15 @@ const (
 )
 
 type mockArbitratorLog struct {
-	state           ArbitratorState
-	newStates       chan ArbitratorState
-	failLog         bool
-	failFetch       error
-	failCommit      bool
-	failCommitState ArbitratorState
-	resolutions     *ContractResolutions
-	resolvers       map[ContractResolver]struct{}
+	state              ArbitratorState
+	newStates          chan ArbitratorState
+	failLog            bool
+	failFetch          error
+	failCommit         bool
+	failCommitState    ArbitratorState
+	resolutions        *ContractResolutions
+	resolverSupplement *ResolverSupplement
+	resolvers          map[ContractResolver]struct{}
 
 	commitSet *CommitSet
 
@@ -133,6 +134,23 @@ func (b *mockArbitratorLog) FetchContractResolutions() (*ContractResolutions, er
 	}
 
 	return b.resolutions, nil
+}
+
+func (b *mockArbitratorLog) PersistResolverSupplement(
+	supplement *ResolverSupplement) error {
+
+	b.resolverSupplement = supplement
+	return nil
+}
+
+func (b *mockArbitratorLog) FetchResolverSupplement() (*ResolverSupplement,
+	error) {
+
+	if b.resolverSupplement == nil {
+		return nil, errNoResolverSupplement
+	}
+
+	return b.resolverSupplement, nil
 }
 
 func (b *mockArbitratorLog) FetchChainActions() (ChainActionMap, error) {

--- a/contractcourt/commit_sweep_resolver.go
+++ b/contractcourt/commit_sweep_resolver.go
@@ -29,10 +29,13 @@ import (
 // CLTV to expire.
 // https://docs.lightning.engineering/lightning-network-tools/pool/overview
 type commitSweepResolver struct {
-	// localChanCfg is used to provide the resolver with the keys required
-	// to identify whether the commitment transaction was broadcast by the
-	// local or remote party.
-	localChanCfg channeldb.ChannelConfig
+	// localDelayPubKey stores the local delay basepoint used to identify
+	// whether a taproot commitment output belongs to our local commitment.
+	localDelayPubKey [33]byte
+
+	// localPaymentPubKey stores the local payment basepoint used to identify
+	// whether a taproot commitment output belongs to the remote commitment.
+	localPaymentPubKey [33]byte
 
 	// commitResolution contains all data required to successfully sweep
 	// this HTLC on-chain.
@@ -58,9 +61,6 @@ type commitSweepResolver struct {
 	// NOTE: This value should only be set when the contract belongs to a
 	// leased channel.
 	leaseExpiry uint32
-
-	// chanType denotes the type of channel the contract belongs to.
-	chanType channeldb.ChannelType
 
 	// currentReport stores the current state of the resolver for reporting
 	// over the rpc interface.
@@ -206,17 +206,20 @@ func (c *commitSweepResolver) Stop() {
 	close(c.quit)
 }
 
-// SupplementState allows the user of a ContractResolver to supplement it with
-// state required for the proper resolution of a contract.
-//
-// NOTE: Part of the ContractResolver interface.
-func (c *commitSweepResolver) SupplementState(state *channeldb.OpenChannel) {
-	if state.ChanType.HasLeaseExpiration() {
-		c.leaseExpiry = state.ThawHeight
+// ApplySupplement restores channel-scoped state required to resolve the
+// commitment output.
+func (c *commitSweepResolver) ApplySupplement(
+	supplement *ResolverSupplement) {
+
+	c.contractResolverKit.ApplySupplement(supplement)
+	if supplement == nil {
+		return
 	}
-	c.localChanCfg = state.LocalChanCfg
-	c.channelInitiator = state.IsInitiator
-	c.chanType = state.ChanType
+
+	c.leaseExpiry = supplement.LeaseExpiry
+	c.channelInitiator = supplement.ChannelInitiator
+	c.localDelayPubKey = supplement.LocalDelayPubKey
+	c.localPaymentPubKey = supplement.LocalPaymentPubKey
 }
 
 // hasCLTV denotes whether the resolver must wait for an additional CLTV to
@@ -436,20 +439,26 @@ func (c *commitSweepResolver) decideWitnessType() (input.WitnessType, error) {
 	// on the timelock value. For remote commitment transactions, the
 	// witness script has a timelock of 1.
 	case c.chanType.IsTaproot():
-		delayKey := c.localChanCfg.DelayBasePoint.PubKey
-		nonDelayKey := c.localChanCfg.PaymentBasePoint.PubKey
-
 		signKey := c.commitResolution.SelfOutputSignDesc.KeyDesc.PubKey
+		if signKey == nil {
+			return nil, fmt.Errorf("nil sign key")
+		}
+
+		var signKeyBytes [33]byte
+		copy(signKeyBytes[:], signKey.SerializeCompressed())
 
 		// If the key in the script is neither of these, we shouldn't
 		// proceed. This should be impossible.
-		if !signKey.IsEqual(delayKey) && !signKey.IsEqual(nonDelayKey) {
+		if signKeyBytes != c.localDelayPubKey &&
+			signKeyBytes != c.localPaymentPubKey {
+
+			c.log.Errorf("taproot commit sweep signing key matched neither stored basepoint")
 			return nil, fmt.Errorf("unknown sign key %v", signKey)
 		}
 
 		// The commitment transaction is ours iff the signing key is
 		// the delay key.
-		isLocalCommitTx = signKey.IsEqual(delayKey)
+		isLocalCommitTx = signKeyBytes == c.localDelayPubKey
 
 	// The output is on our local commitment if the script starts with
 	// OP_IF for the revocation clause. On the remote commitment it will

--- a/contractcourt/commit_sweep_resolver_test.go
+++ b/contractcourt/commit_sweep_resolver_test.go
@@ -4,12 +4,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/graph/db/models"
 	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/lntest/mock"
 	"github.com/lightningnetwork/lnd/lnwallet"
@@ -167,6 +169,80 @@ func (s *mockSweeper) UpdateParams(input wire.OutPoint,
 }
 
 var _ UtxoSweeper = &mockSweeper{}
+
+func TestCommitSweepResolverTaprootWitnessSelectionFromSupplement(
+	t *testing.T) {
+
+	t.Parallel()
+
+	delayPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	paymentPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	var (
+		localDelayPubKey   [33]byte
+		localPaymentPubKey [33]byte
+	)
+	copy(localDelayPubKey[:], delayPriv.PubKey().SerializeCompressed())
+	copy(localPaymentPubKey[:], paymentPriv.PubKey().SerializeCompressed())
+
+	testCases := []struct {
+		name         string
+		signKey      *btcec.PublicKey
+		expectedType input.WitnessType
+	}{
+		{
+			name:         "local commit",
+			signKey:      delayPriv.PubKey(),
+			expectedType: input.TaprootLocalCommitSpend,
+		},
+		{
+			name:         "remote commit",
+			signKey:      paymentPriv.PubKey(),
+			expectedType: input.TaprootRemoteCommitSpend,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			resolution := &lnwallet.CommitOutputResolution{
+				SelfOutputSignDesc: input.SignDescriptor{
+					KeyDesc: keychain.KeyDescriptor{
+						PubKey: testCase.signKey,
+					},
+					Output: &wire.TxOut{Value: 100},
+				},
+				MaturityDelay: 1,
+			}
+
+			ctx := newCommitSweepResolverTestContext(
+				t, resolution, testCommitSweepConfHeight,
+			)
+
+			ctx.resolver.ApplySupplement(&ResolverSupplement{
+				ChanType:           channeldb.AnchorOutputsBit | channeldb.SimpleTaprootFeatureBit,
+				LocalDelayPubKey:   localDelayPubKey,
+				LocalPaymentPubKey: localPaymentPubKey,
+			})
+
+			require.NoError(t, ctx.resolver.Launch())
+
+			select {
+			case sweptInput := <-ctx.sweeper.sweptInputs:
+				require.Equal(t, testCase.expectedType,
+					sweptInput.WitnessType())
+			case <-time.After(defaultTimeout):
+				t.Fatal("resolver did not offer input to sweeper")
+			}
+		})
+	}
+}
 
 // TestCommitSweepResolverNoDelay tests resolution of a direct commitment output
 // unencumbered by a time lock.

--- a/contractcourt/contract_resolver.go
+++ b/contractcourt/contract_resolver.go
@@ -57,9 +57,9 @@ type ContractResolver interface {
 	// NOTE: This function MUST be run as a goroutine.
 	Resolve() (ContractResolver, error)
 
-	// SupplementState allows the user of a ContractResolver to supplement
-	// it with state required for the proper resolution of a contract.
-	SupplementState(*channeldb.OpenChannel)
+	// ApplySupplement allows the user of a ContractResolver to restore any
+	// channel-scoped state required for proper contract resolution.
+	ApplySupplement(*ResolverSupplement)
 
 	// IsResolved returns true if the stored state in the resolve is fully
 	// resolved. In this case the target output can be forgotten.
@@ -119,6 +119,9 @@ type ResolverConfig struct {
 type contractResolverKit struct {
 	ResolverConfig
 
+	// chanType denotes the type of channel the contract belongs to.
+	chanType channeldb.ChannelType
+
 	log btclog.Logger
 
 	quit chan struct{}
@@ -153,6 +156,17 @@ func (r *contractResolverKit) initLogger(prefix string) {
 		prefix)
 
 	r.log = log.WithPrefix(logPrefix)
+}
+
+// ApplySupplement restores the shared resolver state.
+func (r *contractResolverKit) ApplySupplement(
+	supplement *ResolverSupplement) {
+
+	if supplement == nil {
+		return
+	}
+
+	r.chanType = supplement.ChanType
 }
 
 // IsResolved returns true if the stored state in the resolve is fully

--- a/contractcourt/htlc_lease_resolver.go
+++ b/contractcourt/htlc_lease_resolver.go
@@ -3,7 +3,6 @@ package contractcourt
 import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/chainntnfs"
-	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/tlv"
@@ -72,13 +71,13 @@ func (h *htlcLeaseResolver) makeSweepInput(op *wire.OutPoint,
 	)
 }
 
-// SupplementState allows the user of a ContractResolver to supplement it with
-// state required for the proper resolution of a contract.
-//
-// NOTE: Part of the ContractResolver interface.
-func (h *htlcLeaseResolver) SupplementState(state *channeldb.OpenChannel) {
-	if state.ChanType.HasLeaseExpiration() {
-		h.leaseExpiry = state.ThawHeight
+// setLeaseFields restores lease-specific resolver state from the channel-wide
+// supplement.
+func (h *htlcLeaseResolver) setLeaseFields(supplement *ResolverSupplement) {
+	if supplement == nil {
+		return
 	}
-	h.channelInitiator = state.IsInitiator
+
+	h.leaseExpiry = supplement.LeaseExpiry
+	h.channelInitiator = supplement.ChannelInitiator
 }

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -104,6 +104,14 @@ func (h *htlcSuccessResolver) ResolverKey() []byte {
 	return key[:]
 }
 
+// ApplySupplement restores channel-scoped state required to resolve the HTLC.
+func (h *htlcSuccessResolver) ApplySupplement(
+	supplement *ResolverSupplement) {
+
+	h.contractResolverKit.ApplySupplement(supplement)
+	h.htlcLeaseResolver.setLeaseFields(supplement)
+}
+
 // Resolve attempts to resolve an unresolved incoming HTLC that we know the
 // preimage to. If the HTLC is on the commitment of the remote party, then we'll
 // simply sweep it directly. Otherwise, we'll hand this off to the utxo nursery

--- a/contractcourt/htlc_timeout_resolver.go
+++ b/contractcourt/htlc_timeout_resolver.go
@@ -113,6 +113,14 @@ func (h *htlcTimeoutResolver) ResolverKey() []byte {
 	return key[:]
 }
 
+// ApplySupplement restores channel-scoped state required to resolve the HTLC.
+func (h *htlcTimeoutResolver) ApplySupplement(
+	supplement *ResolverSupplement) {
+
+	h.contractResolverKit.ApplySupplement(supplement)
+	h.htlcLeaseResolver.setLeaseFields(supplement)
+}
+
 const (
 	// expectedRemoteWitnessSuccessSize is the expected size of the witness
 	// on the remote commitment transaction for an outgoing HTLC that is

--- a/contractcourt/resolver_supplement.go
+++ b/contractcourt/resolver_supplement.go
@@ -1,0 +1,134 @@
+package contractcourt
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"github.com/lightningnetwork/lnd/channeldb"
+)
+
+const resolverSupplementVersion byte = 1
+
+// ResolverSupplement stores channel-scoped resolver state that needs to
+// survive restarts but doesn't belong in each resolver's individual encoding.
+type ResolverSupplement struct {
+	// ChanType is the channel type for the closing channel.
+	ChanType channeldb.ChannelType
+
+	// ChannelInitiator records whether we initiated the channel.
+	ChannelInitiator bool
+
+	// LeaseExpiry is the lease thaw height for leased channels. For all other
+	// channels this is zero.
+	LeaseExpiry uint32
+
+	// LocalDelayPubKey is the local delay basepoint used to identify the local
+	// taproot commitment output on restart.
+	LocalDelayPubKey [33]byte
+
+	// LocalPaymentPubKey is the local payment basepoint used to identify the
+	// remote taproot commitment output on restart.
+	LocalPaymentPubKey [33]byte
+}
+
+// deriveResolverSupplement normalizes the restart-only resolver state from the
+// historical channel record. This should be called once per channel close.
+func deriveResolverSupplement(state *channeldb.OpenChannel) *ResolverSupplement {
+	if state == nil {
+		return nil
+	}
+
+	supplement := &ResolverSupplement{
+		ChanType:         state.ChanType,
+		ChannelInitiator: state.IsInitiator,
+	}
+
+	if state.ChanType.HasLeaseExpiration() {
+		supplement.LeaseExpiry = state.ThawHeight
+	}
+
+	if pubKey := state.LocalChanCfg.DelayBasePoint.PubKey; pubKey != nil {
+		copy(supplement.LocalDelayPubKey[:], pubKey.SerializeCompressed())
+	}
+
+	if pubKey := state.LocalChanCfg.PaymentBasePoint.PubKey; pubKey != nil {
+		copy(supplement.LocalPaymentPubKey[:], pubKey.SerializeCompressed())
+	}
+
+	return supplement
+}
+
+// encodeResolverSupplement writes the resolver supplement using a versioned
+// format to allow future extensions.
+func encodeResolverSupplement(w io.Writer, supplement *ResolverSupplement) error {
+	if supplement == nil {
+		return fmt.Errorf("resolver supplement is nil")
+	}
+
+	if err := binary.Write(w, endian, resolverSupplementVersion); err != nil {
+		return err
+	}
+
+	if err := binary.Write(w, endian, uint64(supplement.ChanType)); err != nil {
+		return err
+	}
+
+	if err := binary.Write(w, endian, supplement.ChannelInitiator); err != nil {
+		return err
+	}
+
+	if err := binary.Write(w, endian, supplement.LeaseExpiry); err != nil {
+		return err
+	}
+
+	if _, err := w.Write(supplement.LocalDelayPubKey[:]); err != nil {
+		return err
+	}
+
+	if _, err := w.Write(supplement.LocalPaymentPubKey[:]); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// decodeResolverSupplement reads a resolver supplement written by
+// encodeResolverSupplement.
+func decodeResolverSupplement(r io.Reader) (*ResolverSupplement, error) {
+	var version byte
+	if err := binary.Read(r, endian, &version); err != nil {
+		return nil, err
+	}
+
+	if version != resolverSupplementVersion {
+		return nil, fmt.Errorf("unknown resolver supplement version %d", version)
+	}
+
+	var chanType uint64
+	if err := binary.Read(r, endian, &chanType); err != nil {
+		return nil, err
+	}
+
+	supplement := &ResolverSupplement{
+		ChanType: channeldb.ChannelType(chanType),
+	}
+
+	if err := binary.Read(r, endian, &supplement.ChannelInitiator); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Read(r, endian, &supplement.LeaseExpiry); err != nil {
+		return nil, err
+	}
+
+	if _, err := io.ReadFull(r, supplement.LocalDelayPubKey[:]); err != nil {
+		return nil, err
+	}
+
+	if _, err := io.ReadFull(r, supplement.LocalPaymentPubKey[:]); err != nil {
+		return nil, err
+	}
+
+	return supplement, nil
+}

--- a/contractcourt/resolver_supplement_test.go
+++ b/contractcourt/resolver_supplement_test.go
@@ -1,0 +1,84 @@
+package contractcourt
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeriveResolverSupplement(t *testing.T) {
+	t.Parallel()
+
+	delayPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	paymentPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	chanType := channeldb.AnchorOutputsBit |
+		channeldb.LeaseExpirationBit |
+		channeldb.SimpleTaprootFeatureBit
+
+	state := &channeldb.OpenChannel{
+		ChanType:     chanType,
+		IsInitiator:  true,
+		ThawHeight:   144,
+		LocalChanCfg: channeldb.ChannelConfig{},
+	}
+	state.LocalChanCfg.DelayBasePoint = keychain.KeyDescriptor{
+		PubKey: delayPriv.PubKey(),
+	}
+	state.LocalChanCfg.PaymentBasePoint = keychain.KeyDescriptor{
+		PubKey: paymentPriv.PubKey(),
+	}
+
+	supplement := deriveResolverSupplement(state)
+	require.NotNil(t, supplement)
+	require.Equal(t, chanType, supplement.ChanType)
+	require.True(t, supplement.ChannelInitiator)
+	require.EqualValues(t, 144, supplement.LeaseExpiry)
+	require.Equal(
+		t, delayPriv.PubKey().SerializeCompressed(),
+		supplement.LocalDelayPubKey[:],
+	)
+	require.Equal(
+		t, paymentPriv.PubKey().SerializeCompressed(),
+		supplement.LocalPaymentPubKey[:],
+	)
+
+	nonLease := deriveResolverSupplement(&channeldb.OpenChannel{
+		ChanType: channeldb.AnchorOutputsBit,
+	})
+	require.NotNil(t, nonLease)
+	require.Zero(t, nonLease.LeaseExpiry)
+}
+
+func TestResolverSupplementEncodeDecode(t *testing.T) {
+	t.Parallel()
+
+	supplement := &ResolverSupplement{
+		ChanType:           channeldb.AnchorOutputsBit | channeldb.SimpleTaprootFeatureBit,
+		ChannelInitiator:   true,
+		LeaseExpiry:        144,
+		LocalDelayPubKey:   [33]byte{1, 2, 3},
+		LocalPaymentPubKey: [33]byte{4, 5, 6},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, encodeResolverSupplement(&buf, supplement))
+
+	decoded, err := decodeResolverSupplement(bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+	require.Equal(t, supplement, decoded)
+}
+
+func TestResolverSupplementDecodeUnknownVersion(t *testing.T) {
+	t.Parallel()
+
+	_, err := decodeResolverSupplement(bytes.NewReader([]byte{99}))
+	require.ErrorContains(t, err, "unknown resolver supplement version")
+}


### PR DESCRIPTION
## Summary
- persist channel-scoped resolver supplements in the arbitrator log and restore resolver state through a shared `ApplySupplement` hook
- write supplements on the close path and reload/backfill them on restart so taproot resolver augmentation no longer depends on historical channel availability
- add restart coverage for taproot HTLC and anchor resolvers, including the nil-historical-state path that previously panicked

## Testing
- `GOWORK=off go test ./contractcourt`