### PR TITLE
contractcourt: retry HTLC resolver launches

### DIFF
--- a/contractcourt/anchor_resolver.go
+++ b/contractcourt/anchor_resolver.go
@@ -141,7 +141,13 @@ func (c *anchorResolver) Resolve() (ContractResolver, error) {
 	c.reportLock.Unlock()
 
 	c.markResolved()
-	return nil, c.PutResolverReport(nil, report)
+	err := c.PutResolverReport(nil, report)
+	if err != nil {
+		c.unresolve()
+		return nil, err
+	}
+
+	return nil, nil
 }
 
 // Stop signals the resolver to cancel any current resolution processes, and

--- a/contractcourt/anchor_resolver.go
+++ b/contractcourt/anchor_resolver.go
@@ -252,6 +252,10 @@ func (c *anchorResolver) Launch() error {
 	)
 
 	if err != nil {
+		// launchResolvers only logs this error and returns. Clearing
+		// launched lets a later blockbeat or restart retry without a
+		// tight loop.
+		c.unlaunch()
 		return err
 	}
 

--- a/contractcourt/breach_resolver.go
+++ b/contractcourt/breach_resolver.go
@@ -59,8 +59,7 @@ func (b *breachResolver) Resolve() (ContractResolver, error) {
 		// If the breach resolution process is already complete, then
 		// we can cleanup and checkpoint the resolved state.
 		if complete {
-			b.markResolved()
-			return nil, b.Checkpoint(b)
+			return nil, b.resolve(b)
 		}
 
 		// Prevent duplicate subscriptions.
@@ -72,8 +71,7 @@ func (b *breachResolver) Resolve() (ContractResolver, error) {
 		// The replyChan has been closed, signalling that the breach
 		// has been fully resolved. Checkpoint the resolved state and
 		// exit.
-		b.markResolved()
-		return nil, b.Checkpoint(b)
+		return nil, b.resolve(b)
 
 	case <-b.quit:
 	}

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -643,7 +643,9 @@ func maybeAugmentTaprootResolvers(chanType channeldb.ChannelType,
 			if r.htlcResolution.ClaimOutpoint ==
 				htlcRes.ClaimOutpoint {
 
-				r.htlcResolution = htlcRes
+				augmentIncomingHtlcResolution(
+					&r.htlcResolution, htlcRes,
+				)
 			}
 		}
 	case *htlcSuccessResolver:
@@ -654,9 +656,25 @@ func maybeAugmentTaprootResolvers(chanType channeldb.ChannelType,
 			if r.htlcResolution.ClaimOutpoint ==
 				htlcRes.ClaimOutpoint {
 
-				r.htlcResolution = htlcRes
+				augmentIncomingHtlcResolution(
+					&r.htlcResolution, htlcRes,
+				)
 			}
 		}
+	}
+}
+
+// augmentIncomingHtlcResolution applies the taproot close-summary resolution
+// while preserving any preimage learned by the existing resolver. The close
+// summary can lack a preimage even when the in-memory resolver has already
+// recovered one from invoices or the witness cache.
+func augmentIncomingHtlcResolution(dst *lnwallet.IncomingHtlcResolution,
+	src lnwallet.IncomingHtlcResolution) {
+
+	preimage := dst.Preimage
+	*dst = src
+	if preimage != [32]byte{} {
+		dst.Preimage = preimage
 	}
 }
 

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -1591,8 +1591,14 @@ func (c *ChannelArbitrator) resolveContracts(resolvers []ContractResolver) {
 	c.activeResolvers = resolvers
 	c.activeResolversLock.Unlock()
 
-	// Launch all resolvers.
-	c.launchResolvers()
+	// Launch all resolvers. If shutdown interrupts launch, don't start the
+	// resolve goroutines as some Launch results may not have been observed.
+	if !c.launchResolvers() {
+		log.Debugf("ChannelArbitrator(%v): launch interrupted, "+
+			"skipping resolver goroutines", c.cfg.ChanPoint)
+
+		return
+	}
 
 	for _, contract := range resolvers {
 		c.wg.Add(1)
@@ -1600,8 +1606,9 @@ func (c *ChannelArbitrator) resolveContracts(resolvers []ContractResolver) {
 	}
 }
 
-// launchResolvers launches all the active resolvers concurrently.
-func (c *ChannelArbitrator) launchResolvers() {
+// launchResolvers launches all the active resolvers concurrently. It returns
+// false if shutdown interrupts launch before every launch result is observed.
+func (c *ChannelArbitrator) launchResolvers() bool {
 	c.activeResolversLock.Lock()
 	resolvers := c.activeResolvers
 	c.activeResolversLock.Unlock()
@@ -1648,9 +1655,11 @@ func (c *ChannelArbitrator) launchResolvers() {
 			log.Debugf("ChannelArbitrator quit signal received, " +
 				"exit launchResolvers")
 
-			return
+			return false
 		}
 	}
+
+	return true
 }
 
 // advanceState is the main driver of our state machine. This method is an
@@ -2647,6 +2656,13 @@ func (c *ChannelArbitrator) resolveContract(currentContract ContractResolver) {
 	log.Tracef("ChannelArbitrator(%v): attempting to resolve %T",
 		c.cfg.ChanPoint, currentContract)
 
+	// Launch may have reached the terminal checkpoint.
+	if currentContract.IsResolved() {
+		c.markContractResolved(currentContract)
+
+		return
+	}
+
 	// Until the contract is fully resolved, we'll continue to iteratively
 	// resolve the contract one step at a time.
 	for !currentContract.IsResolved() {
@@ -2718,29 +2734,37 @@ func (c *ChannelArbitrator) resolveContract(currentContract ContractResolver) {
 						currentContract, err)
 				}
 
+				// Nested Launch can resolve too.
+				if currentContract.IsResolved() {
+					c.markContractResolved(currentContract)
+					return
+				}
+
 			// If this contract is actually fully resolved, then
 			// we'll mark it as such within the database.
 			case currentContract.IsResolved():
-				log.Debugf("ChannelArbitrator(%v): marking "+
-					"contract %T fully resolved",
-					c.cfg.ChanPoint, currentContract)
-
-				err := c.log.ResolveContract(currentContract)
-				if err != nil {
-					log.Errorf("unable to resolve contract: %v",
-						err)
-				}
-
-				// Now that the contract has been resolved,
-				// well signal to the main goroutine.
-				select {
-				case c.resolutionSignal <- struct{}{}:
-				case <-c.quit:
-					return
-				}
+				c.markContractResolved(currentContract)
 			}
 
 		}
+	}
+}
+
+// markContractResolved removes a fully resolved contract from the unresolved
+// log and signals the arbitrator state machine to check if all contracts are
+// done.
+func (c *ChannelArbitrator) markContractResolved(contract ContractResolver) {
+	log.Debugf("ChannelArbitrator(%v): marking contract %T fully resolved",
+		c.cfg.ChanPoint, contract)
+
+	err := c.log.ResolveContract(contract)
+	if err != nil {
+		log.Errorf("unable to resolve contract: %v", err)
+	}
+
+	select {
+	case c.resolutionSignal <- struct{}{}:
+	case <-c.quit:
 	}
 }
 

--- a/contractcourt/channel_arbitrator_test.go
+++ b/contractcourt/channel_arbitrator_test.go
@@ -2316,7 +2316,7 @@ func TestFindCommitmentDeadlineAndValue(t *testing.T) {
 	// Add a dummy payment hash to the preimage lookup.
 	rHash := [lntypes.PreimageSize]byte{1, 2, 3}
 	mockPreimageDB := newMockWitnessBeacon()
-	mockPreimageDB.lookupPreimage[rHash] = rHash
+	mockPreimageDB.setLookupPreimage(rHash, rHash)
 
 	// Attach a mock PreimageDB and Registry to channel arbitrator.
 	chanArb := chanArbCtx.chanArb
@@ -2506,7 +2506,7 @@ func TestSweepAnchors(t *testing.T) {
 	// Add a dummy payment hash to the preimage lookup.
 	rHash := [lntypes.PreimageSize]byte{1, 2, 3}
 	mockPreimageDB := newMockWitnessBeacon()
-	mockPreimageDB.lookupPreimage[rHash] = rHash
+	mockPreimageDB.setLookupPreimage(rHash, rHash)
 
 	// Attach a mock PreimageDB and Registry to channel arbitrator.
 	chanArb := chanArbCtx.chanArb
@@ -2790,7 +2790,7 @@ func TestChannelArbitratorAnchors(t *testing.T) {
 	// Add a dummy payment hash to the preimage lookup.
 	rHash := [lntypes.PreimageSize]byte{1, 2, 3}
 	mockPreimageDB := newMockWitnessBeacon()
-	mockPreimageDB.lookupPreimage[rHash] = rHash
+	mockPreimageDB.setLookupPreimage(rHash, rHash)
 
 	// Attach a mock PreimageDB and Registry to channel arbitrator.
 	chanArb := chanArbCtx.chanArb

--- a/contractcourt/channel_arbitrator_test.go
+++ b/contractcourt/channel_arbitrator_test.go
@@ -3,6 +3,7 @@ package contractcourt
 import (
 	"errors"
 	"fmt"
+	"io"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -22,11 +23,12 @@ import (
 	"github.com/lightningnetwork/lnd/graph/db/models"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/kvdb"
-	"github.com/lightningnetwork/lnd/lntest/mock"
+	lntestmock "github.com/lightningnetwork/lnd/lntest/mock"
 	"github.com/lightningnetwork/lnd/lntest/wait"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
+	testifymock "github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -149,6 +151,59 @@ func (b *mockArbitratorLog) FetchConfirmedCommitSet(kvdb.RTx) (*CommitSet, error
 }
 
 func (b *mockArbitratorLog) WipeHistory() error {
+	return nil
+}
+
+// mockResolver is a test ContractResolver backed by testify/mock.
+type mockResolver struct {
+	// Mock records expected resolver method calls.
+	testifymock.Mock
+
+	// contractResolverKit provides resolver state helpers for tests.
+	contractResolverKit
+
+	// key is the resolver key returned by ResolverKey.
+	key []byte
+}
+
+// newMockResolver returns a resolver with a stable key.
+func newMockResolver(key byte) *mockResolver {
+	return &mockResolver{
+		contractResolverKit: *newContractResolverKit(ResolverConfig{}),
+		key:                 []byte{key},
+	}
+}
+
+// ResolverKey returns the test resolver's stable key.
+func (m *mockResolver) ResolverKey() []byte {
+	return m.key
+}
+
+// Launch implements ContractResolver.
+func (m *mockResolver) Launch() error {
+	args := m.Called()
+
+	return args.Error(0)
+}
+
+// Resolve implements ContractResolver.
+func (m *mockResolver) Resolve() (ContractResolver, error) {
+	args := m.Called()
+	next, _ := args.Get(0).(ContractResolver)
+
+	return next, args.Error(1)
+}
+
+// Stop implements ContractResolver.
+func (*mockResolver) Stop() {
+}
+
+// SupplementState implements ContractResolver.
+func (*mockResolver) SupplementState(*channeldb.OpenChannel) {
+}
+
+// Encode implements ContractResolver.
+func (*mockResolver) Encode(io.Writer) error {
 	return nil
 }
 
@@ -277,6 +332,186 @@ func (c *chanArbTestCtx) AssertState(expected ArbitratorState) {
 	}
 }
 
+// TestResolveContractsRemovesLaunchResolvedContract asserts that a resolver
+// which reaches its terminal checkpoint during Launch is still removed from the
+// unresolved-contract log.
+func TestResolveContractsRemovesLaunchResolvedContract(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: install a resolver in the unresolved log that marks itself
+	// resolved during Launch.
+	arbLog := &mockArbitratorLog{
+		newStates: make(chan ArbitratorState, 5),
+		resolvers: make(map[ContractResolver]struct{}),
+	}
+	chanArbCtx, err := createTestChannelArbitrator(t, arbLog)
+	require.NoError(t, err, "unable to create ChannelArbitrator")
+
+	resolver := newMockResolver(1)
+	launchCalled := make(chan struct{})
+	resolver.On("Launch").Run(func(testifymock.Arguments) {
+		resolver.markResolved()
+		close(launchCalled)
+	}).Return(nil).Once()
+	require.NoError(t, arbLog.InsertUnresolvedContracts(nil, resolver))
+
+	// Act: resolveContracts launches the resolver before starting the
+	// resolveContract goroutine, matching the production ordering.
+	chanArbCtx.chanArb.resolveContracts([]ContractResolver{resolver})
+
+	select {
+	case <-launchCalled:
+	case <-time.After(defaultTimeout):
+		t.Fatal("resolver was not launched")
+	}
+
+	select {
+	case <-chanArbCtx.chanArb.resolutionSignal:
+	case <-time.After(defaultTimeout):
+		t.Fatal("resolved contract was not signaled")
+	}
+
+	chanArbCtx.chanArb.wg.Wait()
+
+	// Assert: the resolved resolver was deleted without calling Resolve.
+	arbLog.Lock()
+	_, ok := arbLog.resolvers[resolver]
+	arbLog.Unlock()
+	require.False(t, ok)
+
+	resolver.AssertNotCalled(t, "Resolve")
+	resolver.AssertExpectations(t)
+}
+
+// TestResolveContractsKeepsUnobservedLaunchResolvedContract asserts that a
+// resolver is not deleted if shutdown wins before its Launch result is read.
+func TestResolveContractsKeepsUnobservedLaunchResolvedContract(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: install a resolver that resolves itself during Launch, then
+	// blocks before launchResolvers can observe the result.
+	arbLog := &mockArbitratorLog{
+		newStates: make(chan ArbitratorState, 5),
+		resolvers: make(map[ContractResolver]struct{}),
+	}
+	chanArbCtx, err := createTestChannelArbitrator(t, arbLog)
+	require.NoError(t, err, "unable to create ChannelArbitrator")
+
+	resolver := newMockResolver(1)
+	launchCalled := make(chan struct{})
+	launchBlock := make(chan struct{})
+	resolver.On("Launch").Run(func(testifymock.Arguments) {
+		resolver.markResolved()
+		close(launchCalled)
+		<-launchBlock
+	}).Return(nil).Once()
+	require.NoError(t, arbLog.InsertUnresolvedContracts(nil, resolver))
+
+	done := make(chan struct{})
+
+	// Act: start resolution, wait until Launch has marked the resolver
+	// resolved, then shut down before Launch returns.
+	go func() {
+		chanArbCtx.chanArb.resolveContracts(
+			[]ContractResolver{resolver},
+		)
+		close(done)
+	}()
+
+	select {
+	case <-launchCalled:
+	case <-time.After(defaultTimeout):
+		t.Fatal("resolver was not launched")
+	}
+
+	close(chanArbCtx.chanArb.quit)
+	select {
+	case <-done:
+	case <-time.After(defaultTimeout):
+		t.Fatal("resolveContracts did not return")
+	}
+	chanArbCtx.chanArb.wg.Wait()
+	close(launchBlock)
+
+	// Assert: the resolver remains in the unresolved log because its Launch
+	// result was not observed.
+	arbLog.Lock()
+	_, ok := arbLog.resolvers[resolver]
+	arbLog.Unlock()
+	require.True(t, ok)
+
+	resolver.AssertNotCalled(t, "Resolve")
+	resolver.AssertExpectations(t)
+}
+
+// TestResolveContractsRemovesNestedLaunchResolvedContract asserts that a
+// swapped-in resolver that reaches its terminal checkpoint during Launch is
+// removed from the unresolved-contract log.
+func TestResolveContractsRemovesNestedLaunchResolvedContract(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: install a resolver that swaps to a nested one. The nested
+	// resolver resolves itself during Launch.
+	arbLog := &mockArbitratorLog{
+		newStates: make(chan ArbitratorState, 5),
+		resolvers: make(map[ContractResolver]struct{}),
+	}
+	chanArbCtx, err := createTestChannelArbitrator(t, arbLog)
+	require.NoError(t, err, "unable to create ChannelArbitrator")
+
+	nestedResolver := newMockResolver(2)
+	nestedLaunchCalled := make(chan struct{})
+	nestedResolver.On("Launch").Run(func(testifymock.Arguments) {
+		nestedResolver.markResolved()
+		close(nestedLaunchCalled)
+	}).Return(nil).Once()
+
+	resolver := newMockResolver(1)
+	resolveCalled := make(chan struct{})
+	resolver.On("Launch").Return(nil).Once()
+	resolver.On("Resolve").Run(func(testifymock.Arguments) {
+		close(resolveCalled)
+	}).Return(nestedResolver, nil).Once()
+	require.NoError(t, arbLog.InsertUnresolvedContracts(nil, resolver))
+
+	// Act: resolveContracts runs the parent resolver, swaps in the nested
+	// resolver, then launches the nested resolver.
+	chanArbCtx.chanArb.resolveContracts([]ContractResolver{resolver})
+
+	select {
+	case <-resolveCalled:
+	case <-time.After(defaultTimeout):
+		t.Fatal("parent resolver was not resolved")
+	}
+
+	select {
+	case <-nestedLaunchCalled:
+	case <-time.After(defaultTimeout):
+		t.Fatal("nested resolver was not launched")
+	}
+
+	select {
+	case <-chanArbCtx.chanArb.resolutionSignal:
+	case <-time.After(defaultTimeout):
+		t.Fatal("resolved nested contract was not signaled")
+	}
+
+	chanArbCtx.chanArb.wg.Wait()
+
+	// Assert: the parent and nested resolver were deleted from the log, and
+	// the already-resolved nested resolver did not call Resolve.
+	arbLog.Lock()
+	_, parentFound := arbLog.resolvers[resolver]
+	_, nestedFound := arbLog.resolvers[nestedResolver]
+	arbLog.Unlock()
+	require.False(t, parentFound)
+	require.False(t, nestedFound)
+
+	nestedResolver.AssertNotCalled(t, "Resolve")
+	resolver.AssertExpectations(t)
+	nestedResolver.AssertExpectations(t)
+}
+
 // Restart simulates a clean restart of the channel arbitrator, forcing it to
 // walk through it's recovery logic. If this function returns nil, then a
 // restart was successful. Note that the restart process keeps the log in
@@ -370,7 +605,7 @@ func createTestChannelArbitrator(t *testing.T, log ArbitratorLog,
 		},
 		OutgoingBroadcastDelta: 5,
 		IncomingBroadcastDelta: 5,
-		Notifier: &mock.ChainNotifier{
+		Notifier: &lntestmock.ChainNotifier{
 			EpochChan: make(chan *chainntnfs.BlockEpoch),
 			SpendChan: make(chan *chainntnfs.SpendDetail),
 			ConfChan:  make(chan *chainntnfs.TxConfirmation),
@@ -1040,7 +1275,8 @@ func TestChannelArbitratorLocalForceClosePendingHtlc(t *testing.T) {
 	// We'll grab the old notifier here as our resolvers are still holding
 	// a reference to this instance, and a new one will be created when we
 	// restart the channel arb below.
-	oldNotifier := chanArb.cfg.Notifier.(*mock.ChainNotifier)
+	oldNotifier, ok := chanArb.cfg.Notifier.(*lntestmock.ChainNotifier)
+	require.True(t, ok)
 
 	// At this point, in order to simulate a restart, we'll re-create the
 	// channel arbitrator. We do this to ensure that all information

--- a/contractcourt/commit_sweep_resolver.go
+++ b/contractcourt/commit_sweep_resolver.go
@@ -189,11 +189,9 @@ func (c *commitSweepResolver) Resolve() (ContractResolver, error) {
 	report := c.currentReport.resolverReport(
 		&sweepTxID, channeldb.ResolverTypeCommit, outcome,
 	)
-	c.markResolved()
-
 	// Checkpoint the resolver with a closure that will write the outcome
 	// of the resolver and its sweep transaction to disk.
-	return nil, c.Checkpoint(c, report)
+	return nil, c.resolve(c, report)
 }
 
 // Stop signals the resolver to cancel any current resolution processes, and

--- a/contractcourt/commit_sweep_resolver.go
+++ b/contractcourt/commit_sweep_resolver.go
@@ -363,6 +363,7 @@ func (c *commitSweepResolver) Launch() error {
 	// Derive the witness type for this input.
 	witnessType, err := c.decideWitnessType()
 	if err != nil {
+		c.unlaunch()
 		return err
 	}
 
@@ -413,6 +414,7 @@ func (c *commitSweepResolver) Launch() error {
 	)
 	if err != nil {
 		c.log.Errorf("unable to sweep input: %v", err)
+		c.unlaunch()
 
 		return err
 	}

--- a/contractcourt/commit_sweep_resolver_test.go
+++ b/contractcourt/commit_sweep_resolver_test.go
@@ -117,6 +117,7 @@ type mockSweeper struct {
 	updatedInputs     chan wire.OutPoint
 	sweepTx           *wire.MsgTx
 	sweepErr          error
+	sweepInputErr     error
 	createSweepTxChan chan *wire.MsgTx
 
 	deadlines []int
@@ -134,6 +135,10 @@ func newMockSweeper() *mockSweeper {
 
 func (s *mockSweeper) SweepInput(input input.Input, params sweep.Params) (
 	chan sweep.Result, error) {
+
+	if s.sweepInputErr != nil {
+		return nil, s.sweepInputErr
+	}
 
 	s.sweptInputs <- input
 

--- a/contractcourt/contract_resolver.go
+++ b/contractcourt/contract_resolver.go
@@ -168,6 +168,11 @@ func (r *contractResolverKit) markResolved() {
 	r.resolved.Store(true)
 }
 
+// unresolve marks the resolver as unresolved.
+func (r *contractResolverKit) unresolve() {
+	r.resolved.Store(false)
+}
+
 // isLaunched returns true if the resolver has been launched.
 func (r *contractResolverKit) isLaunched() bool {
 	return r.launched.Load()

--- a/contractcourt/contract_resolver.go
+++ b/contractcourt/contract_resolver.go
@@ -200,6 +200,12 @@ func (r *contractResolverKit) markLaunched() {
 	r.launched.Store(true)
 }
 
+// unlaunch marks the resolver as not launched again. Launch methods call
+// this when offering work fails so a later blockbeat can retry in-process.
+func (r *contractResolverKit) unlaunch() {
+	r.launched.Store(false)
+}
+
 var (
 	// errResolverShuttingDown is returned when the resolver stops
 	// progressing because it received the quit signal.

--- a/contractcourt/contract_resolver.go
+++ b/contractcourt/contract_resolver.go
@@ -168,9 +168,26 @@ func (r *contractResolverKit) markResolved() {
 	r.resolved.Store(true)
 }
 
-// unresolve marks the resolver as unresolved.
+// unresolve marks the resolver as unresolved again. This is used when a
+// terminal checkpoint fails after the resolver has prepared resolved state in
+// memory, but before that state is durably persisted.
 func (r *contractResolverKit) unresolve() {
 	r.resolved.Store(false)
+}
+
+// resolve persists a terminal resolver checkpoint. If persistence fails, the
+// in-memory resolved bit is cleared so callers can safely retry.
+func (r *contractResolverKit) resolve(resolver ContractResolver,
+	reports ...*channeldb.ResolverReport) error {
+
+	r.markResolved()
+	err := r.Checkpoint(resolver, reports...)
+	if err != nil {
+		r.unresolve()
+		return err
+	}
+
+	return nil
 }
 
 // isLaunched returns true if the resolver has been launched.

--- a/contractcourt/htlc_incoming_contest_resolver.go
+++ b/contractcourt/htlc_incoming_contest_resolver.go
@@ -270,7 +270,7 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 		// If the htlc resolution was a settle, apply the
 		// preimage and return a success resolver.
 		case *invoices.HtlcSettleResolution:
-			err := h.applyPreimage(resolution.Preimage)
+			err := h.storeAndApplyPreimage(resolution.Preimage)
 			if err != nil {
 				return nil, err
 			}
@@ -534,6 +534,28 @@ func (h *htlcIncomingContestResolver) applyPreimage(
 	}
 
 	return nil
+}
+
+// storeAndApplyPreimage persists an invoice-learned preimage before applying it
+// to the resolver. This gives relaunched success resolvers a durable source for
+// restoring their sweep preimage.
+func (h *htlcIncomingContestResolver) storeAndApplyPreimage(
+	preimage lntypes.Preimage) error {
+
+	if !preimage.Matches(h.htlc.RHash) {
+		return errors.New("preimage does not match hash")
+	}
+
+	if !h.hasAppliedPreimage() {
+		// AddPreimages is idempotent for an existing hash: the witness
+		// cache overwrites the same key and returns nil.
+		err := h.PreimageDB.AddPreimages(preimage)
+		if err != nil {
+			return err
+		}
+	}
+
+	return h.applyPreimage(preimage)
 }
 
 // report returns a report on the resolution state of the contract.

--- a/contractcourt/htlc_incoming_contest_resolver.go
+++ b/contractcourt/htlc_incoming_contest_resolver.go
@@ -126,11 +126,11 @@ func (h *htlcIncomingContestResolver) Launch() error {
 		return err
 	}
 
-	if uint32(bestHeight) >= h.htlcExpiry {
-		h.log.Infof("expired (height=%v, expiry=%v), leaving "+
-			"resolution to Resolve", bestHeight, h.htlcExpiry)
-
-		return nil
+	startExpired := uint32(bestHeight) >= h.htlcExpiry
+	if startExpired {
+		h.log.Infof("expired (height=%v, expiry=%v), only "+
+			"launching if a preimage was already known", bestHeight,
+			h.htlcExpiry)
 	}
 
 	// Query the preimage and apply it if we already know it.
@@ -156,7 +156,7 @@ func (h *htlcIncomingContestResolver) Launch() error {
 		return err
 	}
 
-	if uint32(bestHeight) >= h.htlcExpiry {
+	if !startExpired && uint32(bestHeight) >= h.htlcExpiry {
 		h.log.Infof("expired after applying preimage (height=%v, "+
 			"expiry=%v), skipping success launch", bestHeight,
 			h.htlcExpiry)

--- a/contractcourt/htlc_incoming_contest_resolver.go
+++ b/contractcourt/htlc_incoming_contest_resolver.go
@@ -90,9 +90,20 @@ func (h *htlcIncomingContestResolver) Launch() error {
 	}
 
 	h.log.Debugf("launching contest resolver...")
+	_, bestHeight, err := h.ChainIO.GetBestBlock()
+	if err != nil {
+		return err
+	}
+
+	if uint32(bestHeight) >= h.htlcExpiry {
+		h.log.Infof("expired (height=%v, expiry=%v), leaving "+
+			"resolution to Resolve", bestHeight, h.htlcExpiry)
+
+		return nil
+	}
 
 	// Query the preimage and apply it if we already know it.
-	applied, err := h.findAndapplyPreimage()
+	applied, err := h.findAndapplyPreimage(bestHeight)
 	if err != nil {
 		return err
 	}
@@ -615,7 +626,8 @@ var _ htlcContractResolver = (*htlcIncomingContestResolver)(nil)
 //
 // NOTE: Since we have two places to query the preimage, we need to check both
 // the preimage db and the invoice db to look up the preimage.
-func (h *htlcIncomingContestResolver) findAndapplyPreimage() (bool, error) {
+func (h *htlcIncomingContestResolver) findAndapplyPreimage(
+	currentHeight int32) (bool, error) {
 	// Query to see if we already know the preimage.
 	preimage, ok := h.PreimageDB.LookupPreimage(h.htlc.RHash)
 
@@ -658,13 +670,13 @@ func (h *htlcIncomingContestResolver) findAndapplyPreimage() (bool, error) {
 	// immediately, we'll assume we don't know it yet and let the `Resolve`
 	// handle the waiting.
 	//
-	// NOTE: we use a nil subscriber here and a zero current height as we
-	// are only interested in the settle resolution.
+	// NOTE: we use a nil subscriber here as we are only interested in the
+	// settle resolution.
 	//
 	// TODO(yy): move this logic to link and let the preimage be accessed
 	// via the preimage beacon.
 	resolution, err := h.Registry.NotifyExitHopHtlc(
-		h.htlc.RHash, h.htlc.Amt, h.htlcExpiry, 0,
+		h.htlc.RHash, h.htlc.Amt, h.htlcExpiry, currentHeight,
 		circuitKey, nil, h.htlc.CustomRecords, payload,
 	)
 	if err != nil {

--- a/contractcourt/htlc_incoming_contest_resolver.go
+++ b/contractcourt/htlc_incoming_contest_resolver.go
@@ -55,16 +55,43 @@ func newIncomingContestResolver(
 	}
 }
 
-func (h *htlcIncomingContestResolver) processFinalHtlcFail() error {
+// persistFinalHtlcFail persists that the HTLC reached a final failed outcome.
+// The corresponding notifier event is emitted only after the terminal resolver
+// checkpoint succeeds.
+func (h *htlcIncomingContestResolver) persistFinalHtlcFail() error {
 	// Mark the htlc as final failed.
 	err := h.ChainArbitratorConfig.PutFinalHtlcOutcome(
 		h.ChannelArbitratorConfig.ShortChanID, h.htlc.HtlcIndex, false,
 	)
+
+	return err
+}
+
+// checkpointFinalHtlcFail persists the failed outcome and terminal resolver
+// checkpoint, then notifies subscribers after the checkpoint is durable.
+func (h *htlcIncomingContestResolver) checkpointFinalHtlcFail(
+	outcome channeldb.ResolverOutcome) error {
+
+	err := h.persistFinalHtlcFail()
 	if err != nil {
 		return err
 	}
 
-	// Send notification.
+	report := h.report().resolverReport(
+		nil, channeldb.ResolverTypeIncomingHtlc, outcome,
+	)
+	err = h.resolve(h, report)
+	if err != nil {
+		return err
+	}
+
+	h.notifyFinalHtlcFail()
+
+	return nil
+}
+
+// notifyFinalHtlcFail emits the final failed HTLC outcome to subscribers.
+func (h *htlcIncomingContestResolver) notifyFinalHtlcFail() {
 	h.ChainArbitratorConfig.HtlcNotifier.NotifyFinalHtlcEvent(
 		models.CircuitKey{
 			ChanID: h.ShortChanID,
@@ -75,8 +102,6 @@ func (h *htlcIncomingContestResolver) processFinalHtlcFail() error {
 			Offchain: false,
 		},
 	)
-
-	return nil
 }
 
 // Launch will call the inner resolver's launch method if the preimage can be
@@ -172,19 +197,10 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 		// will time it out and get their funds back. This situation
 		// can present itself when we crash before processRemoteAdds in
 		// the link has ran.
-		h.markResolved()
 
-		if err := h.processFinalHtlcFail(); err != nil {
-			return nil, err
-		}
-
-		// We write a report to disk that indicates we could not decode
-		// the htlc.
-		resReport := h.report().resolverReport(
-			nil, channeldb.ResolverTypeIncomingHtlc,
+		return nil, h.checkpointFinalHtlcFail(
 			channeldb.ResolverOutcomeAbandoned,
 		)
-		return nil, h.PutResolverReport(nil, resReport)
 	}
 
 	// Register for block epochs. After registration, the current height
@@ -225,19 +241,10 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 		log.Infof("%T(%v): HTLC has timed out (expiry=%v, height=%v), "+
 			"abandoning", h, h.htlcResolution.ClaimOutpoint,
 			h.htlcExpiry, currentHeight)
-		h.markResolved()
 
-		if err := h.processFinalHtlcFail(); err != nil {
-			return nil, err
-		}
-
-		// Finally, get our report and checkpoint our resolver with a
-		// timeout outcome report.
-		report := h.report().resolverReport(
-			nil, channeldb.ResolverTypeIncomingHtlc,
+		return nil, h.checkpointFinalHtlcFail(
 			channeldb.ResolverOutcomeTimeout,
 		)
-		return nil, h.Checkpoint(h, report)
 	}
 
 	// Define a closure to process htlc resolutions either directly or
@@ -266,19 +273,9 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 				h.htlcResolution.ClaimOutpoint,
 				h.htlcExpiry, currentHeight)
 
-			h.markResolved()
-
-			if err := h.processFinalHtlcFail(); err != nil {
-				return nil, err
-			}
-
-			// Checkpoint our resolver with an abandoned outcome
-			// because we take no further action on this htlc.
-			report := h.report().resolverReport(
-				nil, channeldb.ResolverTypeIncomingHtlc,
+			return nil, h.checkpointFinalHtlcFail(
 				channeldb.ResolverOutcomeAbandoned,
 			)
-			return nil, h.Checkpoint(h, report)
 
 		// Error if the resolution type is unknown, we are only
 		// expecting settles and fails.
@@ -429,18 +426,9 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 					h.htlcResolution.ClaimOutpoint,
 					h.htlcExpiry, currentHeight)
 
-				h.markResolved()
-
-				if err := h.processFinalHtlcFail(); err != nil {
-					return nil, err
-				}
-
-				report := h.report().resolverReport(
-					nil,
-					channeldb.ResolverTypeIncomingHtlc,
+				return nil, h.checkpointFinalHtlcFail(
 					channeldb.ResolverOutcomeTimeout,
 				)
-				return nil, h.Checkpoint(h, report)
 			}
 
 		case <-h.quit:

--- a/contractcourt/htlc_incoming_contest_resolver.go
+++ b/contractcourt/htlc_incoming_contest_resolver.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync"
 
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/txscript"
@@ -37,6 +38,10 @@ type htlcIncomingContestResolver struct {
 	// htlcSuccessResolver is the inner resolver that may be utilized if we
 	// learn of the preimage.
 	*htlcSuccessResolver
+
+	// preimageLock synchronizes preimage application between Launch and
+	// Resolve, which can run concurrently on blockbeats.
+	preimageLock sync.Mutex
 }
 
 // newIncomingContestResolver instantiates a new incoming htlc contest resolver.
@@ -233,6 +238,13 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 	// preimage. Otherwise the resolver could potentially stay active
 	// indefinitely and the channel will never close properly.
 	if uint32(currentHeight) >= h.htlcExpiry {
+		// Launch may have already applied a known preimage and started
+		// the inner success resolver. Continue with it before
+		// treating the HTLC as timed out.
+		if h.hasAppliedPreimage() {
+			return h.htlcSuccessResolver, nil
+		}
+
 		// TODO(roasbeef): should also somehow check if outgoing is
 		// resolved or not
 		//  * may need to hook into the circuit map
@@ -421,6 +433,11 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 			// resolved and exit.
 			newHeight := uint32(newBlock.Height)
 			if newHeight >= h.htlcExpiry {
+				// Launch can set this while Resolve waits.
+				if h.hasAppliedPreimage() {
+					return h.htlcSuccessResolver, nil
+				}
+
 				log.Infof("%T(%v): HTLC has timed out "+
 					"(expiry=%v, height=%v), abandoning", h,
 					h.htlcResolution.ClaimOutpoint,
@@ -437,6 +454,15 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 	}
 }
 
+// hasAppliedPreimage returns true if Launch or Resolve already attached the
+// HTLC preimage to the inner success resolver.
+func (h *htlcIncomingContestResolver) hasAppliedPreimage() bool {
+	h.preimageLock.Lock()
+	defer h.preimageLock.Unlock()
+
+	return h.htlcResolution.Preimage != lntypes.ZeroHash
+}
+
 // applyPreimage is a helper function that will populate our internal resolver
 // with the preimage we learn of. This should be called once the preimage is
 // revealed so the inner resolver can properly complete its duties. The error
@@ -449,6 +475,9 @@ func (h *htlcIncomingContestResolver) applyPreimage(
 	if !preimage.Matches(h.htlc.RHash) {
 		return errors.New("preimage does not match hash")
 	}
+
+	h.preimageLock.Lock()
+	defer h.preimageLock.Unlock()
 
 	// We may already have the preimage since both the `Launch` and
 	// `Resolve` methods will look for it.

--- a/contractcourt/htlc_incoming_contest_resolver.go
+++ b/contractcourt/htlc_incoming_contest_resolver.go
@@ -16,6 +16,7 @@ import (
 	"github.com/lightningnetwork/lnd/htlcswitch/hop"
 	"github.com/lightningnetwork/lnd/invoices"
 	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnutils"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/queue"
@@ -716,44 +717,102 @@ func (h *htlcIncomingContestResolver) findAndapplyPreimage(
 		return false, nil
 	}
 
-	// Notify registry that we are potentially resolving as an exit hop
-	// on-chain. If this HTLC indeed pays to an existing invoice, the
-	// invoice registry will tell us what to do with the HTLC. This is
-	// identical to HTLC resolution in the link.
-	circuitKey := models.CircuitKey{
-		ChanID: h.ShortChanID,
-		HtlcID: h.htlc.HtlcIndex,
-	}
-
-	// Try get the resolution - if it doesn't give us a resolution
-	// immediately, we'll assume we don't know it yet and let the `Resolve`
-	// handle the waiting.
-	//
-	// NOTE: we use a nil subscriber here as we are only interested in the
-	// settle resolution.
-	//
-	// TODO(yy): move this logic to link and let the preimage be accessed
-	// via the preimage beacon.
-	resolution, err := h.Registry.NotifyExitHopHtlc(
-		h.htlc.RHash, h.htlc.Amt, h.htlcExpiry, currentHeight,
-		circuitKey, nil, h.htlc.CustomRecords, payload,
-	)
+	invoicePreimage, ok, err := h.lookupReplayedInvoicePreimage(payload)
 	if err != nil {
 		return false, err
 	}
-
-	res, ok := resolution.(*invoices.HtlcSettleResolution)
-
-	// Exit early if it's not a settle resolution.
 	if !ok {
 		return false, nil
 	}
 
-	// Otherwise we have a settle resolution, apply the preimage.
-	err = h.applyPreimage(res.Preimage)
+	// Otherwise this exact HTLC was already settled, store and apply the
+	// preimage.
+	err = h.storeAndApplyPreimage(invoicePreimage)
 	if err != nil {
 		return false, err
 	}
 
 	return true, nil
+}
+
+// lookupReplayedInvoicePreimage looks up the invoice without mutating registry
+// state and returns a preimage only if this exact circuit was already settled.
+func (h *htlcIncomingContestResolver) lookupReplayedInvoicePreimage(
+	payload invoices.Payload) (lntypes.Preimage, bool, error) {
+
+	// Resolve will run NotifyExitHopHtlc with the real height. Launch only
+	// needs preimages from this exact circuit if it was already settled
+	// before this resolver started.
+	invoiceRef := invoiceRefForPayload(h.htlc.RHash, payload)
+	ctx, cancel := lnutils.ContextFromQuit(h.quit)
+	defer cancel()
+
+	invoice, err := h.Registry.LookupInvoiceByRef(
+		ctx, invoiceRef,
+	)
+	switch {
+	case err == nil:
+	case errors.Is(err, invoices.ErrInvoiceNotFound) ||
+		errors.Is(err, invoices.ErrNoInvoicesCreated):
+
+		return lntypes.Preimage{}, false, nil
+	default:
+		return lntypes.Preimage{}, false, err
+	}
+
+	circuitKey := models.CircuitKey{
+		ChanID: h.ShortChanID,
+		HtlcID: h.htlc.HtlcIndex,
+	}
+	preimage, ok := replayedInvoicePreimage(invoice, circuitKey)
+
+	return preimage, ok, nil
+}
+
+// invoiceRefForPayload returns the same invoice reference that the invoice
+// registry uses for this exit-hop payload.
+func invoiceRefForPayload(hash lntypes.Hash,
+	payload invoices.Payload) invoices.InvoiceRef {
+
+	mpp := payload.MultiPath()
+	amp := payload.AMPRecord()
+	pathID := payload.PathID()
+
+	switch {
+	case pathID != nil:
+		return invoices.InvoiceRefByHashAndAddr(hash, *pathID)
+
+	case amp != nil && mpp != nil:
+		payAddr := mpp.PaymentAddr()
+		return invoices.InvoiceRefByAddr(payAddr)
+
+	case mpp != nil:
+		payAddr := mpp.PaymentAddr()
+		return invoices.InvoiceRefByHashAndAddr(hash, payAddr)
+
+	default:
+		return invoices.InvoiceRefByHash(hash)
+	}
+}
+
+// replayedInvoicePreimage returns the preimage for this exact circuit if it was
+// already settled on the invoice.
+func replayedInvoicePreimage(invoice invoices.Invoice,
+	circuitKey models.CircuitKey) (lntypes.Preimage, bool) {
+
+	htlc, ok := invoice.Htlcs[circuitKey]
+	if !ok || htlc.State != invoices.HtlcStateSettled {
+		return lntypes.Preimage{}, false
+	}
+
+	preimage := invoice.Terms.PaymentPreimage
+	if preimage == nil {
+		if htlc.AMP == nil || htlc.AMP.Preimage == nil {
+			return lntypes.Preimage{}, false
+		}
+
+		preimage = htlc.AMP.Preimage
+	}
+
+	return *preimage, true
 }

--- a/contractcourt/htlc_incoming_contest_resolver.go
+++ b/contractcourt/htlc_incoming_contest_resolver.go
@@ -113,6 +113,26 @@ func (h *htlcIncomingContestResolver) Launch() error {
 		return nil
 	}
 
+	if h.IsResolved() {
+		h.log.Debugf("resolver resolved after applying preimage for htlc=%x",
+			h.htlc.RHash)
+
+		return nil
+	}
+
+	_, bestHeight, err = h.ChainIO.GetBestBlock()
+	if err != nil {
+		return err
+	}
+
+	if uint32(bestHeight) >= h.htlcExpiry {
+		h.log.Infof("expired after applying preimage (height=%v, "+
+			"expiry=%v), skipping success launch", bestHeight,
+			h.htlcExpiry)
+
+		return nil
+	}
+
 	h.log.Debugf("found preimage for htlc=%x,  transforming into success "+
 		"resolver and launching it", h.htlc.RHash)
 

--- a/contractcourt/htlc_incoming_contest_resolver_test.go
+++ b/contractcourt/htlc_incoming_contest_resolver_test.go
@@ -116,6 +116,93 @@ func TestHtlcIncomingResolverFwdTimeout(t *testing.T) {
 	ctx.waitForResult(false)
 }
 
+func TestHtlcIncomingResolverLaunchSkipsPreimageAfterExpiry(t *testing.T) {
+	t.Parallel()
+	defer timeout()()
+
+	tests := []struct {
+		name   string
+		isExit bool
+		setup  func(*incomingResolverTestContext)
+		assert func(*testing.T, *incomingResolverTestContext)
+	}{
+		{
+			name:   "preimage db",
+			isExit: false,
+			setup: func(ctx *incomingResolverTestContext) {
+				ctx.witnessBeacon.lookupPreimage[testResHash] =
+					testResPreimage
+			},
+			assert: func(t *testing.T,
+				ctx *incomingResolverTestContext) {
+
+				require.Empty(t, ctx.registry.immediateNotify)
+			},
+		},
+		{
+			name:   "invoice registry",
+			isExit: true,
+			setup: func(ctx *incomingResolverTestContext) {
+				ctx.registry.notifyResolution =
+					invoices.NewSettleResolution(
+						testResPreimage,
+						testResCircuitKey,
+						testAcceptHeight,
+						invoices.ResultReplayToSettled,
+					)
+			},
+			assert: func(t *testing.T,
+				ctx *incomingResolverTestContext) {
+
+				require.Empty(t, ctx.registry.immediateNotify)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Arrange.
+			ctx := newIncomingResolverTestContext(t, test.isExit)
+			ctx.resolver.htlcExpiry = testInitialBlockHeight
+			test.setup(ctx)
+
+			// Act.
+			require.NoError(t, ctx.resolver.Launch())
+
+			// Assert.
+			require.False(t, ctx.resolver.isLaunched())
+			require.Equal(
+				t, [32]byte{},
+				ctx.resolver.htlcResolution.Preimage,
+			)
+			test.assert(t, ctx)
+		})
+	}
+}
+
+func TestHtlcIncomingResolverLaunchUsesCurrentHeight(t *testing.T) {
+	t.Parallel()
+	defer timeout()()
+
+	// Arrange.
+	ctx := newIncomingResolverTestContext(t, true)
+	ctx.chainIO.BestHeight = testInitialBlockHeight + 1
+	ctx.registry.notifyResolution = invoices.NewSettleResolution(
+		testResPreimage, testResCircuitKey, testAcceptHeight,
+		invoices.ResultReplayToSettled,
+	)
+
+	// Act.
+	require.NoError(t, ctx.resolver.Launch())
+
+	// Assert.
+	require.Len(t, ctx.registry.immediateNotify, 1)
+	require.Equal(
+		t, ctx.chainIO.BestHeight,
+		ctx.registry.immediateNotify[0].currentHeight,
+	)
+}
+
 // TestHtlcIncomingResolverExitSettle tests resolution of an exit hop htlc for
 // which the invoice has already been settled when the resolver starts.
 func TestHtlcIncomingResolverExitSettle(t *testing.T) {
@@ -306,6 +393,7 @@ type incomingResolverTestContext struct {
 	witnessBeacon          *mockWitnessBeacon
 	resolver               *htlcIncomingContestResolver
 	notifier               *mock.ChainNotifier
+	chainIO                *mock.ChainIO
 	onionProcessor         *mockOnionProcessor
 	resolveErr             chan error
 	nextResolver           ContractResolver
@@ -320,6 +408,9 @@ func newIncomingResolverTestContext(t *testing.T, isExit bool) *incomingResolver
 		ConfChan:  make(chan *chainntnfs.TxConfirmation),
 	}
 	witnessBeacon := newMockWitnessBeacon()
+	chainIO := &mock.ChainIO{
+		BestHeight: testInitialBlockHeight,
+	}
 	registry := &mockRegistry{
 		notifyChan: make(chan notifyExitHopData, 1),
 	}
@@ -332,6 +423,7 @@ func newIncomingResolverTestContext(t *testing.T, isExit bool) *incomingResolver
 		registry:       registry,
 		witnessBeacon:  witnessBeacon,
 		notifier:       notifier,
+		chainIO:        chainIO,
 		onionProcessor: onionProcessor,
 		t:              t,
 	}
@@ -359,6 +451,7 @@ func newIncomingResolverTestContext(t *testing.T, isExit bool) *incomingResolver
 				return nil
 			},
 			Sweeper: newMockSweeper(),
+			ChainIO: chainIO,
 		},
 		PutResolverReport: func(_ kvdb.RwTx,
 			_ *channeldb.ResolverReport) error {

--- a/contractcourt/htlc_incoming_contest_resolver_test.go
+++ b/contractcourt/htlc_incoming_contest_resolver_test.go
@@ -44,7 +44,7 @@ func TestHtlcIncomingResolverFwdPreimageKnown(t *testing.T) {
 	defer timeout()()
 
 	ctx := newIncomingResolverTestContext(t, false)
-	ctx.witnessBeacon.lookupPreimage[testResHash] = testResPreimage
+	ctx.witnessBeacon.setLookupPreimage(testResHash, testResPreimage)
 	ctx.resolve()
 	ctx.waitForResult(true)
 }
@@ -111,8 +111,7 @@ func TestHtlcIncomingResolverFwdTimeout(t *testing.T) {
 	t.Parallel()
 	defer timeout()()
 
-	ctx := newIncomingResolverTestContext(t, true)
-	ctx.witnessBeacon.lookupPreimage[testResHash] = testResPreimage
+	ctx := newIncomingResolverTestContext(t, false)
 	ctx.resolver.htlcExpiry = 90
 	ctx.resolve()
 	ctx.waitForResult(false)
@@ -264,6 +263,62 @@ func TestHtlcIncomingResolverFailCheckpointErrorSkipsFinalEvent(t *testing.T) {
 	case <-ctx.finalHtlcEvents:
 		t.Fatal("unexpected final htlc event")
 	default:
+	}
+}
+
+// TestHtlcIncomingResolverBlockEpochUsesLaunchedPreimageAfterExpiry asserts
+// that Resolve continues with the success resolver if a blockbeat Launch
+// applies the preimage while Resolve is already waiting for block epochs.
+func TestHtlcIncomingResolverBlockEpochUsesLaunchedPreimageAfterExpiry(
+	t *testing.T) {
+
+	t.Parallel()
+	defer timeout()()
+
+	ctx := newIncomingResolverTestContext(t, false)
+	ctx.resolver.htlcExpiry = testInitialBlockHeight + 1
+	lookupSignal := make(chan lntypes.Hash, 1)
+	ctx.witnessBeacon.lookupSignal = lookupSignal
+
+	resolveResultChan := make(chan resolveResult, 1)
+	go func() {
+		nextResolver, err := ctx.resolver.Resolve()
+		resolveResultChan <- resolveResult{
+			nextResolver: nextResolver,
+			err:          err,
+		}
+	}()
+	ctx.notifyEpoch(testInitialBlockHeight)
+
+	select {
+	case hash := <-lookupSignal:
+		require.Equal(t, testResHash, hash)
+	case <-time.After(time.Second):
+		t.Fatal("expected resolve preimage lookup")
+	}
+
+	ctx.witnessBeacon.setLookupPreimage(testResHash, testResPreimage)
+	require.NoError(t, ctx.resolver.Launch())
+
+	sweeper, ok := ctx.resolver.Sweeper.(*mockSweeper)
+	require.True(t, ok)
+	select {
+	case <-sweeper.sweptInputs:
+	case <-time.After(time.Second):
+		t.Fatal("expected launched preimage sweep")
+	}
+
+	ctx.notifyEpoch(testInitialBlockHeight + 1)
+
+	select {
+	case result := <-resolveResultChan:
+		require.NoError(t, result.err)
+		require.Same(
+			t, ctx.resolver.htlcSuccessResolver,
+			result.nextResolver,
+		)
+	case <-time.After(time.Second):
+		t.Fatal("expected launched success resolver")
 	}
 }
 

--- a/contractcourt/htlc_incoming_contest_resolver_test.go
+++ b/contractcourt/htlc_incoming_contest_resolver_test.go
@@ -2,8 +2,10 @@ package contractcourt
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/wire"
 	sphinx "github.com/lightningnetwork/lightning-onion"
@@ -231,6 +233,40 @@ func TestHtlcIncomingResolverLaunchSkipsSuccessAfterLookupExpiry(
 	require.Len(t, ctx.registry.immediateNotify, 1)
 }
 
+// TestHtlcIncomingResolverFailCheckpointErrorSkipsFinalEvent asserts that
+// final failed HTLC events are emitted only after the terminal checkpoint is
+// durably persisted.
+func TestHtlcIncomingResolverFailCheckpointErrorSkipsFinalEvent(t *testing.T) {
+	t.Parallel()
+	defer timeout()()
+
+	checkpointErr := errors.New("checkpoint failed")
+	ctx := newIncomingResolverTestContext(t, false)
+	ctx.resolver.htlcExpiry = testInitialBlockHeight
+	ctx.resolver.Checkpoint = func(_ ContractResolver,
+		_ ...*channeldb.ResolverReport) error {
+
+		return checkpointErr
+	}
+
+	ctx.resolve()
+
+	select {
+	case err := <-ctx.resolveErr:
+		require.ErrorIs(t, err, checkpointErr)
+	case <-time.After(time.Second):
+		t.Fatal("expected checkpoint error")
+	}
+
+	require.True(t, ctx.finalHtlcOutcomeStored)
+	require.False(t, ctx.resolver.IsResolved())
+	select {
+	case <-ctx.finalHtlcEvents:
+		t.Fatal("unexpected final htlc event")
+	default:
+	}
+}
+
 // TestHtlcIncomingResolverExitSettle tests resolution of an exit hop htlc for
 // which the invoice has already been settled when the resolver starts.
 func TestHtlcIncomingResolverExitSettle(t *testing.T) {
@@ -416,6 +452,16 @@ func (o *mockOnionProcessor) ReconstructHopIterator(r io.Reader, rHash []byte,
 	return &mockHopIterator{isExit: o.isExit}, nil
 }
 
+type incomingFinalHtlcNotifier struct {
+	events chan struct{}
+}
+
+func (i *incomingFinalHtlcNotifier) NotifyFinalHtlcEvent(
+	_ models.CircuitKey, _ channeldb.FinalHtlcInfo) {
+
+	i.events <- struct{}{}
+}
+
 type incomingResolverTestContext struct {
 	registry               *mockRegistry
 	witnessBeacon          *mockWitnessBeacon
@@ -423,6 +469,7 @@ type incomingResolverTestContext struct {
 	notifier               *mock.ChainNotifier
 	chainIO                *mock.ChainIO
 	onionProcessor         *mockOnionProcessor
+	finalHtlcEvents        chan struct{}
 	resolveErr             chan error
 	nextResolver           ContractResolver
 	finalHtlcOutcomeStored bool
@@ -444,19 +491,19 @@ func newIncomingResolverTestContext(t *testing.T, isExit bool) *incomingResolver
 	}
 
 	onionProcessor := &mockOnionProcessor{isExit: isExit}
+	finalHtlcEvents := make(chan struct{}, 1)
 
 	checkPointChan := make(chan struct{}, 1)
 
 	c := &incomingResolverTestContext{
-		registry:       registry,
-		witnessBeacon:  witnessBeacon,
-		notifier:       notifier,
-		chainIO:        chainIO,
-		onionProcessor: onionProcessor,
-		t:              t,
+		registry:        registry,
+		witnessBeacon:   witnessBeacon,
+		notifier:        notifier,
+		chainIO:         chainIO,
+		onionProcessor:  onionProcessor,
+		finalHtlcEvents: finalHtlcEvents,
+		t:               t,
 	}
-
-	htlcNotifier := &mockHTLCNotifier{}
 
 	chainCfg := ChannelArbitratorConfig{
 		ChainArbitratorConfig: ChainArbitratorConfig{
@@ -471,8 +518,10 @@ func newIncomingResolverTestContext(t *testing.T, isExit bool) *incomingResolver
 
 				return nil
 			},
-			HtlcNotifier: htlcNotifier,
-			Budget:       *DefaultBudgetConfig(),
+			HtlcNotifier: &incomingFinalHtlcNotifier{
+				events: finalHtlcEvents,
+			},
+			Budget: *DefaultBudgetConfig(),
 			QueryIncomingCircuit: func(
 				circuit models.CircuitKey) *models.CircuitKey {
 

--- a/contractcourt/htlc_incoming_contest_resolver_test.go
+++ b/contractcourt/htlc_incoming_contest_resolver_test.go
@@ -203,6 +203,34 @@ func TestHtlcIncomingResolverLaunchUsesCurrentHeight(t *testing.T) {
 	)
 }
 
+func TestHtlcIncomingResolverLaunchSkipsSuccessAfterLookupExpiry(
+	t *testing.T) {
+
+	t.Parallel()
+	defer timeout()()
+
+	// Arrange.
+	ctx := newIncomingResolverTestContext(t, true)
+	ctx.registry.notifyResolution = invoices.NewSettleResolution(
+		testResPreimage, testResCircuitKey, testAcceptHeight,
+		invoices.ResultReplayToSettled,
+	)
+	ctx.registry.notifyHook = func() {
+		ctx.chainIO.BestHeight = testHtlcExpiry
+	}
+
+	// Act.
+	require.NoError(t, ctx.resolver.Launch())
+
+	// Assert.
+	require.False(t, ctx.resolver.isLaunched())
+	require.Equal(
+		t, [32]byte(testResPreimage),
+		ctx.resolver.htlcResolution.Preimage,
+	)
+	require.Len(t, ctx.registry.immediateNotify, 1)
+}
+
 // TestHtlcIncomingResolverExitSettle tests resolution of an exit hop htlc for
 // which the invoice has already been settled when the resolver starts.
 func TestHtlcIncomingResolverExitSettle(t *testing.T) {

--- a/contractcourt/htlc_incoming_contest_resolver_test.go
+++ b/contractcourt/htlc_incoming_contest_resolver_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/record"
 	"github.com/stretchr/testify/require"
 )
 
@@ -111,9 +112,15 @@ func TestHtlcIncomingResolverFwdTimeout(t *testing.T) {
 	t.Parallel()
 	defer timeout()()
 
+	// Arrange: start an already expired forwarded HTLC without a known
+	// preimage.
 	ctx := newIncomingResolverTestContext(t, false)
 	ctx.resolver.htlcExpiry = 90
+
+	// Act: resolve the expired HTLC.
 	ctx.resolve()
+
+	// Assert: no success resolver is returned and the HTLC is failed.
 	ctx.waitForResult(false)
 }
 
@@ -266,6 +273,123 @@ func TestHtlcIncomingResolverFailCheckpointErrorSkipsFinalEvent(t *testing.T) {
 	}
 }
 
+// TestHtlcIncomingResolverLaunchUsesKnownPreimageAfterExpiry asserts that
+// Launch still offers the HTLC to the sweeper when the preimage was already
+// learned before restart, even if the HTLC is now expired.
+func TestHtlcIncomingResolverLaunchUsesKnownPreimageAfterExpiry(t *testing.T) {
+	t.Parallel()
+	defer timeout()()
+
+	tests := []struct {
+		name   string
+		isExit bool
+		setup  func(*incomingResolverTestContext)
+		assert func(*testing.T, *incomingResolverTestContext)
+	}{
+		{
+			name:   "preimage db",
+			isExit: false,
+			setup: func(ctx *incomingResolverTestContext) {
+				ctx.witnessBeacon.setLookupPreimage(
+					testResHash,
+					testResPreimage,
+				)
+			},
+			assert: func(t *testing.T,
+				ctx *incomingResolverTestContext) {
+
+				require.Empty(t, ctx.registry.immediateNotify)
+			},
+		},
+		{
+			name:   "settled invoice lookup",
+			isExit: true,
+			setup: func(ctx *incomingResolverTestContext) {
+				ctx.registry.lookupInvoiceSet = true
+				ctx.registry.lookupInvoice =
+					settledTestInvoice()
+			},
+			assert: func(t *testing.T,
+				ctx *incomingResolverTestContext) {
+
+				require.Equal(t, 1, ctx.registry.lookupCount)
+				require.Empty(t, ctx.registry.immediateNotify)
+			},
+		},
+		{
+			name:   "settled AMP invoice lookup",
+			isExit: true,
+			setup: func(ctx *incomingResolverTestContext) {
+				ctx.onionProcessor.payload = ampTestPayload()
+				ctx.registry.lookupInvoiceSet = true
+				ctx.registry.lookupInvoice =
+					settledAMPTestInvoice()
+			},
+			assert: func(t *testing.T,
+				ctx *incomingResolverTestContext) {
+
+				require.Equal(t, 1, ctx.registry.lookupCount)
+				require.Empty(t, ctx.registry.immediateNotify)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Arrange: restart at the HTLC expiry with the preimage
+			// already available from this test's source.
+			ctx := newIncomingResolverTestContext(t, test.isExit)
+			ctx.resolver.htlcExpiry = testInitialBlockHeight
+			test.setup(ctx)
+
+			// Act: launch the resolver, then enter the production
+			// Resolve path at the HTLC expiry height.
+			require.NoError(t, ctx.resolver.Launch())
+			resolveResultChan := make(chan resolveResult, 1)
+			go func() {
+				nextResolver, err := ctx.resolver.Resolve()
+				resolveResultChan <- resolveResult{
+					nextResolver: nextResolver,
+					err:          err,
+				}
+			}()
+			ctx.notifyEpoch(testInitialBlockHeight)
+
+			// Assert: the known preimage still starts a sweep after
+			// expiry. Resolve also returns the launched success
+			// resolver instead of timing out.
+			require.True(t, ctx.resolver.isLaunched())
+			preimage := lntypes.Preimage(
+				ctx.resolver.htlcResolution.Preimage,
+			)
+			require.Equal(
+				t, testResPreimage, preimage,
+			)
+
+			sweeper, ok := ctx.resolver.Sweeper.(*mockSweeper)
+			require.True(t, ok)
+			select {
+			case <-sweeper.sweptInputs:
+			case <-time.After(time.Second):
+				t.Fatal("expected known preimage sweep")
+			}
+
+			select {
+			case result := <-resolveResultChan:
+				require.NoError(t, result.err)
+				require.Same(
+					t, ctx.resolver.htlcSuccessResolver,
+					result.nextResolver,
+				)
+			case <-time.After(time.Second):
+				t.Fatal("expected launched success resolver")
+			}
+
+			test.assert(t, ctx)
+		})
+	}
+}
+
 // TestHtlcIncomingResolverBlockEpochUsesLaunchedPreimageAfterExpiry asserts
 // that Resolve continues with the success resolver if a blockbeat Launch
 // applies the preimage while Resolve is already waiting for block epochs.
@@ -319,6 +443,156 @@ func TestHtlcIncomingResolverBlockEpochUsesLaunchedPreimageAfterExpiry(
 		)
 	case <-time.After(time.Second):
 		t.Fatal("expected launched success resolver")
+	}
+}
+
+// TestHtlcIncomingResolverLaunchIgnoresOtherSettledCircuitAfterExpiry asserts
+// that Launch only consumes settled invoices for this exact circuit.
+func TestHtlcIncomingResolverLaunchIgnoresOtherSettledCircuitAfterExpiry(
+	t *testing.T) {
+
+	t.Parallel()
+	defer timeout()()
+
+	// Arrange: set up an expired exit-hop resolver where another HTLC on
+	// the same invoice has already settled.
+	ctx := newIncomingResolverTestContext(t, true)
+	ctx.resolver.htlcExpiry = testInitialBlockHeight
+	ctx.registry.lookupInvoiceSet = true
+	ctx.registry.lookupInvoice = settledOtherCircuitTestInvoice()
+
+	// Act: launch runs the immediate lookup, then Resolve runs at expiry.
+	require.NoError(t, ctx.resolver.Launch())
+	ctx.resolveErr = make(chan error, 1)
+	go func() {
+		var err error
+		ctx.nextResolver, err = ctx.resolver.Resolve()
+		ctx.resolveErr <- err
+	}()
+	ctx.notifyEpoch(testInitialBlockHeight)
+
+	// Assert: the other settled HTLC was not consumed by Launch and the
+	// expired HTLC fails rather than returning a success resolver.
+	require.Equal(t, 1, ctx.registry.lookupCount)
+	require.Empty(t, ctx.registry.immediateNotify)
+	require.False(t, ctx.resolver.isLaunched())
+	ctx.waitForResult(false)
+}
+
+// TestHtlcIncomingResolverLaunchUsesSideEffectFreeLookup asserts that Launch
+// uses a side-effect-free invoice-registry lookup.
+func TestHtlcIncomingResolverLaunchUsesSideEffectFreeLookup(t *testing.T) {
+	t.Parallel()
+	defer timeout()()
+
+	// Arrange: set up an expired exit-hop resolver with a settled invoice
+	// that Launch can consume immediately.
+	ctx := newIncomingResolverTestContext(t, true)
+	ctx.resolver.htlcExpiry = testInitialBlockHeight
+	ctx.chainIO.BestHeight = testInitialBlockHeight + 1
+	ctx.registry.lookupInvoiceSet = true
+	ctx.registry.lookupInvoice = settledTestInvoice()
+
+	// Act: launch performs the immediate invoice lookup.
+	require.NoError(t, ctx.resolver.Launch())
+
+	// Assert: the immediate lookup did not use the mutating registry path.
+	require.Equal(t, 1, ctx.registry.lookupCount)
+	require.Empty(t, ctx.registry.immediateNotify)
+	require.True(t, ctx.resolver.isLaunched())
+}
+
+// TestHtlcIncomingResolverLaunchIgnoresOpenInvoiceAfterExpiry asserts that an
+// immediate launch-time invoice lookup does not bypass expiry checks by
+// consuming an open invoice.
+func TestHtlcIncomingResolverLaunchIgnoresOpenInvoiceAfterExpiry(t *testing.T) {
+	t.Parallel()
+	defer timeout()()
+
+	// Arrange: set up an expired exit-hop resolver where the invoice lookup
+	// finds an open invoice with a known preimage.
+	ctx := newIncomingResolverTestContext(t, true)
+	ctx.resolver.htlcExpiry = testInitialBlockHeight
+	ctx.registry.lookupInvoiceSet = true
+	ctx.registry.lookupInvoice = invoices.Invoice{
+		State: invoices.ContractOpen,
+		Terms: invoices.ContractTerm{
+			PaymentPreimage: &testResPreimage,
+		},
+	}
+
+	// Act: launch runs the immediate lookup, then Resolve runs at expiry.
+	require.NoError(t, ctx.resolver.Launch())
+	ctx.resolveErr = make(chan error, 1)
+	go func() {
+		var err error
+		ctx.nextResolver, err = ctx.resolver.Resolve()
+		ctx.resolveErr <- err
+	}()
+	ctx.notifyEpoch(testInitialBlockHeight)
+
+	// Assert: the open invoice was not consumed by Launch and the expired
+	// HTLC fails rather than returning a success resolver.
+	require.Equal(t, 1, ctx.registry.lookupCount)
+	require.Empty(t, ctx.registry.immediateNotify)
+	require.False(t, ctx.resolver.isLaunched())
+	ctx.waitForResult(false)
+}
+
+// settledTestInvoice returns a settled invoice with the test preimage.
+func settledTestInvoice() invoices.Invoice {
+	return invoices.Invoice{
+		State: invoices.ContractSettled,
+		Terms: invoices.ContractTerm{
+			PaymentPreimage: &testResPreimage,
+		},
+		Htlcs: map[models.CircuitKey]*invoices.InvoiceHTLC{
+			testResCircuitKey: {
+				State: invoices.HtlcStateSettled,
+			},
+		},
+	}
+}
+
+// settledOtherCircuitTestInvoice returns a settled invoice whose settled HTLC
+// is not the circuit used by the resolver.
+func settledOtherCircuitTestInvoice() invoices.Invoice {
+	invoice := settledTestInvoice()
+	invoice.Htlcs = map[models.CircuitKey]*invoices.InvoiceHTLC{
+		{HtlcID: 99}: {
+			State: invoices.HtlcStateSettled,
+		},
+	}
+
+	return invoice
+}
+
+// settledAMPTestInvoice returns a settled AMP invoice with the test preimage on
+// the exact HTLC rather than the invoice terms.
+func settledAMPTestInvoice() invoices.Invoice {
+	return invoices.Invoice{
+		State: invoices.ContractSettled,
+		Htlcs: map[models.CircuitKey]*invoices.InvoiceHTLC{
+			testResCircuitKey: {
+				State: invoices.HtlcStateSettled,
+				AMP: &invoices.InvoiceHtlcAMPData{
+					Preimage: &testResPreimage,
+				},
+			},
+		},
+	}
+}
+
+// ampTestPayload returns an exit-hop AMP payload.
+func ampTestPayload() *hop.Payload {
+	return &hop.Payload{
+		FwdInfo: hop.ForwardingInfo{
+			NextHop: hop.Exit,
+		},
+		MPP: record.NewMPP(
+			lnwire.MilliSatoshi(testHtlcAmount), [32]byte{1},
+		),
+		AMP: record.NewAMP([32]byte{2}, [32]byte{3}, 4),
 	}
 }
 
@@ -467,11 +741,16 @@ func TestHtlcIncomingResolverExitCancelHodl(t *testing.T) {
 }
 
 type mockHopIterator struct {
-	isExit bool
+	isExit  bool
+	payload *hop.Payload
 	hop.Iterator
 }
 
 func (h *mockHopIterator) HopPayload() (*hop.Payload, hop.RouteRole, error) {
+	if h.payload != nil {
+		return h.payload, hop.RouteRoleCleartext, nil
+	}
+
 	var nextAddress [8]byte
 	if !h.isExit {
 		nextAddress = [8]byte{0x01}
@@ -492,6 +771,7 @@ func (h *mockHopIterator) EncodeNextHop(w io.Writer) error {
 
 type mockOnionProcessor struct {
 	isExit           bool
+	payload          *hop.Payload
 	offeredOnionBlob []byte
 }
 
@@ -504,7 +784,7 @@ func (o *mockOnionProcessor) ReconstructHopIterator(r io.Reader, rHash []byte,
 	}
 	o.offeredOnionBlob = data
 
-	return &mockHopIterator{isExit: o.isExit}, nil
+	return &mockHopIterator{isExit: o.isExit, payload: o.payload}, nil
 }
 
 type incomingFinalHtlcNotifier struct {

--- a/contractcourt/htlc_incoming_contest_resolver_test.go
+++ b/contractcourt/htlc_incoming_contest_resolver_test.go
@@ -124,46 +124,25 @@ func TestHtlcIncomingResolverFwdTimeout(t *testing.T) {
 	ctx.waitForResult(false)
 }
 
-func TestHtlcIncomingResolverLaunchSkipsPreimageAfterExpiry(t *testing.T) {
+func TestHtlcIncomingResolverLaunchSkipsUnknownPreimageAfterExpiry(
+	t *testing.T) {
+
 	t.Parallel()
 	defer timeout()()
 
 	tests := []struct {
-		name   string
-		isExit bool
-		setup  func(*incomingResolverTestContext)
-		assert func(*testing.T, *incomingResolverTestContext)
+		name         string
+		isExit       bool
+		expectLookup bool
 	}{
 		{
-			name:   "preimage db",
+			name:   "forwarded",
 			isExit: false,
-			setup: func(ctx *incomingResolverTestContext) {
-				ctx.witnessBeacon.lookupPreimage[testResHash] =
-					testResPreimage
-			},
-			assert: func(t *testing.T,
-				ctx *incomingResolverTestContext) {
-
-				require.Empty(t, ctx.registry.immediateNotify)
-			},
 		},
 		{
-			name:   "invoice registry",
-			isExit: true,
-			setup: func(ctx *incomingResolverTestContext) {
-				ctx.registry.notifyResolution =
-					invoices.NewSettleResolution(
-						testResPreimage,
-						testResCircuitKey,
-						testAcceptHeight,
-						invoices.ResultReplayToSettled,
-					)
-			},
-			assert: func(t *testing.T,
-				ctx *incomingResolverTestContext) {
-
-				require.Empty(t, ctx.registry.immediateNotify)
-			},
+			name:         "exit hop missing invoice",
+			isExit:       true,
+			expectLookup: true,
 		},
 	}
 
@@ -172,7 +151,6 @@ func TestHtlcIncomingResolverLaunchSkipsPreimageAfterExpiry(t *testing.T) {
 			// Arrange.
 			ctx := newIncomingResolverTestContext(t, test.isExit)
 			ctx.resolver.htlcExpiry = testInitialBlockHeight
-			test.setup(ctx)
 
 			// Act.
 			require.NoError(t, ctx.resolver.Launch())
@@ -183,32 +161,35 @@ func TestHtlcIncomingResolverLaunchSkipsPreimageAfterExpiry(t *testing.T) {
 				t, [32]byte{},
 				ctx.resolver.htlcResolution.Preimage,
 			)
-			test.assert(t, ctx)
+			require.Empty(t, ctx.registry.immediateNotify)
+			if test.expectLookup {
+				require.Equal(t, 1, ctx.registry.lookupCount)
+			} else {
+				require.Zero(t, ctx.registry.lookupCount)
+			}
 		})
 	}
 }
 
-func TestHtlcIncomingResolverLaunchUsesCurrentHeight(t *testing.T) {
+func TestHtlcIncomingResolverLaunchUsesSideEffectFreeLookupBeforeExpiry(
+	t *testing.T) {
+
 	t.Parallel()
 	defer timeout()()
 
 	// Arrange.
 	ctx := newIncomingResolverTestContext(t, true)
 	ctx.chainIO.BestHeight = testInitialBlockHeight + 1
-	ctx.registry.notifyResolution = invoices.NewSettleResolution(
-		testResPreimage, testResCircuitKey, testAcceptHeight,
-		invoices.ResultReplayToSettled,
-	)
+	ctx.registry.lookupInvoiceSet = true
+	ctx.registry.lookupInvoice = settledTestInvoice()
 
 	// Act.
 	require.NoError(t, ctx.resolver.Launch())
 
 	// Assert.
-	require.Len(t, ctx.registry.immediateNotify, 1)
-	require.Equal(
-		t, ctx.chainIO.BestHeight,
-		ctx.registry.immediateNotify[0].currentHeight,
-	)
+	require.Equal(t, 1, ctx.registry.lookupCount)
+	require.Empty(t, ctx.registry.immediateNotify)
+	require.True(t, ctx.resolver.isLaunched())
 }
 
 func TestHtlcIncomingResolverLaunchSkipsSuccessAfterLookupExpiry(
@@ -219,11 +200,9 @@ func TestHtlcIncomingResolverLaunchSkipsSuccessAfterLookupExpiry(
 
 	// Arrange.
 	ctx := newIncomingResolverTestContext(t, true)
-	ctx.registry.notifyResolution = invoices.NewSettleResolution(
-		testResPreimage, testResCircuitKey, testAcceptHeight,
-		invoices.ResultReplayToSettled,
-	)
-	ctx.registry.notifyHook = func() {
+	ctx.registry.lookupInvoiceSet = true
+	ctx.registry.lookupInvoice = settledTestInvoice()
+	ctx.registry.lookupHook = func() {
 		ctx.chainIO.BestHeight = testHtlcExpiry
 	}
 
@@ -236,7 +215,8 @@ func TestHtlcIncomingResolverLaunchSkipsSuccessAfterLookupExpiry(
 		t, [32]byte(testResPreimage),
 		ctx.resolver.htlcResolution.Preimage,
 	)
-	require.Len(t, ctx.registry.immediateNotify, 1)
+	require.Equal(t, 1, ctx.registry.lookupCount)
+	require.Empty(t, ctx.registry.immediateNotify)
 }
 
 // TestHtlcIncomingResolverFailCheckpointErrorSkipsFinalEvent asserts that

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -247,17 +247,6 @@ func (h *htlcSuccessResolver) checkpointForeignSpend(
 		return err
 	}
 
-	h.ChainArbitratorConfig.HtlcNotifier.NotifyFinalHtlcEvent(
-		models.CircuitKey{
-			ChanID: h.ShortChanID,
-			HtlcID: h.htlc.HtlcIndex,
-		},
-		channeldb.FinalHtlcInfo{
-			Settled:  false,
-			Offchain: false,
-		},
-	)
-
 	var spendTxID *chainhash.Hash
 	if commitSpend != nil {
 		spendTxID = commitSpend.SpenderTxHash
@@ -280,7 +269,23 @@ func (h *htlcSuccessResolver) checkpointForeignSpend(
 	h.outputIncubating = false
 	h.markResolved()
 
-	return h.Checkpoint(h, report)
+	if err := h.Checkpoint(h, report); err != nil {
+		h.unresolve()
+		return err
+	}
+
+	h.ChainArbitratorConfig.HtlcNotifier.NotifyFinalHtlcEvent(
+		models.CircuitKey{
+			ChanID: h.ShortChanID,
+			HtlcID: h.htlc.HtlcIndex,
+		},
+		channeldb.FinalHtlcInfo{
+			Settled:  false,
+			Offchain: false,
+		},
+	)
+
+	return nil
 }
 
 // Stop signals the resolver to cancel any current resolution processes, and

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -1,6 +1,7 @@
 package contractcourt
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -10,6 +11,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/graph/db/models"
@@ -232,6 +234,55 @@ func (h *htlcSuccessResolver) checkpointClaim(spendTx *chainhash.Hash) error {
 	return h.Checkpoint(h, reports...)
 }
 
+// checkpointForeignSpend checkpoints the resolver as failed when the original
+// HTLC outpoint was spent by a transaction that did not create our expected
+// second-level success output.
+func (h *htlcSuccessResolver) checkpointForeignSpend(
+	commitSpend *chainntnfs.SpendDetail) error {
+
+	err := h.ChainArbitratorConfig.PutFinalHtlcOutcome(
+		h.ChannelArbitratorConfig.ShortChanID, h.htlc.HtlcIndex, false,
+	)
+	if err != nil {
+		return err
+	}
+
+	h.ChainArbitratorConfig.HtlcNotifier.NotifyFinalHtlcEvent(
+		models.CircuitKey{
+			ChanID: h.ShortChanID,
+			HtlcID: h.htlc.HtlcIndex,
+		},
+		channeldb.FinalHtlcInfo{
+			Settled:  false,
+			Offchain: false,
+		},
+	)
+
+	var spendTxID *chainhash.Hash
+	if commitSpend != nil {
+		spendTxID = commitSpend.SpenderTxHash
+	}
+	h.log.Warnf("HTLC outpoint %v was spent by tx %v, which did not "+
+		"create our expected second-level success output", h.outpoint(),
+		spendTxID)
+
+	// A foreign spend of an incoming HTLC on our commitment means we cannot
+	// complete the success path. The known production case is the remote
+	// timeout reclaim.
+	report := &channeldb.ResolverReport{
+		OutPoint:        h.outpoint(),
+		Amount:          h.htlc.Amt.ToSatoshis(),
+		ResolverType:    channeldb.ResolverTypeIncomingHtlc,
+		ResolverOutcome: channeldb.ResolverOutcomeTimeout,
+		SpendTxID:       spendTxID,
+	}
+
+	h.outputIncubating = false
+	h.markResolved()
+
+	return h.Checkpoint(h, report)
+}
+
 // Stop signals the resolver to cancel any current resolution processes, and
 // suspend.
 //
@@ -431,6 +482,36 @@ func (h *htlcSuccessResolver) isTaprootFinal() bool {
 	return h.chanType.IsTaprootFinal()
 }
 
+// successTxOutpoint returns the second-level success output outpoint if the
+// spending transaction created the output that this resolver expects to sweep.
+func (h *htlcSuccessResolver) successTxOutpoint(
+	commitSpend *chainntnfs.SpendDetail) (wire.OutPoint, bool) {
+
+	if commitSpend == nil || commitSpend.SpendingTx == nil ||
+		commitSpend.SpenderTxHash == nil {
+
+		return wire.OutPoint{}, false
+	}
+
+	outputIndex := commitSpend.SpenderInputIndex
+	if outputIndex >= uint32(len(commitSpend.SpendingTx.TxOut)) {
+		return wire.OutPoint{}, false
+	}
+
+	expected := h.htlcResolution.SweepSignDesc.Output
+	actual := commitSpend.SpendingTx.TxOut[outputIndex]
+	if expected == nil || actual.Value != expected.Value ||
+		!bytes.Equal(actual.PkScript, expected.PkScript) {
+
+		return wire.OutPoint{}, false
+	}
+
+	return wire.OutPoint{
+		Hash:  *commitSpend.SpenderTxHash,
+		Index: outputIndex,
+	}, true
+}
+
 // sweepRemoteCommitOutput creates a sweep request to sweep the HTLC output on
 // the remote commitment via the direct preimage-spend.
 func (h *htlcSuccessResolver) sweepRemoteCommitOutput() error {
@@ -560,6 +641,10 @@ func (h *htlcSuccessResolver) sweepSuccessTxOutput() error {
 	if err != nil {
 		return err
 	}
+	op, ok := h.successTxOutpoint(commitSpend)
+	if !ok {
+		return h.checkpointForeignSpend(commitSpend)
+	}
 
 	// The HTLC success tx has a CSV lock that we must wait for, and if
 	// this is a lease enforced channel and we're the imitator, we may need
@@ -583,16 +668,6 @@ func (h *htlcSuccessResolver) sweepSuccessTxOutput() error {
 			h, h.htlc.RHash[:], waitHeight)
 	}
 
-	// We'll use this input index to determine the second-level output
-	// index on the transaction, as the signatures requires the indexes to
-	// be the same. We don't look for the second-level output script
-	// directly, as there might be more than one HTLC output to the same
-	// pkScript.
-	op := &wire.OutPoint{
-		Hash:  *commitSpend.SpenderTxHash,
-		Index: commitSpend.SpenderInputIndex,
-	}
-
 	// Let the sweeper sweep the second-level output now that the
 	// CSV/CLTV locks have expired.
 	var witType input.StandardWitnessType
@@ -605,7 +680,7 @@ func (h *htlcSuccessResolver) sweepSuccessTxOutput() error {
 		witType = input.HtlcAcceptedSuccessSecondLevel
 	}
 	inp := h.makeSweepInput(
-		op, witType,
+		&op, witType,
 		input.LeaseHtlcAcceptedSuccessSecondLevel,
 		&h.htlcResolution.SweepSignDesc,
 		h.htlcResolution.CsvDelay, uint32(commitSpend.SpendingHeight),
@@ -703,15 +778,9 @@ func (h *htlcSuccessResolver) resolveSuccessTx() error {
 	if err != nil {
 		return err
 	}
-
-	// We'll use this input index to determine the second-level output
-	// index on the transaction, as the signatures requires the indexes to
-	// be the same. We don't look for the second-level output script
-	// directly, as there might be more than one HTLC output to the same
-	// pkScript.
-	op := wire.OutPoint{
-		Hash:  *commitSpend.SpenderTxHash,
-		Index: commitSpend.SpenderInputIndex,
+	op, ok := h.successTxOutpoint(commitSpend)
+	if !ok {
+		return h.checkpointForeignSpend(commitSpend)
 	}
 
 	// If the 2nd-stage sweeping has already been started, we can

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -186,18 +186,6 @@ func (h *htlcSuccessResolver) checkpointClaim(spendTx *chainhash.Hash) error {
 		return err
 	}
 
-	// Send notification.
-	h.ChainArbitratorConfig.HtlcNotifier.NotifyFinalHtlcEvent(
-		models.CircuitKey{
-			ChanID: h.ShortChanID,
-			HtlcID: h.htlc.HtlcIndex,
-		},
-		channeldb.FinalHtlcInfo{
-			Settled:  true,
-			Offchain: false,
-		},
-	)
-
 	// Create a resolver report for claiming of the htlc itself.
 	amt := btcutil.Amount(h.htlcResolution.SweepSignDesc.Output.Value)
 	reports := []*channeldb.ResolverReport{
@@ -229,9 +217,24 @@ func (h *htlcSuccessResolver) checkpointClaim(spendTx *chainhash.Hash) error {
 		reports = append(reports, report)
 	}
 
-	// Finally, we checkpoint the resolver with our report(s).
-	h.markResolved()
-	return h.Checkpoint(h, reports...)
+	// Finally, we checkpoint the resolver with our report(s). Notify after
+	// the checkpoint succeeds so retries do not duplicate terminal events.
+	err = h.resolve(h, reports...)
+	if err != nil {
+		return err
+	}
+	h.ChainArbitratorConfig.HtlcNotifier.NotifyFinalHtlcEvent(
+		models.CircuitKey{
+			ChanID: h.ShortChanID,
+			HtlcID: h.htlc.HtlcIndex,
+		},
+		channeldb.FinalHtlcInfo{
+			Settled:  true,
+			Offchain: false,
+		},
+	)
+
+	return nil
 }
 
 // checkpointForeignSpend checkpoints the resolver as failed when the original

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -853,16 +853,16 @@ func (h *htlcSuccessResolver) Launch() error {
 	h.log.Debugf("launching resolver...")
 	h.markLaunched()
 
+	var err error
 	switch {
 	// If we're already resolved, then we can exit early.
 	case h.IsResolved():
 		h.log.Errorf("already resolved")
-		return nil
 
 	// If this is an output on the remote party's commitment transaction,
 	// use the direct-spend path.
 	case h.isRemoteCommitOutput():
-		return h.sweepRemoteCommitOutput()
+		err = h.sweepRemoteCommitOutput()
 
 	// If this is an anchor type channel, we now sweep either the
 	// second-level success tx or the output from the second-level success
@@ -871,17 +871,23 @@ func (h *htlcSuccessResolver) Launch() error {
 		// If the second-level success tx has already been swept, we
 		// can go ahead and sweep its output.
 		if h.outputIncubating {
-			return h.sweepSuccessTxOutput()
+			err = h.sweepSuccessTxOutput()
+			break
 		}
 
 		// Otherwise, sweep the second level tx.
-		return h.sweepSuccessTx()
+		err = h.sweepSuccessTx()
 
-	// If this is a legacy channel type, the output is handled by the
-	// nursery via the Resolve so we do nothing here.
-	//
-	// TODO(yy): handle the legacy output by offering it to the sweeper.
 	default:
-		return nil
+		// Legacy channel outputs are handled by the nursery through
+		// Resolve, so Launch does nothing here.
+		//
+		// TODO(yy): offer legacy output to the sweeper.
 	}
+
+	if err != nil {
+		h.unlaunch()
+	}
+
+	return err
 }

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -830,7 +830,9 @@ func (h *htlcSuccessResolver) resolveSuccessTx() error {
 	// Now that the second-level transaction has confirmed, we checkpoint
 	// the state so we'll go to the next stage in case of restarts.
 	h.outputIncubating = true
-	if err := h.Checkpoint(h); err != nil {
+	h.unlaunch()
+	err = h.Checkpoint(h)
+	if err != nil {
 		log.Errorf("unable to Checkpoint: %v", err)
 		return err
 	}
@@ -839,7 +841,10 @@ func (h *htlcSuccessResolver) resolveSuccessTx() error {
 		commitSpend.SpenderTxHash)
 
 	// Send the sweep request for the output from the success tx.
-	if err := h.sweepSuccessTxOutput(); err != nil {
+	h.markLaunched()
+	err = h.sweepSuccessTxOutput()
+	if err != nil {
+		h.unlaunch()
 		return err
 	}
 

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -523,6 +523,11 @@ func (h *htlcSuccessResolver) successTxOutpoint(
 // sweepRemoteCommitOutput creates a sweep request to sweep the HTLC output on
 // the remote commitment via the direct preimage-spend.
 func (h *htlcSuccessResolver) sweepRemoteCommitOutput() error {
+	err := h.attachPreimage()
+	if err != nil {
+		return err
+	}
+
 	// Before we can craft out sweeping transaction, we need to create an
 	// input which contains all the items required to add this input to a
 	// sweeping transaction, and generate a witness.
@@ -575,7 +580,7 @@ func (h *htlcSuccessResolver) sweepRemoteCommitOutput() error {
 		h.htlc.RefundTimeout, budget)
 
 	// We'll now offer the direct preimage HTLC to the sweeper.
-	_, err := h.Sweeper.SweepInput(
+	_, err = h.Sweeper.SweepInput(
 		inp,
 		sweep.Params{
 			Budget:         budget,
@@ -588,6 +593,11 @@ func (h *htlcSuccessResolver) sweepRemoteCommitOutput() error {
 
 // sweepSuccessTx attempts to sweep the second level success tx.
 func (h *htlcSuccessResolver) sweepSuccessTx() error {
+	err := h.attachPreimage()
+	if err != nil {
+		return err
+	}
+
 	var secondLevelInput input.HtlcSecondLevelAnchorInput
 	if h.isTaproot() {
 		secondLevelInput = input.MakeHtlcSecondLevelSuccessTaprootInput(
@@ -621,7 +631,7 @@ func (h *htlcSuccessResolver) sweepSuccessTx() error {
 		"deadline=%v, budget=%v", h.htlc.RefundTimeout, budget)
 
 	// We'll now offer the second-level transaction to the sweeper.
-	_, err := h.Sweeper.SweepInput(
+	_, err = h.Sweeper.SweepInput(
 		&secondLevelInput,
 		sweep.Params{
 			Budget:         budget,
@@ -630,6 +640,25 @@ func (h *htlcSuccessResolver) sweepSuccessTx() error {
 	)
 
 	return err
+}
+
+// attachPreimage attaches a learned preimage from the global preimage DB if a
+// restarted resolver was decoded without it. The normal contest path persists
+// invoice-learned preimages before launching the inner success resolver.
+func (h *htlcSuccessResolver) attachPreimage() error {
+	if h.htlcResolution.Preimage != [32]byte{} {
+		return nil
+	}
+
+	preimage, ok := h.PreimageDB.LookupPreimage(h.htlc.RHash)
+	if !ok {
+		return fmt.Errorf("missing preimage for incoming HTLC %v",
+			h.htlc.RHash)
+	}
+
+	h.htlcResolution.Preimage = preimage
+
+	return nil
 }
 
 // sweepSuccessTxOutput attempts to sweep the output of the second level

--- a/contractcourt/htlc_success_resolver_test.go
+++ b/contractcourt/htlc_success_resolver_test.go
@@ -333,12 +333,10 @@ func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 			},
 		},
 		TxOut: []*wire.TxOut{
-			{
-				Value:    123,
-				PkScript: []byte{0xff, 0xff},
-			},
+			cloneTxOut(testSignDesc.Output),
 		},
 	}
+	successHash := successTx.TxHash()
 
 	reSignedSuccessTx := &wire.MsgTx{
 		TxIn: []*wire.TxIn{
@@ -365,7 +363,7 @@ func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 			successTx.TxOut[0],
 		},
 	}
-	reSignedHash := successTx.TxHash()
+	reSignedHash := reSignedSuccessTx.TxHash()
 
 	sweepTx := &wire.MsgTx{
 		TxIn: []*wire.TxIn{
@@ -400,7 +398,7 @@ func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 		Amount:          testHtlcAmt.ToSatoshis(),
 		ResolverType:    channeldb.ResolverTypeIncomingHtlc,
 		ResolverOutcome: channeldb.ResolverOutcomeFirstStage,
-		SpendTxID:       &reSignedHash,
+		SpendTxID:       &successHash,
 	}
 
 	secondStage := &channeldb.ResolverReport{
@@ -532,6 +530,14 @@ func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 	}
 
 	testHtlcSuccess(t, twoStageResolution, checkpoints)
+}
+
+func cloneTxOut(txOut *wire.TxOut) *wire.TxOut {
+	pkScript := append([]byte(nil), txOut.PkScript...)
+	return &wire.TxOut{
+		Value:    txOut.Value,
+		PkScript: pkScript,
+	}
 }
 
 // checkpoint holds expected data we expect the resolver to checkpoint itself

--- a/contractcourt/htlc_success_resolver_test.go
+++ b/contractcourt/htlc_success_resolver_test.go
@@ -2,6 +2,7 @@ package contractcourt
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -33,6 +34,7 @@ type htlcResolverTestContext struct {
 		_ ...*channeldb.ResolverReport) error
 
 	notifier           *mock.ChainNotifier
+	htlcNotifier       *mockHTLCNotifier
 	resolverResultChan chan resolveResult
 	resolutionChan     chan ResolutionMsg
 
@@ -60,15 +62,15 @@ func newHtlcResolverTestContext(t *testing.T,
 		SpendChan: make(chan *chainntnfs.SpendDetail, 1),
 		ConfChan:  make(chan *chainntnfs.TxConfirmation, 1),
 	}
+	htlcNotifier := &mockHTLCNotifier{}
 
 	testCtx := &htlcResolverTestContext{
 		checkpoint:     nil,
 		notifier:       notifier,
+		htlcNotifier:   htlcNotifier,
 		resolutionChan: make(chan ResolutionMsg, 1),
 		t:              t,
 	}
-
-	htlcNotifier := &mockHTLCNotifier{}
 
 	witnessBeacon := newMockWitnessBeacon()
 	chainCfg := ChannelArbitratorConfig{
@@ -665,6 +667,67 @@ func TestHtlcSuccessResolverRejectsForeignSpendOnRestart(t *testing.T) {
 	resolver := successResolverFromContext(t, ctx)
 	assertNoSweptInput(t, mockSweeperFromResolver(t, resolver))
 	assertFinalHtlcFailed(t, ctx)
+}
+
+func TestHtlcSuccessResolverForeignSpendCheckpointError(t *testing.T) {
+	defer timeout()()
+
+	// Arrange.
+	commitOutpoint := wire.OutPoint{
+		Hash:  chainhash.Hash{0x03},
+		Index: 4,
+	}
+	resolution := newTestAnchorSuccessResolution(commitOutpoint)
+	foreignTx, foreignHash := newForeignSuccessSpend(commitOutpoint)
+	errCheckpoint := errors.New("checkpoint failed")
+	ctx := newTestHtlcSuccessContext(t, resolution, false)
+
+	checkpointChan := make(chan struct{}, 1)
+	ctx.checkpoint = func(resolver ContractResolver,
+		reports ...*channeldb.ResolverReport) error {
+
+		successResolver, ok := resolver.(*htlcSuccessResolver)
+		require.True(t, ok)
+
+		require.True(t, successResolver.IsResolved())
+		require.Len(t, reports, 1)
+
+		checkpointChan <- struct{}{}
+
+		return errCheckpoint
+	}
+
+	// Act.
+	ctx.resolve()
+
+	resolver := successResolverFromContext(t, ctx)
+	sweeper := mockSweeperFromResolver(t, resolver)
+	select {
+	case inp := <-sweeper.sweptInputs:
+		require.Equal(t, commitOutpoint, inp.OutPoint())
+	case <-time.After(time.Second):
+		t.Fatal("expected first-stage input to be swept")
+	}
+
+	ctx.notifier.SpendChan <- &chainntnfs.SpendDetail{
+		SpendingTx:        foreignTx,
+		SpenderTxHash:     &foreignHash,
+		SpenderInputIndex: 0,
+		SpendingHeight:    10,
+		SpentOutPoint:     &commitOutpoint,
+	}
+
+	select {
+	case <-checkpointChan:
+	case <-time.After(time.Second):
+		t.Fatal("expected foreign spend checkpoint")
+	}
+
+	result := <-ctx.resolverResultChan
+	require.ErrorIs(t, result.err, errCheckpoint)
+	require.Nil(t, result.nextResolver)
+	require.False(t, resolver.IsResolved())
+	require.Empty(t, ctx.htlcNotifier.finalHtlcEvents)
 }
 
 func newTestHtlcSuccessContext(t *testing.T,

--- a/contractcourt/htlc_success_resolver_test.go
+++ b/contractcourt/htlc_success_resolver_test.go
@@ -188,6 +188,7 @@ func TestHtlcSuccessSingleStage(t *testing.T) {
 	// singleStageResolution is a resolution for a htlc on the remote
 	// party's commitment.
 	singleStageResolution := lnwallet.IncomingHtlcResolution{
+		Preimage:      testResPreimage,
 		SweepSignDesc: testSignDesc,
 		ClaimOutpoint: htlcOutpoint,
 	}
@@ -236,6 +237,46 @@ func TestHtlcSuccessSingleStage(t *testing.T) {
 	)
 }
 
+// TestHtlcSuccessResolverLaunchRestoresPreimage asserts that Launch restores a
+// missing direct-sweep preimage from the preimage DB before offering the input.
+func TestHtlcSuccessResolverLaunchRestoresPreimage(t *testing.T) {
+	defer timeout()()
+
+	claimOutpoint := wire.OutPoint{
+		Hash:  chainhash.Hash{0x05},
+		Index: 6,
+	}
+	resolution := lnwallet.IncomingHtlcResolution{
+		SweepSignDesc: testSignDesc,
+		ClaimOutpoint: claimOutpoint,
+	}
+	ctx := newHtlcResolverTestContext(
+		t, func(htlc channeldb.HTLC,
+			cfg ResolverConfig) ContractResolver {
+
+			return newSuccessResolver(resolution, 0, htlc, 0, cfg)
+		},
+	)
+	resolver, ok := ctx.resolver.(*htlcSuccessResolver)
+	require.True(t, ok)
+	witnessBeacon, ok := resolver.PreimageDB.(*mockWitnessBeacon)
+	require.True(t, ok)
+	witnessBeacon.setLookupPreimage(testResHash, testResPreimage)
+
+	require.NoError(t, resolver.Launch())
+
+	sweeper, ok := resolver.Sweeper.(*mockSweeper)
+	require.True(t, ok)
+	select {
+	case inp := <-sweeper.sweptInputs:
+		require.Equal(t, claimOutpoint, inp.OutPoint())
+		preimage := inp.Preimage().UnwrapOrFail(t)
+		require.Equal(t, testResPreimage, preimage)
+	case <-time.After(time.Second):
+		t.Fatal("expected direct input to be swept")
+	}
+}
+
 // TestHtlcSuccessSecondStageResolution tests successful sweep of a second
 // stage htlc claim, going through the Nursery.
 func TestHtlcSuccessSecondStageResolution(t *testing.T) {
@@ -251,7 +292,7 @@ func TestHtlcSuccessSecondStageResolution(t *testing.T) {
 	// twoStageResolution is a resolution for htlc on our own commitment
 	// which is spent from the signed success tx.
 	twoStageResolution := lnwallet.IncomingHtlcResolution{
-		Preimage: [32]byte{},
+		Preimage: testResPreimage,
 		SignedSuccessTx: &wire.MsgTx{
 			TxIn: []*wire.TxIn{
 				{
@@ -386,7 +427,7 @@ func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 	// twoStageResolution is a resolution for htlc on our own commitment
 	// which is spent from the signed success tx.
 	twoStageResolution := lnwallet.IncomingHtlcResolution{
-		Preimage:        [32]byte{},
+		Preimage:        testResPreimage,
 		CsvDelay:        4,
 		SignedSuccessTx: successTx,
 		SignDetails: &input.SignDetails{

--- a/contractcourt/htlc_success_resolver_test.go
+++ b/contractcourt/htlc_success_resolver_test.go
@@ -389,6 +389,107 @@ func TestHtlcSuccessResolverTaprootAugmentMergesPreimage(t *testing.T) {
 	ctx.waitForResult()
 }
 
+// TestHtlcSuccessResolverRetriesSecondStageLaunch asserts that the success
+// resolver re-arms Launch after moving from the first-stage HTLC success tx to
+// its second-stage output.
+func TestHtlcSuccessResolverRetriesSecondStageLaunch(t *testing.T) {
+	defer timeout()()
+
+	commitOutpoint := wire.OutPoint{
+		Hash:  chainhash.Hash{0x07},
+		Index: 8,
+	}
+	resolution := newTestAnchorSuccessResolution(commitOutpoint)
+	ctx := newTestHtlcSuccessContext(t, resolution, false)
+	resolver := successResolverFromContext(t, ctx)
+	sweeper := mockSweeperFromResolver(t, resolver)
+
+	checkpointChan := make(chan struct{}, 1)
+	ctx.checkpoint = func(resolver ContractResolver,
+		reports ...*channeldb.ResolverReport) error {
+
+		successResolver, ok := resolver.(*htlcSuccessResolver)
+		require.True(t, ok)
+		require.True(t, successResolver.outputIncubating)
+		require.False(t, successResolver.isLaunched())
+		require.Empty(t, reports)
+
+		checkpointChan <- struct{}{}
+
+		return nil
+	}
+
+	// The first launch offers the first-stage HTLC success tx.
+	require.NoError(t, resolver.Launch())
+	select {
+	case inp := <-sweeper.sweptInputs:
+		require.Equal(t, commitOutpoint, inp.OutPoint())
+	case <-time.After(time.Second):
+		t.Fatal("expected first-stage input to be swept")
+	}
+	require.True(t, resolver.isLaunched())
+
+	// Let Resolve advance to the second stage, then fail the second-stage
+	// offer. The resolver should clear launched so a later Launch can retry
+	// the second-stage output.
+	offerErr := errors.New("stage two offer failed")
+	sweeper.sweepInputErr = offerErr
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- resolver.resolveSuccessTx()
+	}()
+
+	successTx := resolution.SignedSuccessTx
+	successHash := successTx.TxHash()
+	commitSpend := &chainntnfs.SpendDetail{
+		SpendingTx:        successTx,
+		SpenderTxHash:     &successHash,
+		SpenderInputIndex: 0,
+		SpendingHeight:    10,
+		SpentOutPoint:     &commitOutpoint,
+	}
+	ctx.notifier.SpendChan <- commitSpend
+
+	select {
+	case <-checkpointChan:
+	case <-time.After(time.Second):
+		t.Fatal("expected second-stage checkpoint")
+	}
+	ctx.notifier.SpendChan <- commitSpend
+
+	select {
+	case err := <-errChan:
+		require.ErrorIs(t, err, offerErr)
+	case <-time.After(time.Second):
+		t.Fatal("expected second-stage offer error")
+	}
+	require.True(t, resolver.outputIncubating)
+	require.False(t, resolver.isLaunched())
+
+	// A later Launch should retry the second-stage output instead of
+	// returning at the stale first-stage launched guard.
+	sweeper.sweepInputErr = nil
+	retryErr := make(chan error, 1)
+	go func() {
+		retryErr <- resolver.Launch()
+	}()
+	ctx.notifier.SpendChan <- commitSpend
+
+	select {
+	case err := <-retryErr:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("expected retry launch result")
+	}
+	select {
+	case inp := <-sweeper.sweptInputs:
+		require.Equal(t, resolution.ClaimOutpoint, inp.OutPoint())
+	case <-time.After(time.Second):
+		t.Fatal("expected second-stage input to be swept")
+	}
+	require.True(t, resolver.isLaunched())
+}
+
 // TestHtlcSuccessSecondStageResolution tests successful sweep of a second
 // stage htlc claim, going through the Nursery.
 func TestHtlcSuccessSecondStageResolution(t *testing.T) {
@@ -929,6 +1030,8 @@ func mockSweeperFromResolver(t *testing.T,
 	return sweeper
 }
 
+// newTestAnchorSuccessResolution returns an anchor-channel success resolution
+// whose second-level output matches the shared test sign descriptor.
 func newTestAnchorSuccessResolution(
 	commitOutpoint wire.OutPoint) lnwallet.IncomingHtlcResolution {
 
@@ -945,7 +1048,7 @@ func newTestAnchorSuccessResolution(
 	successHash := successTx.TxHash()
 
 	return lnwallet.IncomingHtlcResolution{
-		Preimage:        [32]byte{},
+		Preimage:        testResPreimage,
 		CsvDelay:        4,
 		SignedSuccessTx: successTx,
 		SignDetails: &input.SignDetails{
@@ -980,6 +1083,7 @@ func newForeignSuccessSpend(
 	return foreignTx, foreignTx.TxHash()
 }
 
+// cloneTxOut returns a copy of a transaction output.
 func cloneTxOut(txOut *wire.TxOut) *wire.TxOut {
 	pkScript := append([]byte(nil), txOut.PkScript...)
 	return &wire.TxOut{

--- a/contractcourt/htlc_success_resolver_test.go
+++ b/contractcourt/htlc_success_resolver_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/lnmock"
 	"github.com/lightningnetwork/lnd/lntest/mock"
+	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/stretchr/testify/require"
@@ -275,6 +276,117 @@ func TestHtlcSuccessResolverLaunchRestoresPreimage(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("expected direct input to be swept")
 	}
+}
+
+// TestHtlcSuccessResolverTaprootAugmentMergesPreimage asserts that taproot
+// restart augmentation merges close-summary fields without replacing the
+// resolver's learned preimage.
+func TestHtlcSuccessResolverTaprootAugmentMergesPreimage(t *testing.T) {
+	defer timeout()()
+
+	// Arrange: set up a restarted remote-commitment resolver with a learned
+	// preimage and a close-summary resolution with taproot data but no
+	// preimage.
+	claimOutpoint := wire.OutPoint{
+		Hash:  chainhash.Hash{0x04},
+		Index: 5,
+	}
+	storedResolution := lnwallet.IncomingHtlcResolution{
+		Preimage:      testResPreimage,
+		SweepSignDesc: testSignDesc,
+		ClaimOutpoint: claimOutpoint,
+	}
+	closeSummaryResolution := storedResolution
+	closeSummaryResolution.Preimage = [32]byte{}
+	closeSummaryResolution.CsvDelay = 7
+
+	sweepTx := &wire.MsgTx{
+		TxIn: []*wire.TxIn{
+			{
+				PreviousOutPoint: claimOutpoint,
+				Witness: wire.TxWitness{
+					[]byte{0x01}, testResPreimage[:],
+				},
+			},
+		},
+	}
+	sweepHash := sweepTx.TxHash()
+	expectedReport := &channeldb.ResolverReport{
+		OutPoint:        claimOutpoint,
+		Amount:          btcutil.Amount(testSignDesc.Output.Value),
+		ResolverType:    channeldb.ResolverTypeIncomingHtlc,
+		ResolverOutcome: channeldb.ResolverOutcomeClaimed,
+		SpendTxID:       &sweepHash,
+	}
+	ctx := newTestHtlcSuccessContext(t, storedResolution, false)
+	resolver := successResolverFromContext(t, ctx)
+	taprootChanType := channeldb.SimpleTaprootFeatureBit
+	resolver.SupplementState(&channeldb.OpenChannel{
+		ChanType: taprootChanType,
+	})
+	incomingResolutions := []lnwallet.IncomingHtlcResolution{
+		closeSummaryResolution,
+	}
+	maybeAugmentTaprootResolvers(
+		taprootChanType, resolver, &ContractResolutions{
+			HtlcResolutions: lnwallet.HtlcResolutions{
+				IncomingHTLCs: incomingResolutions,
+			},
+		},
+	)
+	require.Equal(
+		t, testResPreimage,
+		lntypes.Preimage(resolver.htlcResolution.Preimage),
+	)
+	require.EqualValues(t, 7, resolver.htlcResolution.CsvDelay)
+
+	checkpointChan := make(chan struct{}, 1)
+	ctx.checkpoint = func(resolver ContractResolver,
+		reports ...*channeldb.ResolverReport) error {
+
+		successResolver, ok := resolver.(*htlcSuccessResolver)
+		require.True(t, ok)
+
+		require.True(t, successResolver.IsResolved())
+		require.True(t, ctx.finalHtlcOutcomeStored)
+		require.True(t, ctx.finalHtlcSettled)
+		require.Equal(t, []*channeldb.ResolverReport{
+			expectedReport,
+		}, reports)
+
+		checkpointChan <- struct{}{}
+
+		return nil
+	}
+
+	// Act: launch the restarted resolver and inspect the direct sweep input
+	// it offers after augmentation.
+	ctx.resolve()
+
+	sweeper := mockSweeperFromResolver(t, resolver)
+	select {
+	case inp := <-sweeper.sweptInputs:
+		require.Equal(t, claimOutpoint, inp.OutPoint())
+		preimage := inp.Preimage().UnwrapOrFail(t)
+		require.Equal(t, testResPreimage, preimage)
+	case <-time.After(time.Second):
+		t.Fatal("expected direct input to be swept")
+	}
+
+	ctx.notifier.SpendChan <- &chainntnfs.SpendDetail{
+		SpendingTx:        sweepTx,
+		SpenderTxHash:     &sweepHash,
+		SpenderInputIndex: 0,
+		SpendingHeight:    10,
+		SpentOutPoint:     &claimOutpoint,
+	}
+
+	select {
+	case <-checkpointChan:
+	case <-time.After(time.Second):
+		t.Fatal("expected direct-spend checkpoint")
+	}
+	ctx.waitForResult()
 }
 
 // TestHtlcSuccessSecondStageResolution tests successful sweep of a second
@@ -771,6 +883,8 @@ func TestHtlcSuccessResolverForeignSpendCheckpointError(t *testing.T) {
 	require.Empty(t, ctx.htlcNotifier.finalHtlcEvents)
 }
 
+// newTestHtlcSuccessContext creates a success resolver test context with the
+// supplied incoming HTLC resolution and incubation state.
 func newTestHtlcSuccessContext(t *testing.T,
 	resolution lnwallet.IncomingHtlcResolution,
 	outputIncubating bool) *htlcResolverTestContext {
@@ -789,6 +903,8 @@ func newTestHtlcSuccessContext(t *testing.T,
 	)
 }
 
+// successResolverFromContext returns the success resolver installed in a test
+// context.
 func successResolverFromContext(t *testing.T,
 	ctx *htlcResolverTestContext) *htlcSuccessResolver {
 
@@ -800,6 +916,8 @@ func successResolverFromContext(t *testing.T,
 	return resolver
 }
 
+// mockSweeperFromResolver returns the mock sweeper installed on a success
+// resolver.
 func mockSweeperFromResolver(t *testing.T,
 	resolver *htlcSuccessResolver) *mockSweeper {
 

--- a/contractcourt/htlc_success_resolver_test.go
+++ b/contractcourt/htlc_success_resolver_test.go
@@ -37,6 +37,7 @@ type htlcResolverTestContext struct {
 	resolutionChan     chan ResolutionMsg
 
 	finalHtlcOutcomeStored bool
+	finalHtlcSettled       bool
 
 	t *testing.T
 }
@@ -100,6 +101,7 @@ func newHtlcResolverTestContext(t *testing.T,
 				htlcId uint64, settled bool) error {
 
 				testCtx.finalHtlcOutcomeStored = true
+				testCtx.finalHtlcSettled = settled
 
 				return nil
 			},
@@ -532,12 +534,253 @@ func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 	testHtlcSuccess(t, twoStageResolution, checkpoints)
 }
 
+func TestHtlcSuccessResolverRejectsForeignSpend(t *testing.T) {
+	defer timeout()()
+
+	// Arrange.
+	commitOutpoint := wire.OutPoint{
+		Hash:  chainhash.Hash{0x01},
+		Index: 2,
+	}
+	resolution := newTestAnchorSuccessResolution(commitOutpoint)
+	foreignTx, foreignHash := newForeignSuccessSpend(commitOutpoint)
+	expectedReport := &channeldb.ResolverReport{
+		OutPoint:        commitOutpoint,
+		Amount:          testHtlcAmt.ToSatoshis(),
+		ResolverType:    channeldb.ResolverTypeIncomingHtlc,
+		ResolverOutcome: channeldb.ResolverOutcomeTimeout,
+		SpendTxID:       &foreignHash,
+	}
+	ctx := newTestHtlcSuccessContext(t, resolution, false)
+
+	checkpointChan := make(chan struct{}, 1)
+	ctx.checkpoint = func(resolver ContractResolver,
+		reports ...*channeldb.ResolverReport) error {
+
+		successResolver, ok := resolver.(*htlcSuccessResolver)
+		require.True(t, ok)
+
+		require.True(t, successResolver.IsResolved())
+		require.False(t, successResolver.outputIncubating)
+		require.True(t, ctx.finalHtlcOutcomeStored)
+		require.False(t, ctx.finalHtlcSettled)
+		require.Equal(t, []*channeldb.ResolverReport{
+			expectedReport,
+		}, reports)
+
+		checkpointChan <- struct{}{}
+
+		return nil
+	}
+
+	// Act.
+	ctx.resolve()
+
+	resolver := successResolverFromContext(t, ctx)
+	sweeper := mockSweeperFromResolver(t, resolver)
+	select {
+	case inp := <-sweeper.sweptInputs:
+		require.Equal(t, commitOutpoint, inp.OutPoint())
+	case <-time.After(time.Second):
+		t.Fatal("expected first-stage input to be swept")
+	}
+
+	ctx.notifier.SpendChan <- &chainntnfs.SpendDetail{
+		SpendingTx:        foreignTx,
+		SpenderTxHash:     &foreignHash,
+		SpenderInputIndex: 0,
+		SpendingHeight:    10,
+		SpentOutPoint:     &commitOutpoint,
+	}
+
+	select {
+	case <-checkpointChan:
+	case <-time.After(time.Second):
+		t.Fatal("expected foreign spend checkpoint")
+	}
+	ctx.waitForResult()
+
+	// Assert.
+	assertNoSweptInput(t, sweeper)
+	assertFinalHtlcFailed(t, ctx)
+}
+
+func TestHtlcSuccessResolverRejectsForeignSpendOnRestart(t *testing.T) {
+	defer timeout()()
+
+	// Arrange.
+	commitOutpoint := wire.OutPoint{
+		Hash:  chainhash.Hash{0x02},
+		Index: 3,
+	}
+	resolution := newTestAnchorSuccessResolution(commitOutpoint)
+	foreignTx, foreignHash := newForeignSuccessSpend(commitOutpoint)
+	expectedReport := &channeldb.ResolverReport{
+		OutPoint:        commitOutpoint,
+		Amount:          testHtlcAmt.ToSatoshis(),
+		ResolverType:    channeldb.ResolverTypeIncomingHtlc,
+		ResolverOutcome: channeldb.ResolverOutcomeTimeout,
+		SpendTxID:       &foreignHash,
+	}
+	ctx := newTestHtlcSuccessContext(t, resolution, true)
+
+	checkpointChan := make(chan struct{}, 1)
+	ctx.checkpoint = func(resolver ContractResolver,
+		reports ...*channeldb.ResolverReport) error {
+
+		successResolver, ok := resolver.(*htlcSuccessResolver)
+		require.True(t, ok)
+
+		require.True(t, successResolver.IsResolved())
+		require.False(t, successResolver.outputIncubating)
+		require.True(t, ctx.finalHtlcOutcomeStored)
+		require.False(t, ctx.finalHtlcSettled)
+		require.Equal(t, []*channeldb.ResolverReport{
+			expectedReport,
+		}, reports)
+
+		checkpointChan <- struct{}{}
+
+		return nil
+	}
+
+	// Act.
+	ctx.resolve()
+	ctx.notifier.SpendChan <- &chainntnfs.SpendDetail{
+		SpendingTx:        foreignTx,
+		SpenderTxHash:     &foreignHash,
+		SpenderInputIndex: 0,
+		SpendingHeight:    10,
+		SpentOutPoint:     &commitOutpoint,
+	}
+
+	select {
+	case <-checkpointChan:
+	case <-time.After(time.Second):
+		t.Fatal("expected foreign spend checkpoint")
+	}
+	ctx.waitForResult()
+
+	// Assert.
+	resolver := successResolverFromContext(t, ctx)
+	assertNoSweptInput(t, mockSweeperFromResolver(t, resolver))
+	assertFinalHtlcFailed(t, ctx)
+}
+
+func newTestHtlcSuccessContext(t *testing.T,
+	resolution lnwallet.IncomingHtlcResolution,
+	outputIncubating bool) *htlcResolverTestContext {
+
+	return newHtlcResolverTestContext(
+		t, func(htlc channeldb.HTLC,
+			cfg ResolverConfig) ContractResolver {
+
+			r := newSuccessResolver(
+				resolution, 0, htlc, 0, cfg,
+			)
+			r.outputIncubating = outputIncubating
+
+			return r
+		},
+	)
+}
+
+func successResolverFromContext(t *testing.T,
+	ctx *htlcResolverTestContext) *htlcSuccessResolver {
+
+	t.Helper()
+
+	resolver, ok := ctx.resolver.(*htlcSuccessResolver)
+	require.True(t, ok)
+
+	return resolver
+}
+
+func mockSweeperFromResolver(t *testing.T,
+	resolver *htlcSuccessResolver) *mockSweeper {
+
+	t.Helper()
+
+	sweeper, ok := resolver.Sweeper.(*mockSweeper)
+	require.True(t, ok)
+
+	return sweeper
+}
+
+func newTestAnchorSuccessResolution(
+	commitOutpoint wire.OutPoint) lnwallet.IncomingHtlcResolution {
+
+	successTx := &wire.MsgTx{
+		TxIn: []*wire.TxIn{
+			{
+				PreviousOutPoint: commitOutpoint,
+			},
+		},
+		TxOut: []*wire.TxOut{
+			cloneTxOut(testSignDesc.Output),
+		},
+	}
+	successHash := successTx.TxHash()
+
+	return lnwallet.IncomingHtlcResolution{
+		Preimage:        [32]byte{},
+		CsvDelay:        4,
+		SignedSuccessTx: successTx,
+		SignDetails: &input.SignDetails{
+			SignDesc: testSignDesc,
+			PeerSig:  testSig,
+		},
+		ClaimOutpoint: wire.OutPoint{
+			Hash:  successHash,
+			Index: 0,
+		},
+		SweepSignDesc: testSignDesc,
+	}
+}
+
+func newForeignSuccessSpend(
+	commitOutpoint wire.OutPoint) (*wire.MsgTx, chainhash.Hash) {
+
+	foreignTx := &wire.MsgTx{
+		TxIn: []*wire.TxIn{
+			{
+				PreviousOutPoint: commitOutpoint,
+			},
+		},
+		TxOut: []*wire.TxOut{
+			{
+				Value:    testSignDesc.Output.Value,
+				PkScript: []byte{0x51},
+			},
+		},
+	}
+
+	return foreignTx, foreignTx.TxHash()
+}
+
 func cloneTxOut(txOut *wire.TxOut) *wire.TxOut {
 	pkScript := append([]byte(nil), txOut.PkScript...)
 	return &wire.TxOut{
 		Value:    txOut.Value,
 		PkScript: pkScript,
 	}
+}
+
+func assertNoSweptInput(t *testing.T, sweeper *mockSweeper) {
+	t.Helper()
+
+	select {
+	case inp := <-sweeper.sweptInputs:
+		t.Fatalf("unexpected swept input: %v", inp.OutPoint())
+	default:
+	}
+}
+
+func assertFinalHtlcFailed(t *testing.T, ctx *htlcResolverTestContext) {
+	t.Helper()
+
+	require.True(t, ctx.finalHtlcOutcomeStored)
+	require.False(t, ctx.finalHtlcSettled)
 }
 
 // checkpoint holds expected data we expect the resolver to checkpoint itself

--- a/contractcourt/htlc_timeout_resolver.go
+++ b/contractcourt/htlc_timeout_resolver.go
@@ -1291,11 +1291,11 @@ func (h *htlcTimeoutResolver) Launch() error {
 	h.log.Debugf("launching resolver...")
 	h.markLaunched()
 
+	var err error
 	switch {
 	// If we're already resolved, then we can exit early.
 	case h.IsResolved():
 		h.log.Errorf("already resolved")
-		return nil
 
 	// If this is an output on the remote party's commitment transaction,
 	// use the direct timeout spend path.
@@ -1305,7 +1305,7 @@ func (h *htlcTimeoutResolver) Launch() error {
 	// stopped marking this flag for direct timeout spends (#9062). In that
 	// case, we will do nothing and let the utxo nursery handle it.
 	case h.isRemoteCommitOutput() && !h.outputIncubating:
-		return h.sweepDirectHtlcOutput()
+		err = h.sweepDirectHtlcOutput()
 
 	// If this is an anchor type channel, we now sweep either the
 	// second-level timeout tx or the output from the second-level timeout
@@ -1314,17 +1314,23 @@ func (h *htlcTimeoutResolver) Launch() error {
 		// If the second-level timeout tx has already been swept, we
 		// can go ahead and sweep its output.
 		if h.outputIncubating {
-			return h.sweepTimeoutTxOutput()
+			err = h.sweepTimeoutTxOutput()
+			break
 		}
 
 		// Otherwise, sweep the second level tx.
-		return h.sweepTimeoutTx()
+		err = h.sweepTimeoutTx()
 
-	// If this is an output on our own commitment using pre-anchor channel
-	// type, we will let the utxo nursery handle it via Resolve.
-	//
-	// TODO(yy): handle the legacy output by offering it to the sweeper.
 	default:
-		return nil
+		// Pre-anchor local commitment outputs are handled by the
+		// nursery through Resolve, so Launch does nothing here.
+		//
+		// TODO(yy): offer legacy output to the sweeper.
 	}
+
+	if err != nil {
+		h.unlaunch()
+	}
+
+	return err
 }

--- a/contractcourt/htlc_timeout_resolver.go
+++ b/contractcourt/htlc_timeout_resolver.go
@@ -236,8 +236,8 @@ func (h *htlcTimeoutResolver) claimCleanUp(
 	var pre [32]byte
 	copy(pre[:], preimage[:])
 
-	// Finally, we'll send the clean up message, mark ourselves as
-	// resolved, then exit.
+	// Finally, we'll send the clean up message, mark ourselves as resolved,
+	// checkpoint, then exit.
 	if err := h.DeliverResolutionMsg(ResolutionMsg{
 		SourceChan: h.ShortChanID,
 		HtlcIndex:  h.htlc.HtlcIndex,
@@ -245,7 +245,6 @@ func (h *htlcTimeoutResolver) claimCleanUp(
 	}); err != nil {
 		return err
 	}
-	h.markResolved()
 
 	// Checkpoint our resolver with a report which reflects the preimage
 	// claim by the remote party.
@@ -258,7 +257,7 @@ func (h *htlcTimeoutResolver) claimCleanUp(
 		SpendTxID:       commitSpend.SpenderTxHash,
 	}
 
-	return h.Checkpoint(h, report)
+	return h.resolve(h, report)
 }
 
 // chainDetailsToWatch returns the output and script which we use to watch for
@@ -1160,9 +1159,7 @@ func (h *htlcTimeoutResolver) checkpointClaim(
 	}
 
 	// Finally, we checkpoint the resolver with our report(s).
-	h.markResolved()
-
-	return h.Checkpoint(h, report)
+	return h.resolve(h, report)
 }
 
 // resolveRemoteCommitOutput handles sweeping an HTLC output on the remote

--- a/contractcourt/htlc_timeout_resolver.go
+++ b/contractcourt/htlc_timeout_resolver.go
@@ -1240,18 +1240,27 @@ func (h *htlcTimeoutResolver) resolveTimeoutTx() error {
 
 	h.log.Infof("2nd-level HTLC timeout tx=%v confirmed", spenderTxid)
 
-	// Start the process to sweep the output from the timeout tx.
+	// Re-arm Launch before checkpointing the stage transition so later
+	// blockbeats can retry the second-stage output if this path fails.
 	if h.isZeroFeeOutput() {
-		err = h.sweepTimeoutTxOutput()
-		if err != nil {
-			return err
-		}
+		h.unlaunch()
 	}
 
-	// Create a checkpoint since the timeout tx is confirmed and the sweep
-	// request has been made.
-	if err := h.checkpointStageOne(spenderTxid); err != nil {
+	// Create a checkpoint since the timeout tx is confirmed and the second
+	// stage can now be swept.
+	err = h.checkpointStageOne(spenderTxid)
+	if err != nil {
 		return err
+	}
+
+	// Start the process to sweep the output from the timeout tx.
+	if h.isZeroFeeOutput() {
+		h.markLaunched()
+		err = h.sweepTimeoutTxOutput()
+		if err != nil {
+			h.unlaunch()
+			return err
+		}
 	}
 
 	// Start the resolving process for the stage two output.

--- a/contractcourt/htlc_timeout_resolver_test.go
+++ b/contractcourt/htlc_timeout_resolver_test.go
@@ -2,6 +2,7 @@ package contractcourt
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"reflect"
 	"sync"
@@ -1281,6 +1282,144 @@ func TestHtlcTimeoutSecondStageSweeper(t *testing.T) {
 	testHtlcTimeout(
 		t, twoStageResolution, checkpoints,
 	)
+}
+
+// TestHtlcTimeoutResolverRetriesSecondStageLaunch asserts that the timeout
+// resolver re-arms Launch after moving from the first-stage HTLC timeout tx to
+// its second-stage output.
+func TestHtlcTimeoutResolverRetriesSecondStageLaunch(t *testing.T) {
+	defer timeout()()
+
+	commitOutpoint := wire.OutPoint{
+		Hash:  chainhash.Hash{0x08},
+		Index: 9,
+	}
+	timeoutTx := &wire.MsgTx{
+		TxIn: []*wire.TxIn{
+			{
+				PreviousOutPoint: commitOutpoint,
+			},
+		},
+		TxOut: []*wire.TxOut{
+			cloneTxOut(testSignDesc.Output),
+		},
+	}
+	signer := &mock.DummySigner{}
+	timeoutWitness, err := input.SenderHtlcSpendTimeout(
+		&mock.DummySignature{}, txscript.SigHashAll, signer,
+		&testSignDesc, timeoutTx,
+	)
+	require.NoError(t, err)
+	timeoutTx.TxIn[0].Witness = timeoutWitness
+	timeoutHash := timeoutTx.TxHash()
+
+	resolution := lnwallet.OutgoingHtlcResolution{
+		ClaimOutpoint: wire.OutPoint{
+			Hash:  timeoutHash,
+			Index: 0,
+		},
+		CsvDelay:        4,
+		SignedTimeoutTx: timeoutTx,
+		SignDetails: &input.SignDetails{
+			SignDesc: testSignDesc,
+			PeerSig:  testSig,
+		},
+		SweepSignDesc: testSignDesc,
+	}
+	ctx := newHtlcResolverTestContext(
+		t, func(htlc channeldb.HTLC,
+			cfg ResolverConfig) ContractResolver {
+
+			return newTimeoutResolver(resolution, 0, htlc, 0, cfg)
+		},
+	)
+	resolver, ok := ctx.resolver.(*htlcTimeoutResolver)
+	require.True(t, ok)
+	sweeper, ok := resolver.Sweeper.(*mockSweeper)
+	require.True(t, ok)
+
+	checkpointChan := make(chan struct{}, 1)
+	ctx.checkpoint = func(resolver ContractResolver,
+		reports ...*channeldb.ResolverReport) error {
+
+		timeoutResolver, ok := resolver.(*htlcTimeoutResolver)
+		require.True(t, ok)
+		require.True(t, timeoutResolver.outputIncubating)
+		require.False(t, timeoutResolver.isLaunched())
+		require.Len(t, reports, 1)
+
+		checkpointChan <- struct{}{}
+
+		return nil
+	}
+
+	// The first launch offers the first-stage HTLC timeout tx.
+	require.NoError(t, resolver.Launch())
+	select {
+	case inp := <-sweeper.sweptInputs:
+		require.Equal(t, commitOutpoint, inp.OutPoint())
+	case <-time.After(time.Second):
+		t.Fatal("expected first-stage input to be swept")
+	}
+	require.True(t, resolver.isLaunched())
+
+	// Let Resolve advance to the second stage, then fail the second-stage
+	// offer. The resolver should clear launched so a later Launch can retry
+	// the second-stage output.
+	offerErr := errors.New("stage two offer failed")
+	sweeper.sweepInputErr = offerErr
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- resolver.resolveTimeoutTx()
+	}()
+
+	commitSpend := &chainntnfs.SpendDetail{
+		SpendingTx:        timeoutTx,
+		SpenderTxHash:     &timeoutHash,
+		SpenderInputIndex: 0,
+		SpendingHeight:    10,
+		SpentOutPoint:     &commitOutpoint,
+	}
+	ctx.notifier.SpendChan <- commitSpend
+
+	select {
+	case <-checkpointChan:
+	case <-time.After(time.Second):
+		t.Fatal("expected second-stage checkpoint")
+	}
+	ctx.notifier.SpendChan <- commitSpend
+
+	select {
+	case err := <-errChan:
+		require.ErrorIs(t, err, offerErr)
+	case <-time.After(time.Second):
+		t.Fatal("expected second-stage offer error")
+	}
+	require.True(t, resolver.outputIncubating)
+	require.False(t, resolver.isLaunched())
+
+	// A later Launch should retry the second-stage output instead of
+	// returning at the stale first-stage launched guard.
+	sweeper.sweepInputErr = nil
+	retryErr := make(chan error, 1)
+	go func() {
+		retryErr <- resolver.Launch()
+	}()
+	ctx.notifier.SpendChan <- commitSpend
+
+	select {
+	case err := <-retryErr:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("expected retry launch result")
+	}
+	select {
+	case inp := <-sweeper.sweptInputs:
+		require.Equal(t, resolution.ClaimOutpoint, inp.OutPoint())
+	case <-time.After(time.Second):
+		t.Fatal("expected second-stage input to be swept")
+	}
+	require.True(t, resolver.isLaunched())
 }
 
 // TestHtlcTimeoutSecondStageSweeperRemoteSpend tests that if a local timeout

--- a/contractcourt/htlc_timeout_resolver_test.go
+++ b/contractcourt/htlc_timeout_resolver_test.go
@@ -32,9 +32,11 @@ var (
 )
 
 type mockWitnessBeacon struct {
-	preImageUpdates chan lntypes.Preimage
-	newPreimages    chan []lntypes.Preimage
-	lookupPreimage  map[lntypes.Hash]lntypes.Preimage
+	lookupPreimageLock sync.Mutex
+	preImageUpdates    chan lntypes.Preimage
+	newPreimages       chan []lntypes.Preimage
+	lookupPreimage     map[lntypes.Hash]lntypes.Preimage
+	lookupSignal       chan lntypes.Hash
 }
 
 func newMockWitnessBeacon() *mockWitnessBeacon {
@@ -57,6 +59,16 @@ func (m *mockWitnessBeacon) SubscribeUpdates(
 }
 
 func (m *mockWitnessBeacon) LookupPreimage(payhash lntypes.Hash) (lntypes.Preimage, bool) {
+	if m.lookupSignal != nil {
+		select {
+		case m.lookupSignal <- payhash:
+		default:
+		}
+	}
+
+	m.lookupPreimageLock.Lock()
+	defer m.lookupPreimageLock.Unlock()
+
 	preimage, ok := m.lookupPreimage[payhash]
 	if !ok {
 		return lntypes.Preimage{}, false
@@ -64,7 +76,22 @@ func (m *mockWitnessBeacon) LookupPreimage(payhash lntypes.Hash) (lntypes.Preima
 	return preimage, true
 }
 
+func (m *mockWitnessBeacon) setLookupPreimage(hash lntypes.Hash,
+	preimage lntypes.Preimage) {
+
+	m.lookupPreimageLock.Lock()
+	defer m.lookupPreimageLock.Unlock()
+
+	m.lookupPreimage[hash] = preimage
+}
+
 func (m *mockWitnessBeacon) AddPreimages(preimages ...lntypes.Preimage) error {
+	m.lookupPreimageLock.Lock()
+	for _, preimage := range preimages {
+		m.lookupPreimage[preimage.Hash()] = preimage
+	}
+	m.lookupPreimageLock.Unlock()
+
 	m.newPreimages <- preimages
 	return nil
 }

--- a/contractcourt/interfaces.go
+++ b/contractcourt/interfaces.go
@@ -22,6 +22,11 @@ type Registry interface {
 	// byte payment hash.
 	LookupInvoice(context.Context, lntypes.Hash) (invoices.Invoice, error)
 
+	// LookupInvoiceByRef attempts to look up an invoice according to the
+	// given invoice reference.
+	LookupInvoiceByRef(context.Context, invoices.InvoiceRef) (
+		invoices.Invoice, error)
+
 	// NotifyExitHopHtlc attempts to mark an invoice as settled. If the
 	// invoice is a debug invoice, then this method is a noop as debug
 	// invoices are never fully settled. The return value describes how the

--- a/contractcourt/mock_htlcnotifier_test.go
+++ b/contractcourt/mock_htlcnotifier_test.go
@@ -7,9 +7,12 @@ import (
 
 type mockHTLCNotifier struct {
 	HtlcNotifier
+
+	finalHtlcEvents []channeldb.FinalHtlcInfo
 }
 
 func (m *mockHTLCNotifier) NotifyFinalHtlcEvent(key models.CircuitKey,
 	info channeldb.FinalHtlcInfo) {
 
+	m.finalHtlcEvents = append(m.finalHtlcEvents, info)
 }

--- a/contractcourt/mock_registry_test.go
+++ b/contractcourt/mock_registry_test.go
@@ -23,6 +23,10 @@ type mockRegistry struct {
 	notifyResolution invoices.HtlcResolution
 	immediateNotify  []notifyExitHopData
 	notifyHook       func()
+	lookupInvoice    invoices.Invoice
+	lookupInvoiceSet bool
+	lookupErr        error
+	lookupCount      int
 }
 
 func (r *mockRegistry) NotifyExitHopHtlc(payHash lntypes.Hash,
@@ -65,5 +69,24 @@ func (r *mockRegistry) HodlUnsubscribeAll(subscriber chan<- interface{}) {}
 func (r *mockRegistry) LookupInvoice(context.Context, lntypes.Hash) (
 	invoices.Invoice, error) {
 
-	return invoices.Invoice{}, invoices.ErrInvoiceNotFound
+	return r.lookupInvoiceResult()
+}
+
+func (r *mockRegistry) LookupInvoiceByRef(_ context.Context,
+	_ invoices.InvoiceRef) (invoices.Invoice, error) {
+
+	return r.lookupInvoiceResult()
+}
+
+func (r *mockRegistry) lookupInvoiceResult() (invoices.Invoice, error) {
+	r.lookupCount++
+	if r.lookupErr != nil {
+		return invoices.Invoice{}, r.lookupErr
+	}
+
+	if !r.lookupInvoiceSet {
+		return invoices.Invoice{}, invoices.ErrInvoiceNotFound
+	}
+
+	return r.lookupInvoice, nil
 }

--- a/contractcourt/mock_registry_test.go
+++ b/contractcourt/mock_registry_test.go
@@ -23,6 +23,7 @@ type mockRegistry struct {
 	notifyResolution invoices.HtlcResolution
 	immediateNotify  []notifyExitHopData
 	notifyHook       func()
+	lookupHook       func()
 	lookupInvoice    invoices.Invoice
 	lookupInvoiceSet bool
 	lookupErr        error
@@ -80,6 +81,10 @@ func (r *mockRegistry) LookupInvoiceByRef(_ context.Context,
 
 func (r *mockRegistry) lookupInvoiceResult() (invoices.Invoice, error) {
 	r.lookupCount++
+	if r.lookupHook != nil {
+		r.lookupHook()
+	}
+
 	if r.lookupErr != nil {
 		return invoices.Invoice{}, r.lookupErr
 	}

--- a/contractcourt/mock_registry_test.go
+++ b/contractcourt/mock_registry_test.go
@@ -21,6 +21,7 @@ type mockRegistry struct {
 	notifyChan       chan notifyExitHopData
 	notifyErr        error
 	notifyResolution invoices.HtlcResolution
+	immediateNotify  []notifyExitHopData
 }
 
 func (r *mockRegistry) NotifyExitHopHtlc(payHash lntypes.Hash,
@@ -31,6 +32,13 @@ func (r *mockRegistry) NotifyExitHopHtlc(payHash lntypes.Hash,
 
 	// Exit early if the notification channel is nil.
 	if hodlChan == nil {
+		r.immediateNotify = append(r.immediateNotify, notifyExitHopData{
+			payHash:       payHash,
+			paidAmount:    paidAmount,
+			expiry:        expiry,
+			currentHeight: currentHeight,
+		})
+
 		return r.notifyResolution, r.notifyErr
 	}
 

--- a/contractcourt/mock_registry_test.go
+++ b/contractcourt/mock_registry_test.go
@@ -22,6 +22,7 @@ type mockRegistry struct {
 	notifyErr        error
 	notifyResolution invoices.HtlcResolution
 	immediateNotify  []notifyExitHopData
+	notifyHook       func()
 }
 
 func (r *mockRegistry) NotifyExitHopHtlc(payHash lntypes.Hash,
@@ -38,6 +39,9 @@ func (r *mockRegistry) NotifyExitHopHtlc(payHash lntypes.Hash,
 			expiry:        expiry,
 			currentHeight: currentHeight,
 		})
+		if r.notifyHook != nil {
+			r.notifyHook()
+		}
 
 		return r.notifyResolution, r.notifyErr
 	}
@@ -48,6 +52,9 @@ func (r *mockRegistry) NotifyExitHopHtlc(payHash lntypes.Hash,
 		paidAmount:    paidAmount,
 		expiry:        expiry,
 		currentHeight: currentHeight,
+	}
+	if r.notifyHook != nil {
+		r.notifyHook()
 	}
 
 	return r.notifyResolution, r.notifyErr

--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -42,6 +42,14 @@
   regardless of peer connectivity. Uptime is now seeded from the peer's
   actual connection state.
 
+* [Fixed an issue](https://github.com/lightningnetwork/lnd/issues/10840)
+  where an incoming HTLC resolver could treat a foreign spend of the
+  commitment HTLC output as its own success transaction, causing a
+  phantom second-level input to be offered to the sweeper. The resolver
+  now validates the spending transaction's expected output before
+  sweeping it, and avoids launching the success path for incoming HTLCs
+  that are already expired.
+
 # New Features
 
 ## Functional Enhancements
@@ -116,3 +124,4 @@
 * bitromortac
 * Boris Nagaev
 * Erick Cestari
+* Yong Yu


### PR DESCRIPTION
Stacked on #10869 / fix-10840-success-resolver.

This moves the retry/replay/lifecycle changes out of the focused #10840 fix. It keeps retry resolver checkpointing, invoice replay/preimage attachment, taproot state preservation, launch-resolved handling, and HTLC launch retry work as a follow-up.

Compile check:
GOWORK=off go test ./contractcourt -run ^