### PR TITLE
invoices: defer settlement finality

### DIFF
--- a/channeldb/invoice_test.go
+++ b/channeldb/invoice_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/lightningnetwork/lnd/graph/db/models"
 	invpkg "github.com/lightningnetwork/lnd/invoices"
 	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/record"
 	"github.com/lightningnetwork/lnd/tlv"
 	"github.com/stretchr/testify/require"
 )
@@ -127,4 +128,73 @@ func TestInvoiceBucketTombstone(t *testing.T) {
 	tombstoneExists, err = db.GetInvoiceBucketTombstone()
 	require.NoError(t, err)
 	require.True(t, tombstoneExists)
+}
+
+// TestKVInvoiceUpdaterUpdateAmpStatePersistsFullSet asserts AMP sub-invoice
+// updates rewrite the bucket with every HTLC in the set, including siblings
+// that reached a different state in an earlier update.
+func TestKVInvoiceUpdaterUpdateAmpStatePersistsFullSet(t *testing.T) {
+	t.Parallel()
+
+	setID := invpkg.SetID{1}
+	ampRecord := record.NewAMP([32]byte{2}, [32]byte(setID), 3)
+	circuitKey1 := models.CircuitKey{
+		ChanID: lnwire.NewShortChanIDFromInt(1), HtlcID: 1,
+	}
+	circuitKey2 := models.CircuitKey{
+		ChanID: lnwire.NewShortChanIDFromInt(1), HtlcID: 2,
+	}
+	circuitKey3 := models.CircuitKey{
+		ChanID: lnwire.NewShortChanIDFromInt(1), HtlcID: 3,
+	}
+
+	invoice := &invpkg.Invoice{
+		Htlcs: map[models.CircuitKey]*invpkg.InvoiceHTLC{
+			circuitKey1: {
+				State: invpkg.HtlcStateSettled,
+				AMP: &invpkg.InvoiceHtlcAMPData{
+					Record: *ampRecord,
+				},
+			},
+			circuitKey2: {
+				State: invpkg.HtlcStatePendingSettle,
+				AMP: &invpkg.InvoiceHtlcAMPData{
+					Record: *ampRecord,
+				},
+			},
+			circuitKey3: {
+				State: invpkg.HtlcStatePendingSettle,
+				AMP: &invpkg.InvoiceHtlcAMPData{
+					Record: *ampRecord,
+				},
+			},
+		},
+	}
+
+	newUpdater := func() *kvInvoiceUpdater {
+		return &kvInvoiceUpdater{
+			invoice:         invoice,
+			updatedAmpHtlcs: make(ampHTLCsMap),
+			settledSetIDs:   make(map[invpkg.SetID]struct{}),
+		}
+	}
+
+	updater := newUpdater()
+	err := updater.UpdateAmpState(
+		setID, invpkg.InvoiceStateAMP{
+			State: invpkg.HtlcStatePendingSettle,
+		}, circuitKey2,
+	)
+	require.NoError(t, err)
+	require.Equal(t, invoice.Htlcs, updater.updatedAmpHtlcs[setID])
+
+	updater = newUpdater()
+	err = updater.UpdateAmpState(
+		setID, invpkg.InvoiceStateAMP{
+			State: invpkg.HtlcStateSettled,
+		}, circuitKey3,
+	)
+	require.NoError(t, err)
+	require.Equal(t, invoice.Htlcs, updater.updatedAmpHtlcs[setID])
+	require.Contains(t, updater.settledSetIDs, setID)
 }

--- a/channeldb/invoices.go
+++ b/channeldb/invoices.go
@@ -830,22 +830,21 @@ func (k *kvInvoiceUpdater) UpdateAmpState(setID [32]byte,
 			)
 
 		case invpkg.HtlcStateCanceled:
-			// Only HTLCs in the accepted state, can be cancelled,
-			// but we also want to merge that with HTLCs that may be
-			// canceled as well since it can be cancelled one by
-			// one.
-			k.updatedAmpHtlcs[setID] = k.invoice.HTLCSet(
-				&setID, invpkg.HtlcStateAccepted,
+			k.updatedAmpHtlcs[setID] = ampHTLCSet(
+				k.invoice, &setID,
 			)
 
-			cancelledHtlcs := k.invoice.HTLCSet(
-				&setID, invpkg.HtlcStateCanceled,
+		case invpkg.HtlcStatePendingSettle:
+			// Pending-settle AMP HTLCs must be written through
+			// the AMP sub-invoice bucket, but they do not yet
+			// receive a settle index or resolve as final.
+			k.updatedAmpHtlcs[setID] = ampHTLCSet(
+				k.invoice, &setID,
 			)
-			maps.Copy(k.updatedAmpHtlcs[setID], cancelledHtlcs)
 
 		case invpkg.HtlcStateSettled:
-			k.updatedAmpHtlcs[setID] = make(
-				map[models.CircuitKey]*invpkg.InvoiceHTLC,
+			k.updatedAmpHtlcs[setID] = ampHTLCSet(
+				k.invoice, &setID,
 			)
 		}
 	}
@@ -859,6 +858,21 @@ func (k *kvInvoiceUpdater) UpdateAmpState(setID [32]byte,
 	k.updatedAmpHtlcs[setID][circuitKey] = k.invoice.Htlcs[circuitKey]
 
 	return nil
+}
+
+// ampHTLCSet returns all HTLCs belonging to setID, regardless of their current
+// state.
+func ampHTLCSet(invoice *invpkg.Invoice,
+	setID *[32]byte) map[models.CircuitKey]*invpkg.InvoiceHTLC {
+
+	htlcSet := make(map[models.CircuitKey]*invpkg.InvoiceHTLC)
+	for key, htlc := range invoice.Htlcs {
+		if htlc.IsInHTLCSet(setID) {
+			htlcSet[key] = htlc
+		}
+	}
+
+	return htlcSet
 }
 
 // Finalize finalizes the update before it is written to the database.

--- a/channeldb/invoices.go
+++ b/channeldb/invoices.go
@@ -878,6 +878,12 @@ func (k *kvInvoiceUpdater) Finalize(updateType invpkg.UpdateType) error {
 		// invoice. All HTLCs which were accepted are now canceled, so
 		// we persist this state.
 		return k.storeCancelHtlcsUpdate()
+
+	case invpkg.FinalizeHTLCsUpdate:
+		// Finalization converts pending-settle HTLCs into their
+		// terminal state, so persist the invoice and any updated
+		// AMP sub-invoices.
+		return k.storeAddHtlcsUpdate()
 	}
 
 	return fmt.Errorf("unknown update type: %v", updateType)
@@ -959,14 +965,10 @@ func (k *kvInvoiceUpdater) storeAddHtlcsUpdate() error {
 	return nil
 }
 
-// storeSettleHodlInvoiceUpdate updates the invoice in the database after
-// settling a hodl invoice.
+// storeSettleHodlInvoiceUpdate updates the invoice in the database after a
+// hodl invoice settlement is requested. Settle metadata is only written once
+// the HTLC outcome is final.
 func (k *kvInvoiceUpdater) storeSettleHodlInvoiceUpdate() error {
-	err := k.setSettleMetaFields(nil)
-	if err != nil {
-		return err
-	}
-
 	return k.serializeAndStoreInvoice()
 }
 

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -175,6 +175,13 @@ type ChannelArbitratorConfig struct {
 	// spend his/her outgoing HTLC via the timeout path.
 	FindOutgoingHTLCDeadline func(htlc channeldb.HTLC) fn.Option[int32]
 
+	// subscribeBlockbeats lets a resolver temporarily subscribe to the
+	// channel arbitrator's ordered blockbeat stream while it is actively
+	// waiting for block-based resolution. This is intentionally private to
+	// contractcourt because resolver blockbeat subscriptions are internal
+	// coordination between the ChannelArbitrator and resolver goroutines.
+	subscribeBlockbeats func() (*blockbeatSubscription, func())
+
 	ChainArbitratorConfig
 }
 
@@ -315,6 +322,68 @@ func (h HtlcSetKey) String() string {
 	}
 }
 
+// blockbeatUpdate delivers one blockbeat to a resolver subscription together
+// with the per-beat error channel used to ack that delivery.
+//
+// The ack channel is deliberately scoped to one beat so a late ack after a
+// dispatcher timeout cannot be reused as the ack for a later beat.
+type blockbeatUpdate struct {
+	beat    chainio.Blockbeat
+	errChan chan error
+}
+
+// ack signals that the resolver has finished processing this blockbeat update.
+//
+// Resolver subscriptions are part of the ChannelArbitrator's ordered
+// blockbeat processing path, not fire-and-forget block notifications. The
+// arbitrator waits for this ack after it launches resolvers for a height and
+// before it marks its own parent blockbeat as processed. This preserves the
+// launch-before-expiry ordering and ensures a block is not considered handled
+// until subscribed resolvers have finished their height-dependent work.
+func (b blockbeatUpdate) ack(err error) {
+	select {
+	case b.errChan <- err:
+	default:
+	}
+}
+
+// blockbeatSubscription is a temporary blockbeat subscription owned by the
+// ChannelArbitrator and consumed by a resolver while that resolver is in the
+// part of Resolve that is actually waiting for block-based progress.
+//
+// This type exists because contract resolvers are not long-lived subsystems. A
+// normal chainio.Consumer such as ChainArbitrator, ChannelArbitrator,
+// chainWatcher, or the sweeper owns a goroutine that continuously selects on
+// its BlockbeatChan for as long as the subsystem is running. That makes it
+// safe for a parent dispatcher to call ProcessBlock at any time and wait for
+// the consumer to acknowledge the beat.
+//
+// An htlcIncomingContestResolver has a narrower lifecycle. Launch only needs a
+// current-height snapshot, and Resolve can return before it starts waiting for
+// blocks if it finds a preimage, receives an immediate invoice result, or sees
+// that the HTLC is already expired. Once Resolve does enter its wait loop, it
+// needs ordered blockbeats so expiry is processed after the
+// ChannelArbitrator has retried Launch for the same block. Outside that wait
+// loop, however, there is no resolver goroutine guaranteed to be reading a
+// beat channel.
+//
+// Making the resolver itself a chainio.Consumer would therefore expose an
+// always-ready ProcessBlock method for an object that is only sometimes ready.
+// Dispatching to such a resolver can block until the dispatcher timeout if
+// the resolver is active but has not yet reached its block-waiting select, or
+// if it has already returned.
+//
+// A blockbeatSubscription models the smaller lifecycle directly. The resolver
+// creates one only after it has reached the phase where it can receive and ack
+// blockbeats, and it cancels the subscription when Resolve returns. The
+// ChannelArbitrator dispatches blockbeats only to the currently registered
+// subscriptions, preserving the parent-waits-for-child-ack pattern without
+// pretending that a resolver is an always-running blockbeat consumer.
+type blockbeatSubscription struct {
+	blockbeatChan chan blockbeatUpdate
+	quit          chan struct{}
+}
+
 // ChannelArbitrator is the on-chain arbitrator for a particular channel. The
 // struct will keep in sync with the current set of HTLCs on the commitment
 // transaction. The job of the attendant is to go on-chain to either settle or
@@ -365,6 +434,14 @@ type ChannelArbitrator struct {
 	// resolvers slice.
 	activeResolversLock sync.RWMutex
 
+	// blockbeatSubs is the set of active resolver blockbeat subscriptions.
+	// Membership can change while a blockbeat is being dispatched. This is
+	// safe: canceled subscriptions close their quit channel, subscribers
+	// ack delivered beats, and newly registered resolvers check the
+	// current best height after subscribing to catch a beat that arrived
+	// before they were in the set.
+	blockbeatSubs lnutils.SyncMap[*blockbeatSubscription, struct{}]
+
 	// resolutionSignal is a channel that will be sent upon by contract
 	// resolvers once their contract has been fully resolved. With each
 	// send, we'll check to see if the contract is fully resolved.
@@ -409,6 +486,13 @@ func NewChannelArbitrator(cfg ChannelArbitratorConfig,
 		unmergedSet:      unmerged,
 		cfg:              cfg,
 		quit:             make(chan struct{}),
+	}
+	c.cfg.subscribeBlockbeats = c.subscribeBlockbeats
+
+	// The log keeps its own config copy and uses it when decoding
+	// persisted resolvers, so setting c.cfg above is not enough.
+	if boltLog, ok := log.(*boltArbitratorLog); ok {
+		boltLog.cfg.subscribeBlockbeats = c.subscribeBlockbeats
 	}
 
 	// Mount the block consumer.
@@ -1632,6 +1716,182 @@ func (c *ChannelArbitrator) launchResolvers() {
 
 			return
 		}
+	}
+}
+
+// subscribeBlockbeats registers a resolver as ready to receive ordered
+// blockbeats from this ChannelArbitrator.
+func (c *ChannelArbitrator) subscribeBlockbeats() (
+	*blockbeatSubscription, func()) {
+
+	sub := &blockbeatSubscription{
+		blockbeatChan: make(chan blockbeatUpdate),
+		quit:          make(chan struct{}),
+	}
+	c.blockbeatSubs.Store(sub, struct{}{})
+
+	cancel := func() {
+		c.cancelBlockbeatSubscription(sub)
+	}
+
+	return sub, cancel
+}
+
+// cancelBlockbeatSubscription removes a resolver blockbeat subscription and
+// closes its quit channel. It is safe to call multiple times.
+func (c *ChannelArbitrator) cancelBlockbeatSubscription(
+	sub *blockbeatSubscription) {
+
+	if _, ok := c.blockbeatSubs.LoadAndDelete(sub); !ok {
+		log.Debugf("ChannelArbitrator(%v): resolver blockbeat "+
+			"subscription=%p already canceled",
+			c.cfg.ChanPoint, sub)
+
+		return
+	}
+
+	log.Debugf("ChannelArbitrator(%v): canceling resolver blockbeat "+
+		"subscription=%p", c.cfg.ChanPoint, sub)
+
+	close(sub.quit)
+}
+
+// dispatchBlockbeatToSubscribers notifies registered resolver blockbeat
+// subscriptions of the latest blockbeat. This is called after launchResolvers
+// so contest resolvers process expiry after any relaunch attempt for the same
+// block.
+func (c *ChannelArbitrator) dispatchBlockbeatToSubscribers(
+	beat chainio.Blockbeat) error {
+
+	subs := make([]*blockbeatSubscription, 0)
+	c.blockbeatSubs.Range(func(
+		sub *blockbeatSubscription, _ struct{},
+	) bool {
+
+		subs = append(subs, sub)
+
+		return true
+	})
+
+	errChan := make(chan error, len(subs))
+	var wg sync.WaitGroup
+	for _, sub := range subs {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			err := c.dispatchBlockbeatToSub(beat, sub)
+			if err != nil {
+				errChan <- err
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errChan)
+
+	// Dispatch runs subscribers concurrently, so log every non-nil error.
+	// Return only the last one to keep the caller's single-error contract.
+	var lastErr error
+	for err := range errChan {
+		log.Errorf("ChannelArbitrator(%v): resolver blockbeat "+
+			"dispatch height=%v failed: %v",
+			c.cfg.ChanPoint, beat.Height(), err)
+
+		lastErr = err
+	}
+
+	return lastErr
+}
+
+// dispatchBlockbeatToSub sends a blockbeat to one resolver subscription and
+// waits for its ack.
+func (c *ChannelArbitrator) dispatchBlockbeatToSub(
+	beat chainio.Blockbeat, sub *blockbeatSubscription) error {
+
+	timeout := time.NewTimer(chainio.DefaultProcessBlockTimeout)
+	defer timeout.Stop()
+
+	processTimeoutErr := func(stage string) error {
+		log.Debugf("ChannelArbitrator(%v): resolver blockbeat "+
+			"subscriber=%p timed out while %s height=%v",
+			c.cfg.ChanPoint, sub, stage, beat.Height())
+
+		return fmt.Errorf("resolver blockbeat subscriber: %w",
+			chainio.ErrProcessBlockTimeout)
+	}
+	// Each delivery gets its own ack channel. If the dispatcher times out,
+	// a late resolver ack lands only on this update and cannot satisfy a
+	// future delivery.
+	update := blockbeatUpdate{
+		beat:    beat,
+		errChan: make(chan error, 1),
+	}
+
+	// The timeout covers both sending the beat and waiting for the ack. A
+	// resolver can register before its receive loop is scheduled, so the
+	// send itself must not be allowed to block arbitrator block processing
+	// indefinitely.
+	select {
+	case sub.blockbeatChan <- update:
+		log.Debugf("ChannelArbitrator(%v): dispatched resolver "+
+			"blockbeat height=%v to subscriber=%p",
+			c.cfg.ChanPoint, beat.Height(), sub)
+
+	case <-sub.quit:
+		log.Debugf("ChannelArbitrator(%v): resolver blockbeat "+
+			"subscriber=%p canceled before dispatch height=%v",
+			c.cfg.ChanPoint, sub, beat.Height())
+
+		return nil
+
+	case <-c.quit:
+		log.Debugf("ChannelArbitrator(%v): stopping resolver "+
+			"blockbeat dispatch for height=%v",
+			c.cfg.ChanPoint, beat.Height())
+
+		return nil
+
+	case <-timeout.C:
+		return processTimeoutErr("sending beat")
+	}
+
+	select {
+	case err := <-update.errChan:
+		log.Debugf("ChannelArbitrator(%v): resolver blockbeat "+
+			"subscriber=%p acked height=%v with err=%v",
+			c.cfg.ChanPoint, sub, beat.Height(), err)
+
+		return err
+
+	case <-sub.quit:
+		select {
+		case err := <-update.errChan:
+			log.Debugf("ChannelArbitrator(%v): resolver blockbeat "+
+				"subscriber=%p canceled after ack height=%v "+
+				"with err=%v", c.cfg.ChanPoint, sub,
+				beat.Height(), err)
+
+			return err
+
+		default:
+		}
+
+		log.Debugf("ChannelArbitrator(%v): resolver blockbeat "+
+			"subscriber=%p canceled before ack height=%v",
+			c.cfg.ChanPoint, sub, beat.Height())
+
+		return nil
+
+	case <-c.quit:
+		log.Debugf("ChannelArbitrator(%v): stopping resolver "+
+			"blockbeat ack wait for height=%v",
+			c.cfg.ChanPoint, beat.Height())
+
+		return nil
+
+	case <-timeout.C:
+		return processTimeoutErr("waiting for ack")
 	}
 }
 
@@ -3016,7 +3276,7 @@ func (c *ChannelArbitrator) handleBlockbeat(beat chainio.Blockbeat) error {
 		// their own `launched` states.
 		c.launchResolvers()
 
-		return nil
+		return c.dispatchBlockbeatToSubscribers(beat)
 	}
 
 	// Perform a non-blocking read on the close events in case the channel
@@ -3037,6 +3297,10 @@ func (c *ChannelArbitrator) handleBlockbeat(beat chainio.Blockbeat) error {
 
 	// Launch all active resolvers when a new blockbeat is received.
 	c.launchResolvers()
+	if err := c.dispatchBlockbeatToSubscribers(beat); err != nil {
+		return fmt.Errorf("unable to dispatch resolver "+
+			"blockbeat: %w", err)
+	}
 
 	return nil
 }

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -1352,6 +1352,25 @@ func (c *ChannelArbitrator) stateStep(
 		// HTLCs for their corresponding outgoing HTLCs on the remote
 		// commitment set (remote and remote pending set).
 		if contractResolutions.BreachResolution != nil {
+			incomingHTLCs := fn.NewSet[uint64]()
+			for htlcSetKey, htlcs := range confCommitSet.HtlcSets {
+				if !htlcSetKey.IsRemote {
+					continue
+				}
+
+				for _, htlc := range htlcs {
+					if !htlc.Incoming {
+						continue
+					}
+
+					incomingHTLCs.Add(htlc.HtlcIndex)
+				}
+			}
+			err := c.failBreachedIncomingHtlcs(incomingHTLCs)
+			if err != nil {
+				return StateError, closeTx, err
+			}
+
 			// cancelBreachedHTLCs is a set which holds HTLCs whose
 			// corresponding incoming HTLCs will be failed back
 			// because the peer broadcasted an old state.
@@ -1377,7 +1396,7 @@ func (c *ChannelArbitrator) stateStep(
 				}
 			}
 
-			err := c.abandonForwards(cancelBreachedHTLCs)
+			err = c.abandonForwards(cancelBreachedHTLCs)
 			if err != nil {
 				return StateError, closeTx, err
 			}
@@ -3574,6 +3593,49 @@ func (c *ChannelArbitrator) prepareAnchorSweeps(heightHint uint32,
 	return requests, nil
 }
 
+// failBreachedIncomingHtlcs finalizes incoming HTLCs found on a breached remote
+// commitment as failed. The registry ignores HTLCs that are not pending-settle
+// exit-hop payments.
+func (c *ChannelArbitrator) failBreachedIncomingHtlcs(
+	htlcs fn.Set[uint64]) error {
+
+	for htlcIndex := range htlcs {
+		chainArbCfg := c.cfg.ChainArbitratorConfig
+		key := models.CircuitKey{
+			ChanID: c.cfg.ShortChanID,
+			HtlcID: htlcIndex,
+		}
+
+		err := chainArbCfg.PutFinalHtlcOutcome(
+			key.ChanID, key.HtlcID, false,
+		)
+		if err != nil {
+			return fmt.Errorf("unable to store final breached "+
+				"incoming htlc outcome %v: %w", key, err)
+		}
+
+		err = chainArbCfg.Registry.NotifyExitHopHtlcFinalized(
+			context.Background(), key, false,
+		)
+		if err != nil {
+			log.Warnf(
+				"Unable to finalize breached incoming htlc %v: %v",
+				key, err,
+			)
+		}
+
+		chainArbCfg.HtlcNotifier.NotifyFinalHtlcEvent(
+			key,
+			channeldb.FinalHtlcInfo{
+				Settled:  false,
+				Offchain: false,
+			},
+		)
+	}
+
+	return nil
+}
+
 // failIncomingDust resolves the incoming dust HTLCs because they do not have
 // an output on the commitment transaction and cannot be resolved onchain. We
 // mark them as failed here.
@@ -3598,6 +3660,14 @@ func (c *ChannelArbitrator) failIncomingDust(
 		)
 		if err != nil {
 			return err
+		}
+
+		err = chainArbCfg.Registry.NotifyExitHopHtlcFinalized(
+			context.Background(), key, false,
+		)
+		if err != nil {
+			log.Warnf("Unable to finalize incoming dust htlc %v: %v",
+				key, err)
 		}
 
 		// Send notification.

--- a/contractcourt/channel_arbitrator_test.go
+++ b/contractcourt/channel_arbitrator_test.go
@@ -3164,6 +3164,93 @@ func assertResolverReport(t *testing.T, reports chan *channeldb.ResolverReport,
 	}
 }
 
+// TestDispatchBlockbeatToSubSendTimeout asserts that resolver blockbeat sends
+// cannot block arbitrator processing indefinitely before the resolver starts
+// receiving from its subscription.
+func TestDispatchBlockbeatToSubSendTimeout(t *testing.T) {
+	oldTimeout := chainio.DefaultProcessBlockTimeout
+	chainio.DefaultProcessBlockTimeout = 10 * time.Millisecond
+	t.Cleanup(func() {
+		chainio.DefaultProcessBlockTimeout = oldTimeout
+	})
+
+	chanArb := &ChannelArbitrator{
+		quit: make(chan struct{}),
+	}
+	sub := &blockbeatSubscription{
+		blockbeatChan: make(chan blockbeatUpdate),
+		quit:          make(chan struct{}),
+	}
+	chanArb.blockbeatSubs.Store(sub, struct{}{})
+
+	err := chanArb.dispatchBlockbeatToSub(newBeatFromHeight(1), sub)
+	require.ErrorIs(t, err, chainio.ErrProcessBlockTimeout)
+	require.Equal(t, 1, chanArb.blockbeatSubs.Len())
+
+	select {
+	case <-sub.quit:
+		t.Fatal("expected timeout to leave subscription active")
+
+	default:
+	}
+}
+
+// TestDispatchBlockbeatToSubAckTimeoutIgnoresLateAck asserts that a resolver
+// that acks after dispatch times out cannot leave a stale ack for a future
+// beat.
+func TestDispatchBlockbeatToSubAckTimeoutIgnoresLateAck(t *testing.T) {
+	oldTimeout := chainio.DefaultProcessBlockTimeout
+	chainio.DefaultProcessBlockTimeout = 10 * time.Millisecond
+	t.Cleanup(func() {
+		chainio.DefaultProcessBlockTimeout = oldTimeout
+	})
+
+	chanArb := &ChannelArbitrator{
+		quit: make(chan struct{}),
+	}
+	sub := &blockbeatSubscription{
+		blockbeatChan: make(chan blockbeatUpdate),
+		quit:          make(chan struct{}),
+	}
+	chanArb.blockbeatSubs.Store(sub, struct{}{})
+
+	beatReceived := make(chan struct{})
+	releaseLateAck := make(chan struct{})
+	secondBeatAcked := make(chan struct{})
+	go func() {
+		update := <-sub.blockbeatChan
+		close(beatReceived)
+
+		<-releaseLateAck
+		update.ack(nil)
+
+		update = <-sub.blockbeatChan
+		update.ack(nil)
+		close(secondBeatAcked)
+	}()
+
+	err := chanArb.dispatchBlockbeatToSub(newBeatFromHeight(1), sub)
+	require.ErrorIs(t, err, chainio.ErrProcessBlockTimeout)
+	require.Equal(t, 1, chanArb.blockbeatSubs.Len())
+
+	select {
+	case <-beatReceived:
+	case <-time.After(time.Second):
+		t.Fatal("expected resolver to receive beat")
+	}
+	close(releaseLateAck)
+
+	require.NoError(t, chanArb.dispatchBlockbeatToSubscribers(
+		newBeatFromHeight(2),
+	))
+
+	select {
+	case <-secondBeatAcked:
+	case <-time.After(time.Second):
+		t.Fatal("expected resolver to ack second beat")
+	}
+}
+
 type mockChannel struct {
 	anchorResolutions *lnwallet.AnchorResolutions
 

--- a/contractcourt/channel_arbitrator_test.go
+++ b/contractcourt/channel_arbitrator_test.go
@@ -749,7 +749,8 @@ func TestChannelArbitratorBreachClose(t *testing.T) {
 	require.NoError(t, err, "unable to create ChannelArbitrator")
 	chanArb := chanArbCtx.chanArb
 	chanArb.cfg.PreimageDB = newMockWitnessBeacon()
-	chanArb.cfg.Registry = &mockRegistry{}
+	registry := &mockRegistry{}
+	chanArb.cfg.Registry = registry
 
 	beat := newBeatFromHeight(0)
 	if err := chanArb.Start(nil, beat); err != nil {
@@ -800,7 +801,8 @@ func TestChannelArbitratorBreachClose(t *testing.T) {
 		CommitSet: CommitSet{
 			ConfCommitKey: fn.Some(RemoteHtlcSet),
 			HtlcSets: map[HtlcSetKey][]channeldb.HTLC{
-				RemoteHtlcSet: {htlc1, htlc2},
+				RemoteHtlcSet:        {htlc1, htlc2},
+				RemotePendingHtlcSet: {htlc2},
 			},
 		},
 		CommitHash: chainhash.Hash{},
@@ -842,6 +844,33 @@ func TestChannelArbitratorBreachClose(t *testing.T) {
 		}
 	}
 	require.True(t, anchorExists && breachExists)
+	incomingCircuitKey := models.CircuitKey{
+		ChanID: chanArb.cfg.ShortChanID,
+		HtlcID: htlc2.HtlcIndex,
+	}
+
+	// The breach path stores and emits the final failed outcome for
+	// incoming HTLCs in addition to finalizing the invoice outcome.
+	require.Equal(t, map[uint64]bool{
+		htlc2.HtlcIndex: false,
+	}, chanArbCtx.finalHtlcs)
+	require.Equal(t, []finalizeExitHopData{
+		{
+			circuitKey: incomingCircuitKey,
+			settled:    false,
+		},
+	}, registry.finalized)
+	notifier, ok := chanArb.cfg.HtlcNotifier.(*mockHTLCNotifier)
+	require.True(t, ok)
+	require.Equal(t, []models.CircuitKey{
+		incomingCircuitKey,
+	}, notifier.finalHtlcEventKeys)
+	require.Equal(t, []channeldb.FinalHtlcInfo{
+		{
+			Settled:  false,
+			Offchain: false,
+		},
+	}, notifier.finalHtlcEvents)
 
 	// The anchor resolver is expected to re-offer the anchor input to the
 	// sweeper.
@@ -865,6 +894,38 @@ func TestChannelArbitratorBreachClose(t *testing.T) {
 	}
 }
 
+// TestFailBreachedIncomingHtlcsStoreError asserts breached incoming HTLCs do
+// not notify invoice or final-HTLC subscribers if the final outcome cannot be
+// stored persistently.
+func TestFailBreachedIncomingHtlcsStoreError(t *testing.T) {
+	t.Parallel()
+
+	storeErr := errors.New("store final htlc outcome")
+	registry := &mockRegistry{}
+	notifier := &mockHTLCNotifier{}
+	chanArb := &ChannelArbitrator{
+		cfg: ChannelArbitratorConfig{
+			ShortChanID: lnwire.NewShortChanIDFromInt(1),
+			ChainArbitratorConfig: ChainArbitratorConfig{
+				Registry:     registry,
+				HtlcNotifier: notifier,
+				PutFinalHtlcOutcome: func(
+					_ lnwire.ShortChannelID, _ uint64,
+					_ bool) error {
+
+					return storeErr
+				},
+			},
+		},
+	}
+
+	err := chanArb.failBreachedIncomingHtlcs(fn.NewSet[uint64](3))
+	require.ErrorIs(t, err, storeErr)
+	require.Empty(t, registry.finalized)
+	require.Empty(t, notifier.finalHtlcEventKeys)
+	require.Empty(t, notifier.finalHtlcEvents)
+}
+
 // TestChannelArbitratorLocalForceClosePendingHtlc tests that the
 // ChannelArbitrator goes through the expected states in case we request it to
 // force close a channel that still has an HTLC pending.
@@ -877,7 +938,8 @@ func TestChannelArbitratorLocalForceClosePendingHtlc(t *testing.T) {
 	require.NoError(t, err, "unable to create ChannelArbitrator")
 	chanArb := chanArbCtx.chanArb
 	chanArb.cfg.PreimageDB = newMockWitnessBeacon()
-	chanArb.cfg.Registry = &mockRegistry{}
+	registry := &mockRegistry{}
+	chanArb.cfg.Registry = registry
 
 	beat := newBeatFromHeight(0)
 	if err := chanArb.Start(nil, beat); err != nil {
@@ -1054,6 +1116,15 @@ func TestChannelArbitratorLocalForceClosePendingHtlc(t *testing.T) {
 		incomingDustHtlc.HtlcIndex: false,
 	}
 	require.Equal(t, expectedFinalHtlcs, chanArbCtx.finalHtlcs)
+	require.Equal(t, []finalizeExitHopData{
+		{
+			circuitKey: models.CircuitKey{
+				ChanID: chanArb.cfg.ShortChanID,
+				HtlcID: incomingDustHtlc.HtlcIndex,
+			},
+			settled: false,
+		},
+	}, registry.finalized)
 
 	// We'll now re-create the resolver, notice that we use the existing
 	// arbLog so it carries over the same on-disk state.

--- a/contractcourt/htlc_incoming_contest_resolver.go
+++ b/contractcourt/htlc_incoming_contest_resolver.go
@@ -237,27 +237,7 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 	// preimage. Otherwise the resolver could potentially stay active
 	// indefinitely and the channel will never close properly.
 	if uint32(currentHeight) >= h.htlcExpiry {
-		// TODO(roasbeef): should also somehow check if outgoing is
-		// resolved or not
-		//  * may need to hook into the circuit map
-		//  * can't timeout before the outgoing has been
-
-		log.Infof("%T(%v): HTLC has timed out (expiry=%v, height=%v), "+
-			"abandoning", h, h.htlcResolution.ClaimOutpoint,
-			h.htlcExpiry, currentHeight)
-		h.markResolved()
-
-		if err := h.processFinalHtlcFail(); err != nil {
-			return nil, err
-		}
-
-		// Finally, get our report and checkpoint our resolver with a
-		// timeout outcome report.
-		report := h.report().resolverReport(
-			nil, channeldb.ResolverTypeIncomingHtlc,
-			channeldb.ResolverOutcomeTimeout,
-		)
-		return nil, h.Checkpoint(h, report)
+		return h.timeoutOrSuccessResolver(uint32(currentHeight))
 	}
 
 	// Define a closure to process htlc resolutions either directly or
@@ -444,29 +424,49 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 			// resolved and exit.
 			newHeight := uint32(newBlock.Height)
 			if newHeight >= h.htlcExpiry {
-				log.Infof("%T(%v): HTLC has timed out "+
-					"(expiry=%v, height=%v), abandoning", h,
-					h.htlcResolution.ClaimOutpoint,
-					h.htlcExpiry, currentHeight)
-
-				h.markResolved()
-
-				if err := h.processFinalHtlcFail(); err != nil {
-					return nil, err
-				}
-
-				report := h.report().resolverReport(
-					nil,
-					channeldb.ResolverTypeIncomingHtlc,
-					channeldb.ResolverOutcomeTimeout,
-				)
-				return nil, h.Checkpoint(h, report)
+				return h.timeoutOrSuccessResolver(newHeight)
 			}
 
 		case <-h.quit:
 			return nil, errResolverShuttingDown
 		}
 	}
+}
+
+// timeoutOrSuccessResolver resolves the race between a concurrent Launch that
+// already offered the success resolver and Resolve timing out the HTLC.
+func (h *htlcIncomingContestResolver) timeoutOrSuccessResolver(
+	currentHeight uint32) (ContractResolver, error) {
+
+	// Launch may already have offered the inner success resolver. In that
+	// case, continue with the success resolver instead of checkpointing a
+	// timeout.
+	if h.isLaunched() {
+		return h.htlcSuccessResolver, nil
+	}
+
+	// TODO(roasbeef): This remains unresolved: for forwarded HTLCs, also
+	// check whether the outgoing circuit has resolved before timing out the
+	// incoming side:
+	//  * may need to hook into the circuit map.
+	//  * can't timeout before the outgoing has been.
+	log.Infof("%T(%v): HTLC has timed out (expiry=%v, height=%v), "+
+		"abandoning", h, h.htlcResolution.ClaimOutpoint, h.htlcExpiry,
+		currentHeight)
+	h.markResolved()
+
+	if err := h.processFinalHtlcFail(); err != nil {
+		return nil, err
+	}
+
+	// Finally, get our report and checkpoint our resolver with a timeout
+	// outcome report.
+	report := h.report().resolverReport(
+		nil, channeldb.ResolverTypeIncomingHtlc,
+		channeldb.ResolverOutcomeTimeout,
+	)
+
+	return nil, h.Checkpoint(h, report)
 }
 
 // applyPreimage is a helper function that will populate our internal resolver
@@ -660,9 +660,9 @@ func (h *htlcIncomingContestResolver) decodePayload() (*hop.Payload,
 var _ htlcContractResolver = (*htlcIncomingContestResolver)(nil)
 
 // findAndapplyPreimage performs a non-blocking read to find the preimage for
-// the incoming HTLC. If found, it will be applied to the resolver. This method
-// is used for the resolver to decide whether it wants to transform into a
-// success resolver during launching.
+// the incoming HTLC. If found, it will be applied to the resolver. Launch does
+// not proceed with a fresh invoice settlement at expiry, but already-settled
+// invoice replays can still provide a claimable preimage.
 //
 // NOTE: Since we have two places to query the preimage, we need to check both
 // the preimage db and the invoice db to look up the preimage.
@@ -746,6 +746,15 @@ func (h *htlcIncomingContestResolver) findAndapplyPreimage() (bool, error) {
 
 	// Exit early if it's not a settle resolution.
 	if !ok {
+		return false, nil
+	}
+
+	// Fresh invoice settlements are too late at expiry, but replayed or
+	// duplicate settled invoices already have a preimage that can still
+	// claim the HTLC.
+	if uint32(bestHeight) >= h.htlcExpiry &&
+		res.Outcome == invoices.ResultSettled {
+
 		return false, nil
 	}
 

--- a/contractcourt/htlc_incoming_contest_resolver.go
+++ b/contractcourt/htlc_incoming_contest_resolver.go
@@ -181,23 +181,9 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 		return nil, h.PutResolverReport(nil, resReport)
 	}
 
-	// Register for block epochs. After registration, the current height
-	// will be sent on the channel immediately.
-	blockEpochs, err := h.Notifier.RegisterBlockEpochNtfn(nil)
+	_, currentHeight, err := h.ChainIO.GetBestBlock()
 	if err != nil {
 		return nil, err
-	}
-	defer blockEpochs.Cancel()
-
-	var currentHeight int32
-	select {
-	case newBlock, ok := <-blockEpochs.Epochs:
-		if !ok {
-			return nil, errResolverShuttingDown
-		}
-		currentHeight = newBlock.Height
-	case <-h.quit:
-		return nil, errResolverShuttingDown
 	}
 
 	log.Debugf("%T(%v): Resolving incoming HTLC(expiry=%v, height=%v)", h,
@@ -389,6 +375,31 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 		witnessUpdates = preimageSubscription.WitnessUpdates
 	}
 
+	// This should only be nil if the ChannelArbitrator failed to wire its
+	// private subscription callback into the resolver config.
+	if h.subscribeBlockbeats == nil {
+		return nil, errors.New("blockbeat subscription unavailable")
+	}
+
+	blockbeatSub, cancelBlockbeatSub := h.subscribeBlockbeats()
+	defer cancelBlockbeatSub()
+
+	// Register the subscription before reading the current height.
+	// Otherwise, a block could arrive after GetBestBlock reports a
+	// pre-expiry height but before this resolver waits for beats. The
+	// arbitrator would then dispatch the expiry beat without this resolver
+	// subscribed. Now either the current height is already expired and we
+	// resolve immediately below, or future expiry is delivered through
+	// blockbeatSub.
+	_, currentHeight, err = h.ChainIO.GetBestBlock()
+	if err != nil {
+		return nil, err
+	}
+
+	if uint32(currentHeight) >= h.htlcExpiry {
+		return h.timeoutOrSuccessResolver(uint32(currentHeight))
+	}
+
 	for {
 		select {
 		case preimage := <-witnessUpdates:
@@ -414,18 +425,22 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 			htlcResolution := hodlItem.(invoices.HtlcResolution)
 			return processHtlcResolution(htlcResolution)
 
-		case newBlock, ok := <-blockEpochs.Epochs:
-			if !ok {
-				return nil, errResolverShuttingDown
-			}
-
+		case blockbeatUpdate := <-blockbeatSub.blockbeatChan:
 			// If this new height expires the HTLC, then this means
 			// we never found out the preimage, so we can mark
 			// resolved and exit.
-			newHeight := uint32(newBlock.Height)
-			if newHeight >= h.htlcExpiry {
-				return h.timeoutOrSuccessResolver(newHeight)
+			blockHeight := uint32(blockbeatUpdate.beat.Height())
+
+			if blockHeight >= h.htlcExpiry {
+				nextResolver, err := h.timeoutOrSuccessResolver(
+					blockHeight,
+				)
+				blockbeatUpdate.ack(err)
+
+				return nextResolver, err
 			}
+
+			blockbeatUpdate.ack(nil)
 
 		case <-h.quit:
 			return nil, errResolverShuttingDown

--- a/contractcourt/htlc_incoming_contest_resolver.go
+++ b/contractcourt/htlc_incoming_contest_resolver.go
@@ -711,6 +711,11 @@ func (h *htlcIncomingContestResolver) findAndapplyPreimage() (bool, error) {
 		return false, nil
 	}
 
+	_, bestHeight, err := h.ChainIO.GetBestBlock()
+	if err != nil {
+		return false, err
+	}
+
 	// Notify registry that we are potentially resolving as an exit hop
 	// on-chain. If this HTLC indeed pays to an existing invoice, the
 	// invoice registry will tell us what to do with the HTLC. This is
@@ -724,13 +729,13 @@ func (h *htlcIncomingContestResolver) findAndapplyPreimage() (bool, error) {
 	// immediately, we'll assume we don't know it yet and let the `Resolve`
 	// handle the waiting.
 	//
-	// NOTE: we use a nil subscriber here and a zero current height as we
-	// are only interested in the settle resolution.
+	// NOTE: we use a nil subscriber here as we are only interested in the
+	// settle resolution.
 	//
 	// TODO(yy): move this logic to link and let the preimage be accessed
 	// via the preimage beacon.
 	resolution, err := h.Registry.NotifyExitHopHtlc(
-		h.htlc.RHash, h.htlc.Amt, h.htlcExpiry, 0,
+		h.htlc.RHash, h.htlc.Amt, h.htlcExpiry, bestHeight,
 		circuitKey, nil, h.htlc.CustomRecords, payload,
 	)
 	if err != nil {

--- a/contractcourt/htlc_incoming_contest_resolver.go
+++ b/contractcourt/htlc_incoming_contest_resolver.go
@@ -64,6 +64,11 @@ func (h *htlcIncomingContestResolver) processFinalHtlcFail() error {
 		return err
 	}
 
+	err = h.notifyInvoiceHtlcFinalized(false)
+	if err != nil {
+		h.log.Warnf("Unable to finalize invoice HTLC outcome: %v", err)
+	}
+
 	// Send notification.
 	h.ChainArbitratorConfig.HtlcNotifier.NotifyFinalHtlcEvent(
 		models.CircuitKey{

--- a/contractcourt/htlc_incoming_contest_resolver_test.go
+++ b/contractcourt/htlc_incoming_contest_resolver_test.go
@@ -117,6 +117,28 @@ func TestHtlcIncomingResolverFwdTimeout(t *testing.T) {
 	ctx.waitForResult(false)
 }
 
+// TestHtlcIncomingResolverLaunchUsesCurrentHeight asserts that the immediate
+// registry lookup is given the current chain height instead of zero.
+func TestHtlcIncomingResolverLaunchUsesCurrentHeight(t *testing.T) {
+	t.Parallel()
+	defer timeout()()
+
+	ctx := newIncomingResolverTestContext(t, true)
+	ctx.chainIO.BestHeight = testInitialBlockHeight + 1
+	ctx.registry.notifyResolution = invoices.NewSettleResolution(
+		testResPreimage, testResCircuitKey, testAcceptHeight,
+		invoices.ResultReplayToSettled,
+	)
+
+	require.NoError(t, ctx.resolver.Launch())
+
+	require.Len(t, ctx.registry.immediateNotify, 1)
+	require.Equal(
+		t, ctx.chainIO.BestHeight,
+		ctx.registry.immediateNotify[0].currentHeight,
+	)
+}
+
 // TestHtlcIncomingResolverExitSettle tests resolution of an exit hop htlc for
 // which the invoice has already been settled when the resolver starts.
 func TestHtlcIncomingResolverExitSettle(t *testing.T) {
@@ -412,10 +434,13 @@ func (m mockCustomHtlcChecker) IsCustomHTLC(lnwire.CustomRecords) bool {
 }
 
 type incomingResolverTestContext struct {
-	registry               *mockRegistry
-	witnessBeacon          *mockWitnessBeacon
-	resolver               *htlcIncomingContestResolver
-	notifier               *mock.ChainNotifier
+	registry      *mockRegistry
+	witnessBeacon *mockWitnessBeacon
+	resolver      *htlcIncomingContestResolver
+	notifier      *mock.ChainNotifier
+
+	// chainIO provides the launch-time best height used by the resolver.
+	chainIO                *mock.ChainIO
 	onionProcessor         *mockOnionProcessor
 	resolveErr             chan error
 	nextResolver           ContractResolver
@@ -430,6 +455,9 @@ func newIncomingResolverTestContext(t *testing.T, isExit bool) *incomingResolver
 		ConfChan:  make(chan *chainntnfs.TxConfirmation),
 	}
 	witnessBeacon := newMockWitnessBeacon()
+	chainIO := &mock.ChainIO{
+		BestHeight: testInitialBlockHeight,
+	}
 	registry := &mockRegistry{
 		notifyChan: make(chan notifyExitHopData, 1),
 	}
@@ -442,6 +470,7 @@ func newIncomingResolverTestContext(t *testing.T, isExit bool) *incomingResolver
 		registry:       registry,
 		witnessBeacon:  witnessBeacon,
 		notifier:       notifier,
+		chainIO:        chainIO,
 		onionProcessor: onionProcessor,
 		t:              t,
 	}
@@ -469,6 +498,7 @@ func newIncomingResolverTestContext(t *testing.T, isExit bool) *incomingResolver
 				return nil
 			},
 			Sweeper: newMockSweeper(),
+			ChainIO: chainIO,
 		},
 		PutResolverReport: func(_ kvdb.RwTx,
 			_ *channeldb.ResolverReport) error {

--- a/contractcourt/htlc_incoming_contest_resolver_test.go
+++ b/contractcourt/htlc_incoming_contest_resolver_test.go
@@ -3,7 +3,9 @@ package contractcourt
 import (
 	"bytes"
 	"io"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/wire/v2"
 	sphinx "github.com/lightningnetwork/lightning-onion"
@@ -59,7 +61,7 @@ func TestHtlcIncomingResolverFwdContestedSuccess(t *testing.T) {
 	ctx.resolve()
 
 	// Simulate a new block coming in. HTLC is not yet expired.
-	ctx.notifyEpoch(testInitialBlockHeight + 1)
+	ctx.notifyBlockbeat(testInitialBlockHeight + 1)
 
 	ctx.witnessBeacon.preImageUpdates <- testResPreimage
 	ctx.waitForResult(true)
@@ -76,7 +78,7 @@ func TestHtlcIncomingResolverFwdContestedTimeout(t *testing.T) {
 	// Replace our checkpoint with one which will push reports into a
 	// channel for us to consume. We replace this function on the resolver
 	// itself because it is created by the test context.
-	reportChan := make(chan *channeldb.ResolverReport)
+	reportChan := make(chan *channeldb.ResolverReport, 1)
 	ctx.resolver.Checkpoint = func(_ ContractResolver,
 		reports ...*channeldb.ResolverReport) error {
 
@@ -91,7 +93,7 @@ func TestHtlcIncomingResolverFwdContestedTimeout(t *testing.T) {
 	ctx.resolve()
 
 	// Simulate a new block coming in. HTLC expires.
-	ctx.notifyEpoch(testHtlcExpiry)
+	ctx.notifyBlockbeat(testHtlcExpiry)
 
 	// Assert that we have a failure resolution because our invoice was
 	// cancelled.
@@ -333,7 +335,7 @@ func TestHtlcIncomingResolverExitTimeoutHodl(t *testing.T) {
 	// Replace our checkpoint with one which will push reports into a
 	// channel for us to consume. We replace this function on the resolver
 	// itself because it is created by the test context.
-	reportChan := make(chan *channeldb.ResolverReport)
+	reportChan := make(chan *channeldb.ResolverReport, 1)
 	ctx.resolver.Checkpoint = func(_ ContractResolver,
 		reports ...*channeldb.ResolverReport) error {
 
@@ -346,7 +348,7 @@ func TestHtlcIncomingResolverExitTimeoutHodl(t *testing.T) {
 	}
 
 	ctx.resolve()
-	ctx.notifyEpoch(testHtlcExpiry)
+	ctx.notifyBlockbeat(testHtlcExpiry)
 
 	// Assert that we have a failure resolution because our invoice was
 	// cancelled.
@@ -557,6 +559,8 @@ type incomingResolverTestContext struct {
 
 	// chainIO provides the launch-time best height used by the resolver.
 	chainIO                *mock.ChainIO
+	blockbeatSub           *blockbeatSubscription
+	blockbeatSubChan       chan *blockbeatSubscription
 	onionProcessor         *mockOnionProcessor
 	resolveErr             chan error
 	nextResolver           ContractResolver
@@ -564,7 +568,11 @@ type incomingResolverTestContext struct {
 	t                      *testing.T
 }
 
-func newIncomingResolverTestContext(t *testing.T, isExit bool) *incomingResolverTestContext {
+// newIncomingResolverTestContext creates a resolver test context for incoming
+// HTLC contest resolver tests.
+func newIncomingResolverTestContext(t *testing.T,
+	isExit bool) *incomingResolverTestContext {
+
 	notifier := &mock.ChainNotifier{
 		EpochChan: make(chan *chainntnfs.BlockEpoch),
 		SpendChan: make(chan *chainntnfs.SpendDetail),
@@ -583,10 +591,13 @@ func newIncomingResolverTestContext(t *testing.T, isExit bool) *incomingResolver
 	checkPointChan := make(chan struct{}, 1)
 
 	c := &incomingResolverTestContext{
-		registry:       registry,
-		witnessBeacon:  witnessBeacon,
-		notifier:       notifier,
-		chainIO:        chainIO,
+		registry:      registry,
+		witnessBeacon: witnessBeacon,
+		notifier:      notifier,
+		chainIO:       chainIO,
+		blockbeatSubChan: make(
+			chan *blockbeatSubscription, 1,
+		),
 		onionProcessor: onionProcessor,
 		t:              t,
 	}
@@ -621,6 +632,7 @@ func newIncomingResolverTestContext(t *testing.T, isExit bool) *incomingResolver
 
 			return nil
 		},
+		subscribeBlockbeats: c.subscribeBeats,
 	}
 
 	cfg := ResolverConfig{
@@ -656,29 +668,99 @@ func newIncomingResolverTestContext(t *testing.T, isExit bool) *incomingResolver
 	return c
 }
 
+// resolve launches the resolver and starts Resolve in a goroutine.
 func (i *incomingResolverTestContext) resolve() {
-	// Start resolver.
+	err := i.resolver.Launch()
+	require.NoError(i.t, err)
+
+	// Start resolver resolution.
 	i.resolveErr = make(chan error, 1)
 	go func() {
-		var err error
-
-		err = i.resolver.Launch()
-		require.NoError(i.t, err)
-
-		i.nextResolver, err = i.resolver.Resolve()
+		nextResolver, err := i.resolver.Resolve()
+		i.nextResolver = nextResolver
 		i.resolveErr <- err
 	}()
-
-	// Notify initial block height.
-	i.notifyEpoch(testInitialBlockHeight)
 }
 
-func (i *incomingResolverTestContext) notifyEpoch(height int32) {
-	i.notifier.EpochChan <- &chainntnfs.BlockEpoch{
-		Height: height,
+// subscribeBeats creates a test blockbeat subscription and exposes it to the
+// test context so tests can drive resolver blockbeat delivery manually.
+func (i *incomingResolverTestContext) subscribeBeats() (
+	*blockbeatSubscription, func()) {
+
+	sub := &blockbeatSubscription{
+		blockbeatChan: make(chan blockbeatUpdate),
+		quit:          make(chan struct{}),
+	}
+
+	var cancelOnce sync.Once
+	cancel := func() {
+		cancelOnce.Do(func() {
+			close(sub.quit)
+		})
+	}
+
+	i.blockbeatSubChan <- sub
+
+	return sub, cancel
+}
+
+// activeSub waits for and returns the currently active blockbeat subscription.
+func (i *incomingResolverTestContext) activeSub() *blockbeatSubscription {
+	if i.blockbeatSub != nil {
+		return i.blockbeatSub
+	}
+
+	require.Eventually(i.t, func() bool {
+		select {
+		case i.blockbeatSub = <-i.blockbeatSubChan:
+			return true
+
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+
+	return i.blockbeatSub
+}
+
+// notifyBlockbeat delivers a blockbeat to the resolver and waits for its ack.
+func (i *incomingResolverTestContext) notifyBlockbeat(height int32) {
+	sub := i.activeSub()
+	update := blockbeatUpdate{
+		beat:    newBeatFromHeight(height),
+		errChan: make(chan error, 1),
+	}
+
+	select {
+	case sub.blockbeatChan <- update:
+	case <-sub.quit:
+		i.t.Fatal("blockbeat subscription canceled")
+
+	case <-time.After(time.Second):
+		i.t.Fatal("timeout sending blockbeat")
+	}
+
+	select {
+	case err := <-update.errChan:
+		require.NoError(i.t, err)
+
+	case <-sub.quit:
+		select {
+		case err := <-update.errChan:
+			require.NoError(i.t, err)
+			return
+
+		default:
+		}
+
+		i.t.Fatal("blockbeat subscription canceled")
+
+	case <-time.After(time.Second):
+		i.t.Fatal("timeout waiting for blockbeat ack")
 	}
 }
 
+// waitForResult waits for Resolve to finish and checks its next resolver.
 func (i *incomingResolverTestContext) waitForResult(expectSuccessRes bool) {
 	i.t.Helper()
 

--- a/contractcourt/htlc_incoming_contest_resolver_test.go
+++ b/contractcourt/htlc_incoming_contest_resolver_test.go
@@ -104,9 +104,9 @@ func TestHtlcIncomingResolverFwdContestedTimeout(t *testing.T) {
 	ctx.waitForResult(false)
 }
 
-// TestHtlcIncomingResolverFwdTimeout tests resolution of a forwarded htlc that
-// has already expired when the resolver starts.
-func TestHtlcIncomingResolverFwdTimeout(t *testing.T) {
+// TestHtlcIncomingResolverFwdExpiredPreimageKnown tests that an already-known
+// preimage is still used if the HTLC is expired when the resolver starts.
+func TestHtlcIncomingResolverFwdExpiredPreimageKnown(t *testing.T) {
 	t.Parallel()
 	defer timeout()()
 
@@ -114,7 +114,95 @@ func TestHtlcIncomingResolverFwdTimeout(t *testing.T) {
 	ctx.witnessBeacon.lookupPreimage[testResHash] = testResPreimage
 	ctx.resolver.htlcExpiry = 90
 	ctx.resolve()
-	ctx.waitForResult(false)
+	ctx.waitForResult(true)
+}
+
+// TestHtlcIncomingResolverLaunchAfterExpiry asserts that Launch only starts
+// after expiry when we already knew or settled the preimage.
+func TestHtlcIncomingResolverLaunchAfterExpiry(t *testing.T) {
+	t.Parallel()
+	defer timeout()()
+
+	tests := []struct {
+		name           string
+		isExit         bool
+		setup          func(*incomingResolverTestContext)
+		expectLaunch   bool
+		expectRegistry bool
+		expectPreimage bool
+	}{
+		{
+			name:           "preimage db",
+			isExit:         false,
+			expectLaunch:   true,
+			expectPreimage: true,
+			setup: func(ctx *incomingResolverTestContext) {
+				ctx.witnessBeacon.lookupPreimage[testResHash] =
+					testResPreimage
+			},
+		},
+		{
+			name:           "invoice registry replay",
+			isExit:         true,
+			expectLaunch:   true,
+			expectRegistry: true,
+			expectPreimage: true,
+			setup: func(ctx *incomingResolverTestContext) {
+				ctx.registry.notifyResolution =
+					invoices.NewSettleResolution(
+						testResPreimage,
+						testResCircuitKey,
+						testAcceptHeight,
+						invoices.ResultReplayToSettled,
+					)
+			},
+		},
+		{
+			name:           "fresh invoice settlement",
+			isExit:         true,
+			expectRegistry: true,
+			setup: func(ctx *incomingResolverTestContext) {
+				ctx.registry.notifyResolution =
+					invoices.NewSettleResolution(
+						testResPreimage,
+						testResCircuitKey,
+						testAcceptHeight,
+						invoices.ResultSettled,
+					)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := newIncomingResolverTestContext(t, test.isExit)
+			ctx.resolver.htlcExpiry = testInitialBlockHeight
+			test.setup(ctx)
+
+			require.NoError(t, ctx.resolver.Launch())
+
+			require.Equal(
+				t, test.expectLaunch, ctx.resolver.isLaunched(),
+			)
+			if test.expectPreimage {
+				require.Equal(
+					t, [32]byte(testResPreimage),
+					ctx.resolver.htlcResolution.Preimage,
+				)
+			} else {
+				require.Equal(
+					t, [32]byte{},
+					ctx.resolver.htlcResolution.Preimage,
+				)
+			}
+
+			if test.expectRegistry {
+				require.Len(t, ctx.registry.immediateNotify, 1)
+			} else {
+				require.Empty(t, ctx.registry.immediateNotify)
+			}
+		})
+	}
 }
 
 // TestHtlcIncomingResolverLaunchUsesCurrentHeight asserts that the immediate
@@ -137,6 +225,34 @@ func TestHtlcIncomingResolverLaunchUsesCurrentHeight(t *testing.T) {
 		t, ctx.chainIO.BestHeight,
 		ctx.registry.immediateNotify[0].currentHeight,
 	)
+}
+
+// TestHtlcIncomingResolverLaunchContinuesAfterLookupExpiry asserts that a
+// Launch call that settles the invoice before expiry continues with the
+// success resolver if the tip advances before registry lookup returns.
+func TestHtlcIncomingResolverLaunchContinuesAfterLookupExpiry(
+	t *testing.T) {
+
+	t.Parallel()
+	defer timeout()()
+
+	ctx := newIncomingResolverTestContext(t, true)
+	ctx.registry.notifyResolution = invoices.NewSettleResolution(
+		testResPreimage, testResCircuitKey, testAcceptHeight,
+		invoices.ResultSettled,
+	)
+	ctx.registry.notifyHook = func() {
+		ctx.chainIO.BestHeight = testHtlcExpiry
+	}
+
+	require.NoError(t, ctx.resolver.Launch())
+
+	require.True(t, ctx.resolver.isLaunched())
+	require.Equal(
+		t, [32]byte(testResPreimage),
+		ctx.resolver.htlcResolution.Preimage,
+	)
+	require.Len(t, ctx.registry.immediateNotify, 1)
 }
 
 // TestHtlcIncomingResolverExitSettle tests resolution of an exit hop htlc for

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -1,6 +1,7 @@
 package contractcourt
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -10,6 +11,7 @@ import (
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/graph/db/models"
@@ -232,6 +234,76 @@ func (h *htlcSuccessResolver) checkpointClaim(spendTx *chainhash.Hash) error {
 	return h.Checkpoint(h, reports...)
 }
 
+// checkpointForeignSpend checkpoints the resolver as failed when the original
+// HTLC outpoint was spent by a transaction that did not create our expected
+// second-level success output.
+func (h *htlcSuccessResolver) checkpointForeignSpend(
+	commitSpend *chainntnfs.SpendDetail) error {
+
+	err := h.ChainArbitratorConfig.PutFinalHtlcOutcome(
+		h.ChannelArbitratorConfig.ShortChanID, h.htlc.HtlcIndex, false,
+	)
+	if err != nil {
+		return err
+	}
+
+	var spendTxID *chainhash.Hash
+	switch {
+	// A nil spend detail should only happen if the notifier returned nil
+	// without an error. We cannot identify the spender in that case, but
+	// the success output still cannot be derived, so checkpoint the HTLC
+	// as failed without a SpendTxID.
+	case commitSpend == nil:
+		h.log.Errorf("missing spend detail while checkpointing " +
+			"foreign spend")
+
+	case commitSpend.SpenderTxHash == nil:
+		h.log.Errorf("missing spender txid while checkpointing "+
+			"foreign spend for HTLC outpoint %v", h.outpoint())
+
+	default:
+		spendTxID = commitSpend.SpenderTxHash
+		h.log.Warnf("HTLC outpoint %v was spent by tx %v, which did "+
+			"not create our expected second-level success output",
+			h.outpoint(), spendTxID)
+	}
+
+	// A foreign spend of an incoming HTLC on our commitment means we cannot
+	// complete the success path. The known production case is the remote
+	// timeout reclaim.
+	report := &channeldb.ResolverReport{
+		OutPoint:        h.outpoint(),
+		Amount:          h.htlc.Amt.ToSatoshis(),
+		ResolverType:    channeldb.ResolverTypeIncomingHtlc,
+		ResolverOutcome: channeldb.ResolverOutcomeTimeout,
+		SpendTxID:       spendTxID,
+	}
+
+	// There is no second-level success output to sweep after a foreign
+	// spend, so clear the incubating state. The original HTLC outpoint is
+	// spent and the success path can no longer complete, so this resolver
+	// is terminally resolved as a timeout/fail outcome.
+	h.outputIncubating = false
+	h.markResolved()
+
+	if err := h.Checkpoint(h, report); err != nil {
+		return err
+	}
+
+	h.ChainArbitratorConfig.HtlcNotifier.NotifyFinalHtlcEvent(
+		models.CircuitKey{
+			ChanID: h.ShortChanID,
+			HtlcID: h.htlc.HtlcIndex,
+		},
+		channeldb.FinalHtlcInfo{
+			Settled:  false,
+			Offchain: false,
+		},
+	)
+
+	return nil
+}
+
 // Stop signals the resolver to cancel any current resolution processes, and
 // suspend.
 //
@@ -431,6 +503,77 @@ func (h *htlcSuccessResolver) isTaprootFinal() bool {
 	return h.chanType.IsTaprootFinal()
 }
 
+// successTxOutpoint returns the second-level success output outpoint if the
+// spending transaction created the output that this resolver expects to sweep.
+func (h *htlcSuccessResolver) successTxOutpoint(
+	commitSpend *chainntnfs.SpendDetail) (wire.OutPoint, bool) {
+
+	// The notifier should include the spending transaction and txid for an
+	// observed HTLC spend. These nil checks are defensive: without those
+	// details, we cannot prove that the spend created our success output.
+	if commitSpend == nil {
+		h.log.Errorf("missing spend detail for HTLC outpoint %v",
+			h.outpoint())
+
+		return wire.OutPoint{}, false
+	}
+
+	if commitSpend.SpendingTx == nil {
+		h.log.Errorf("missing spending tx for HTLC outpoint %v",
+			h.outpoint())
+
+		return wire.OutPoint{}, false
+	}
+
+	if commitSpend.SpenderTxHash == nil {
+		h.log.Errorf("missing spender txid for HTLC outpoint %v",
+			h.outpoint())
+
+		return wire.OutPoint{}, false
+	}
+
+	outputIndex := commitSpend.SpenderInputIndex
+
+	// The success output should be at the same index as the HTLC input
+	// being spent. If that output is missing, this cannot be our success
+	// tx.
+	if outputIndex >= uint32(len(commitSpend.SpendingTx.TxOut)) {
+		h.log.Warnf("spending tx %v for HTLC outpoint %v does not "+
+			"create expected output index %d",
+			commitSpend.SpenderTxHash, h.outpoint(), outputIndex)
+
+		return wire.OutPoint{}, false
+	}
+
+	expected := h.htlcResolution.SweepSignDesc.Output
+	if expected == nil {
+		h.log.Warnf("missing expected success output for HTLC "+
+			"outpoint %v", h.outpoint())
+
+		return wire.OutPoint{}, false
+	}
+
+	actual := commitSpend.SpendingTx.TxOut[outputIndex]
+
+	// The spender consumed the HTLC, but only an exact value/script match
+	// gives us a second-level success output that our sweep descriptor can
+	// spend.
+	if actual.Value != expected.Value ||
+		!bytes.Equal(actual.PkScript, expected.PkScript) {
+
+		h.log.Warnf("spending tx %v for HTLC outpoint %v output %d "+
+			"does not match expected success output",
+			commitSpend.SpenderTxHash, h.outpoint(), outputIndex)
+
+		return wire.OutPoint{}, false
+	}
+
+	return wire.OutPoint{
+		Hash:  *commitSpend.SpenderTxHash,
+		Index: outputIndex,
+	}, true
+}
+
 // sweepRemoteCommitOutput creates a sweep request to sweep the HTLC output on
 // the remote commitment via the direct preimage-spend.
 func (h *htlcSuccessResolver) sweepRemoteCommitOutput() error {
@@ -544,7 +687,8 @@ func (h *htlcSuccessResolver) sweepSuccessTx() error {
 }
 
 // sweepSuccessTxOutput attempts to sweep the output of the second level
-// success tx.
+// success tx. If the second-level success output cannot be found, Resolve will
+// checkpoint the foreign spend through the normal resolver-removal path.
 func (h *htlcSuccessResolver) sweepSuccessTxOutput() error {
 	h.log.Debugf("sweeping output %v from 2nd-level HTLC success tx",
 		h.htlcResolution.ClaimOutpoint)
@@ -559,6 +703,11 @@ func (h *htlcSuccessResolver) sweepSuccessTxOutput() error {
 	)
 	if err != nil {
 		return err
+	}
+
+	op, ok := h.successTxOutpoint(commitSpend)
+	if !ok {
+		return nil
 	}
 
 	// The HTLC success tx has a CSV lock that we must wait for, and if
@@ -583,16 +732,6 @@ func (h *htlcSuccessResolver) sweepSuccessTxOutput() error {
 			h, h.htlc.RHash[:], waitHeight)
 	}
 
-	// We'll use this input index to determine the second-level output
-	// index on the transaction, as the signatures requires the indexes to
-	// be the same. We don't look for the second-level output script
-	// directly, as there might be more than one HTLC output to the same
-	// pkScript.
-	op := &wire.OutPoint{
-		Hash:  *commitSpend.SpenderTxHash,
-		Index: commitSpend.SpenderInputIndex,
-	}
-
 	// Let the sweeper sweep the second-level output now that the
 	// CSV/CLTV locks have expired.
 	var witType input.StandardWitnessType
@@ -605,7 +744,7 @@ func (h *htlcSuccessResolver) sweepSuccessTxOutput() error {
 		witType = input.HtlcAcceptedSuccessSecondLevel
 	}
 	inp := h.makeSweepInput(
-		op, witType,
+		&op, witType,
 		input.LeaseHtlcAcceptedSuccessSecondLevel,
 		&h.htlcResolution.SweepSignDesc,
 		h.htlcResolution.CsvDelay, uint32(commitSpend.SpendingHeight),
@@ -704,14 +843,9 @@ func (h *htlcSuccessResolver) resolveSuccessTx() error {
 		return err
 	}
 
-	// We'll use this input index to determine the second-level output
-	// index on the transaction, as the signatures requires the indexes to
-	// be the same. We don't look for the second-level output script
-	// directly, as there might be more than one HTLC output to the same
-	// pkScript.
-	op := wire.OutPoint{
-		Hash:  *commitSpend.SpenderTxHash,
-		Index: commitSpend.SpenderInputIndex,
+	op, ok := h.successTxOutpoint(commitSpend)
+	if !ok {
+		return h.checkpointForeignSpend(commitSpend)
 	}
 
 	// If the 2nd-stage sweeping has already been started, we can
@@ -791,8 +925,10 @@ func (h *htlcSuccessResolver) Launch() error {
 	// second-level success tx or the output from the second-level success
 	// tx.
 	case h.isZeroFeeOutput():
-		// If the second-level success tx has already been swept, we
-		// can go ahead and sweep its output.
+		// If the second-level success tx has already confirmed, Launch
+		// can offer the output to the sweeper. It must not checkpoint a
+		// terminal foreign spend because launchResolvers runs before
+		// resolveContract.
 		if h.outputIncubating {
 			return h.sweepSuccessTxOutput()
 		}

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -2,6 +2,7 @@ package contractcourt
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -114,9 +115,9 @@ func (h *htlcSuccessResolver) ResolverKey() []byte {
 // Resolve attempts to resolve an unresolved incoming HTLC that we know the
 // preimage to. If the HTLC is on the commitment of the remote party, then we'll
 // simply sweep it directly. Otherwise, we'll hand this off to the utxo nursery
-// to do its duty. There is no need to make a call to the invoice registry
-// anymore. Every HTLC has already passed through the incoming contest resolver
-// and in there the invoice was already marked as settled.
+// to do its duty. Every HTLC has already passed through the incoming contest
+// resolver and requested settlement from the invoice registry. The invoice is
+// finalized once this resolver determines the on-chain outcome.
 //
 // NOTE: Part of the ContractResolver interface.
 //
@@ -166,6 +167,12 @@ func (h *htlcSuccessResolver) resolveRemoteCommitOutput() error {
 	if err != nil {
 		return err
 	}
+	if !isPreimageSpend(
+		h.isTaproot(), sweepTxDetails, !h.isRemoteCommitOutput(),
+	) {
+
+		return h.checkpointForeignSpend(sweepTxDetails)
+	}
 
 	// TODO(yy): should also update the `RecoveredBalance` and
 	// `LimboBalance` like other paths?
@@ -184,6 +191,11 @@ func (h *htlcSuccessResolver) checkpointClaim(spendTx *chainhash.Hash) error {
 	)
 	if err != nil {
 		return err
+	}
+
+	err = h.notifyInvoiceHtlcFinalized(true)
+	if err != nil {
+		h.log.Warnf("Unable to finalize invoice HTLC outcome: %v", err)
 	}
 
 	// Send notification.
@@ -234,6 +246,21 @@ func (h *htlcSuccessResolver) checkpointClaim(spendTx *chainhash.Hash) error {
 	return h.Checkpoint(h, reports...)
 }
 
+// notifyInvoiceHtlcFinalized marks the invoice settlement outcome final if the
+// HTLC belongs to an exit-hop invoice.
+func (h *htlcSuccessResolver) notifyInvoiceHtlcFinalized(settled bool) error {
+	if h.Registry == nil {
+		return nil
+	}
+
+	return h.Registry.NotifyExitHopHtlcFinalized(
+		context.Background(), models.CircuitKey{
+			ChanID: h.ShortChanID,
+			HtlcID: h.htlc.HtlcIndex,
+		}, settled,
+	)
+}
+
 // checkpointForeignSpend checkpoints the resolver as failed when the original
 // HTLC outpoint was spent by a transaction that did not create our expected
 // second-level success output.
@@ -245,6 +272,11 @@ func (h *htlcSuccessResolver) checkpointForeignSpend(
 	)
 	if err != nil {
 		return err
+	}
+
+	err = h.notifyInvoiceHtlcFinalized(false)
+	if err != nil {
+		h.log.Warnf("Unable to finalize invoice HTLC outcome: %v", err)
 	}
 
 	var spendTxID *chainhash.Hash
@@ -326,6 +358,7 @@ func (h *htlcSuccessResolver) report() *ContractReport {
 	h.reportLock.Lock()
 	defer h.reportLock.Unlock()
 	cpy := h.currentReport
+
 	return &cpy
 }
 

--- a/contractcourt/htlc_success_resolver_test.go
+++ b/contractcourt/htlc_success_resolver_test.go
@@ -2,12 +2,14 @@ package contractcourt
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/chainntnfs"
@@ -31,11 +33,18 @@ type htlcResolverTestContext struct {
 	checkpoint func(_ ContractResolver,
 		_ ...*channeldb.ResolverReport) error
 
-	notifier           *mock.ChainNotifier
+	notifier *mock.ChainNotifier
+
+	// htlcNotifier records final HTLC events for assertions.
+	htlcNotifier *mockHTLCNotifier
+
 	resolverResultChan chan resolveResult
 	resolutionChan     chan ResolutionMsg
 
 	finalHtlcOutcomeStored bool
+
+	// finalHtlcSettled records the last stored final HTLC outcome.
+	finalHtlcSettled bool
 
 	t *testing.T
 }
@@ -58,15 +67,15 @@ func newHtlcResolverTestContext(t *testing.T,
 		SpendChan: make(chan *chainntnfs.SpendDetail, 1),
 		ConfChan:  make(chan *chainntnfs.TxConfirmation, 1),
 	}
+	htlcNotifier := &mockHTLCNotifier{}
 
 	testCtx := &htlcResolverTestContext{
 		checkpoint:     nil,
 		notifier:       notifier,
+		htlcNotifier:   htlcNotifier,
 		resolutionChan: make(chan ResolutionMsg, 1),
 		t:              t,
 	}
-
-	htlcNotifier := &mockHTLCNotifier{}
 
 	witnessBeacon := newMockWitnessBeacon()
 	chainCfg := ChannelArbitratorConfig{
@@ -99,6 +108,7 @@ func newHtlcResolverTestContext(t *testing.T,
 				htlcId uint64, settled bool) error {
 
 				testCtx.finalHtlcOutcomeStored = true
+				testCtx.finalHtlcSettled = settled
 
 				return nil
 			},
@@ -507,6 +517,325 @@ func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 	testHtlcSuccess(t, twoStageResolution, checkpoints)
 }
 
+// TestHtlcSuccessResolverRejectsForeignSpend asserts that a spend which does
+// not create the expected second-level success output fails the resolver
+// instead of handing a phantom output to the sweeper.
+func TestHtlcSuccessResolverRejectsForeignSpend(t *testing.T) {
+	defer timeout()()
+
+	// Build a success resolution whose expected second-level output can be
+	// distinguished from the foreign spender below.
+	commitOutpoint := wire.OutPoint{
+		Hash:  chainhash.Hash{0x01},
+		Index: 2,
+	}
+	resolution := newTestAnchorSuccessResolution(commitOutpoint)
+	foreignTx, foreignHash := newForeignSuccessSpend(commitOutpoint)
+	expectedReport := &channeldb.ResolverReport{
+		OutPoint:        commitOutpoint,
+		Amount:          testHtlcAmt.ToSatoshis(),
+		ResolverType:    channeldb.ResolverTypeIncomingHtlc,
+		ResolverOutcome: channeldb.ResolverOutcomeTimeout,
+		SpendTxID:       &foreignHash,
+	}
+	ctx := newTestHtlcSuccessContext(t, resolution, false)
+
+	checkpointChan := make(chan struct{}, 1)
+	ctx.checkpoint = func(resolver ContractResolver,
+		reports ...*channeldb.ResolverReport) error {
+
+		successResolver, ok := resolver.(*htlcSuccessResolver)
+		require.True(t, ok)
+
+		require.True(t, successResolver.IsResolved())
+		require.False(t, successResolver.outputIncubating)
+		require.True(t, ctx.finalHtlcOutcomeStored)
+		require.False(t, ctx.finalHtlcSettled)
+		require.Equal(t, []*channeldb.ResolverReport{
+			expectedReport,
+		}, reports)
+
+		checkpointChan <- struct{}{}
+
+		return nil
+	}
+
+	// Start the resolver and wait for it to offer the commitment HTLC as a
+	// success input to the sweeper.
+	ctx.resolve()
+
+	resolver := successResolverFromContext(t, ctx)
+	sweeper := mockSweeperFromResolver(t, resolver)
+	select {
+	case inp := <-sweeper.sweptInputs:
+		require.Equal(t, commitOutpoint, inp.OutPoint())
+	case <-time.After(time.Second):
+		t.Fatal("expected first-stage input to be swept")
+	}
+
+	// Notify that a different transaction spent the commitment HTLC without
+	// creating the expected success output.
+	ctx.notifier.SpendChan <- &chainntnfs.SpendDetail{
+		SpendingTx:        foreignTx,
+		SpenderTxHash:     &foreignHash,
+		SpenderInputIndex: 0,
+		SpendingHeight:    10,
+		SpentOutPoint:     &commitOutpoint,
+	}
+
+	select {
+	case <-checkpointChan:
+	case <-time.After(time.Second):
+		t.Fatal("expected foreign spend checkpoint")
+	}
+	ctx.waitForResult()
+
+	// The resolver should checkpoint the foreign spend as a final failure.
+	// It should not offer a derived second-level output to the sweeper.
+	assertNoSweptInput(t, sweeper)
+	assertFinalHtlcFailed(t, ctx)
+}
+
+// TestHtlcSuccessResolverRejectsForeignSpendOnRestart asserts that a restarted
+// resolver with outputIncubating already set still rejects a foreign
+// first-stage spender instead of sweeping a derived phantom output.
+func TestHtlcSuccessResolverRejectsForeignSpendOnRestart(t *testing.T) {
+	defer timeout()()
+
+	// Start from an incubating resolver to exercise the restart
+	// fast-forward path that immediately waits for the commitment HTLC
+	// spend.
+	commitOutpoint := wire.OutPoint{
+		Hash:  chainhash.Hash{0x02},
+		Index: 3,
+	}
+	resolution := newTestAnchorSuccessResolution(commitOutpoint)
+	foreignTx, foreignHash := newForeignSuccessSpend(commitOutpoint)
+	expectedReport := &channeldb.ResolverReport{
+		OutPoint:        commitOutpoint,
+		Amount:          testHtlcAmt.ToSatoshis(),
+		ResolverType:    channeldb.ResolverTypeIncomingHtlc,
+		ResolverOutcome: channeldb.ResolverOutcomeTimeout,
+		SpendTxID:       &foreignHash,
+	}
+	ctx := newTestHtlcSuccessContext(t, resolution, true)
+
+	checkpointChan := make(chan struct{}, 1)
+	ctx.checkpoint = func(resolver ContractResolver,
+		reports ...*channeldb.ResolverReport) error {
+
+		successResolver, ok := resolver.(*htlcSuccessResolver)
+		require.True(t, ok)
+
+		require.True(t, successResolver.IsResolved())
+		require.False(t, successResolver.outputIncubating)
+		require.True(t, ctx.finalHtlcOutcomeStored)
+		require.False(t, ctx.finalHtlcSettled)
+		require.Equal(t, []*channeldb.ResolverReport{
+			expectedReport,
+		}, reports)
+
+		checkpointChan <- struct{}{}
+
+		return nil
+	}
+
+	// Notify a foreign spender twice. Launch validates the historical
+	// spend but leaves terminal checkpointing to Resolve, which waits for
+	// the same spend again in this mock setup.
+	ctx.resolve()
+	foreignSpend := &chainntnfs.SpendDetail{
+		SpendingTx:        foreignTx,
+		SpenderTxHash:     &foreignHash,
+		SpenderInputIndex: 0,
+		SpendingHeight:    10,
+		SpentOutPoint:     &commitOutpoint,
+	}
+	go func() {
+		ctx.notifier.SpendChan <- foreignSpend
+		ctx.notifier.SpendChan <- foreignSpend
+	}()
+
+	select {
+	case <-checkpointChan:
+	case <-time.After(time.Second):
+		t.Fatal("expected foreign spend checkpoint")
+	}
+	ctx.waitForResult()
+
+	// The restart path should checkpoint the same final failed outcome as
+	// the non-restart path.
+	resolver := successResolverFromContext(t, ctx)
+	assertNoSweptInput(t, mockSweeperFromResolver(t, resolver))
+	assertFinalHtlcFailed(t, ctx)
+}
+
+// TestHtlcSuccessResolverForeignSpendCheckpointError asserts that the final
+// HTLC event is emitted only after the foreign-spend checkpoint succeeds.
+func TestHtlcSuccessResolverForeignSpendCheckpointError(t *testing.T) {
+	defer timeout()()
+
+	// Return a checkpoint error after the resolver prepares its terminal
+	// foreign-spend state. This simulates the DB rejecting the checkpoint.
+	commitOutpoint := wire.OutPoint{
+		Hash:  chainhash.Hash{0x03},
+		Index: 4,
+	}
+	resolution := newTestAnchorSuccessResolution(commitOutpoint)
+	foreignTx, foreignHash := newForeignSuccessSpend(commitOutpoint)
+	errCheckpoint := errors.New("checkpoint failed")
+	ctx := newTestHtlcSuccessContext(t, resolution, false)
+
+	checkpointChan := make(chan struct{}, 1)
+	ctx.checkpoint = func(resolver ContractResolver,
+		reports ...*channeldb.ResolverReport) error {
+
+		successResolver, ok := resolver.(*htlcSuccessResolver)
+		require.True(t, ok)
+
+		require.True(t, successResolver.IsResolved())
+		require.Len(t, reports, 1)
+
+		checkpointChan <- struct{}{}
+
+		return errCheckpoint
+	}
+
+	// Drive the resolver until it offers the first-stage success input,
+	// then notify a foreign spender that triggers the failing checkpoint
+	// path.
+	ctx.resolve()
+
+	resolver := successResolverFromContext(t, ctx)
+	sweeper := mockSweeperFromResolver(t, resolver)
+	select {
+	case inp := <-sweeper.sweptInputs:
+		require.Equal(t, commitOutpoint, inp.OutPoint())
+	case <-time.After(time.Second):
+		t.Fatal("expected first-stage input to be swept")
+	}
+
+	ctx.notifier.SpendChan <- &chainntnfs.SpendDetail{
+		SpendingTx:        foreignTx,
+		SpenderTxHash:     &foreignHash,
+		SpenderInputIndex: 0,
+		SpendingHeight:    10,
+		SpentOutPoint:     &commitOutpoint,
+	}
+
+	select {
+	case <-checkpointChan:
+	case <-time.After(time.Second):
+		t.Fatal("expected foreign spend checkpoint")
+	}
+
+	result := <-ctx.resolverResultChan
+	require.ErrorIs(t, result.err, errCheckpoint)
+	require.Nil(t, result.nextResolver)
+	require.True(t, resolver.IsResolved())
+	require.Empty(t, ctx.htlcNotifier.finalHtlcEvents)
+}
+
+// newTestHtlcSuccessContext creates a success resolver test context with the
+// supplied incoming HTLC resolution and incubation state.
+func newTestHtlcSuccessContext(t *testing.T,
+	resolution lnwallet.IncomingHtlcResolution,
+	outputIncubating bool) *htlcResolverTestContext {
+
+	return newHtlcResolverTestContext(
+		t, func(htlc channeldb.HTLC,
+			cfg ResolverConfig) ContractResolver {
+
+			r := newSuccessResolver(
+				resolution, 0, htlc, 0, cfg,
+			)
+			r.outputIncubating = outputIncubating
+
+			return r
+		},
+	)
+}
+
+// successResolverFromContext returns the success resolver installed in a test
+// context.
+func successResolverFromContext(t *testing.T,
+	ctx *htlcResolverTestContext) *htlcSuccessResolver {
+
+	t.Helper()
+
+	resolver, ok := ctx.resolver.(*htlcSuccessResolver)
+	require.True(t, ok)
+
+	return resolver
+}
+
+// mockSweeperFromResolver returns the mock sweeper used by a success resolver.
+func mockSweeperFromResolver(t *testing.T,
+	resolver *htlcSuccessResolver) *mockSweeper {
+
+	t.Helper()
+
+	sweeper, ok := resolver.Sweeper.(*mockSweeper)
+	require.True(t, ok)
+
+	return sweeper
+}
+
+// newTestAnchorSuccessResolution returns an anchor-channel success resolution
+// whose success transaction creates the expected second-level output.
+func newTestAnchorSuccessResolution(
+	commitOutpoint wire.OutPoint) lnwallet.IncomingHtlcResolution {
+
+	successTx := &wire.MsgTx{
+		TxIn: []*wire.TxIn{
+			{
+				PreviousOutPoint: commitOutpoint,
+			},
+		},
+		TxOut: []*wire.TxOut{
+			cloneTxOut(testSignDesc.Output),
+		},
+	}
+	successHash := successTx.TxHash()
+
+	return lnwallet.IncomingHtlcResolution{
+		Preimage:        [32]byte{},
+		CsvDelay:        4,
+		SignedSuccessTx: successTx,
+		SignDetails: &input.SignDetails{
+			SignDesc: testSignDesc,
+			PeerSig:  testSig,
+		},
+		ClaimOutpoint: wire.OutPoint{
+			Hash:  successHash,
+			Index: 0,
+		},
+		SweepSignDesc: testSignDesc,
+	}
+}
+
+// newForeignSuccessSpend returns a transaction that spends the commitment HTLC
+// without creating the expected second-level success output.
+func newForeignSuccessSpend(
+	commitOutpoint wire.OutPoint) (*wire.MsgTx, chainhash.Hash) {
+
+	foreignTx := &wire.MsgTx{
+		TxIn: []*wire.TxIn{
+			{
+				PreviousOutPoint: commitOutpoint,
+			},
+		},
+		TxOut: []*wire.TxOut{
+			{
+				Value:    testSignDesc.Output.Value,
+				PkScript: []byte{0x51},
+			},
+		},
+	}
+
+	return foreignTx, foreignTx.TxHash()
+}
+
 // cloneTxOut returns a copy of a transaction output.
 func cloneTxOut(txOut *wire.TxOut) *wire.TxOut {
 	pkScript := append([]byte(nil), txOut.PkScript...)
@@ -514,6 +843,25 @@ func cloneTxOut(txOut *wire.TxOut) *wire.TxOut {
 		Value:    txOut.Value,
 		PkScript: pkScript,
 	}
+}
+
+// assertNoSweptInput asserts that the sweeper was not offered another input.
+func assertNoSweptInput(t *testing.T, sweeper *mockSweeper) {
+	t.Helper()
+
+	select {
+	case inp := <-sweeper.sweptInputs:
+		t.Fatalf("unexpected swept input: %v", inp.OutPoint())
+	default:
+	}
+}
+
+// assertFinalHtlcFailed asserts that the final HTLC outcome was failed.
+func assertFinalHtlcFailed(t *testing.T, ctx *htlcResolverTestContext) {
+	t.Helper()
+
+	require.True(t, ctx.finalHtlcOutcomeStored)
+	require.False(t, ctx.finalHtlcSettled)
 }
 
 // checkpoint holds expected data we expect the resolver to checkpoint itself

--- a/contractcourt/htlc_success_resolver_test.go
+++ b/contractcourt/htlc_success_resolver_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil/v2"
-	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/chainntnfs"
@@ -324,7 +323,6 @@ func TestHtlcSuccessSecondStageResolution(t *testing.T) {
 //nolint:ll
 func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 	commitOutpoint := wire.OutPoint{Index: 2}
-	htlcOutpoint := wire.OutPoint{Index: 3}
 
 	successTx := &wire.MsgTx{
 		TxIn: []*wire.TxIn{
@@ -333,47 +331,22 @@ func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 			},
 		},
 		TxOut: []*wire.TxOut{
-			{
-				Value:    123,
-				PkScript: []byte{0xff, 0xff},
-			},
+			cloneTxOut(testSignDesc.Output),
 		},
 	}
-
-	reSignedSuccessTx := &wire.MsgTx{
-		TxIn: []*wire.TxIn{
-			{
-				PreviousOutPoint: wire.OutPoint{
-					Hash:  chainhash.Hash{0xaa, 0xbb},
-					Index: 0,
-				},
-			},
-			successTx.TxIn[0],
-			{
-				PreviousOutPoint: wire.OutPoint{
-					Hash:  chainhash.Hash{0xaa, 0xbb},
-					Index: 2,
-				},
-			},
-		},
-
-		TxOut: []*wire.TxOut{
-			{
-				Value:    111,
-				PkScript: []byte{0xaa, 0xaa},
-			},
-			successTx.TxOut[0],
-		},
+	successHash := successTx.TxHash()
+	htlcOutpoint := wire.OutPoint{
+		Hash:  successHash,
+		Index: 0,
 	}
-	reSignedHash := successTx.TxHash()
 
 	sweepTx := &wire.MsgTx{
 		TxIn: []*wire.TxIn{
 
 			{
 				PreviousOutPoint: wire.OutPoint{
-					Hash:  reSignedHash,
-					Index: 1,
+					Hash:  successHash,
+					Index: 0,
 				},
 			},
 		},
@@ -400,7 +373,7 @@ func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 		Amount:          testHtlcAmt.ToSatoshis(),
 		ResolverType:    channeldb.ResolverTypeIncomingHtlc,
 		ResolverOutcome: channeldb.ResolverOutcomeFirstStage,
-		SpendTxID:       &reSignedHash,
+		SpendTxID:       &successHash,
 	}
 
 	secondStage := &channeldb.ResolverReport{
@@ -441,9 +414,9 @@ func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 				}
 
 				ctx.notifier.SpendChan <- &chainntnfs.SpendDetail{
-					SpendingTx:        reSignedSuccessTx,
-					SpenderTxHash:     &reSignedHash,
-					SpenderInputIndex: 1,
+					SpendingTx:        successTx,
+					SpenderTxHash:     &successHash,
+					SpenderInputIndex: 0,
 					SpendingHeight:    10,
 					SpentOutPoint:     &commitOutpoint,
 				}
@@ -464,9 +437,9 @@ func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 				// spend, hence we must resend it.
 				if resumed {
 					ctx.notifier.SpendChan <- &chainntnfs.SpendDetail{
-						SpendingTx:        reSignedSuccessTx,
-						SpenderTxHash:     &reSignedHash,
-						SpenderInputIndex: 1,
+						SpendingTx:        successTx,
+						SpenderTxHash:     &successHash,
+						SpenderInputIndex: 0,
 						SpendingHeight:    10,
 						SpentOutPoint:     &commitOutpoint,
 					}
@@ -479,9 +452,9 @@ func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 				// Mock `waitForSpend` to return the commit
 				// spend.
 				ctx.notifier.SpendChan <- &chainntnfs.SpendDetail{
-					SpendingTx:        reSignedSuccessTx,
-					SpenderTxHash:     &reSignedHash,
-					SpenderInputIndex: 1,
+					SpendingTx:        successTx,
+					SpenderTxHash:     &successHash,
+					SpenderInputIndex: 0,
 					SpendingHeight:    10,
 					SpentOutPoint:     &commitOutpoint,
 				}
@@ -501,8 +474,8 @@ func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 
 				op := inp.OutPoint()
 				exp := wire.OutPoint{
-					Hash:  reSignedHash,
-					Index: 1,
+					Hash:  successHash,
+					Index: 0,
 				}
 				if op != exp {
 					return fmt.Errorf("swept outpoint %v, expected %v",
@@ -532,6 +505,15 @@ func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 	}
 
 	testHtlcSuccess(t, twoStageResolution, checkpoints)
+}
+
+// cloneTxOut returns a copy of a transaction output.
+func cloneTxOut(txOut *wire.TxOut) *wire.TxOut {
+	pkScript := append([]byte(nil), txOut.PkScript...)
+	return &wire.TxOut{
+		Value:    txOut.Value,
+		PkScript: pkScript,
+	}
 }
 
 // checkpoint holds expected data we expect the resolver to checkpoint itself

--- a/contractcourt/htlc_success_resolver_test.go
+++ b/contractcourt/htlc_success_resolver_test.go
@@ -186,7 +186,12 @@ func TestHtlcSuccessSingleStage(t *testing.T) {
 	htlcOutpoint := wire.OutPoint{Index: 3}
 
 	sweepTx := &wire.MsgTx{
-		TxIn:  []*wire.TxIn{{}},
+		TxIn: []*wire.TxIn{{
+			Witness: wire.TxWitness{
+				[]byte{1}, []byte{1}, []byte{1},
+				make([]byte, 32), []byte{1},
+			},
+		}},
 		TxOut: []*wire.TxOut{{}},
 	}
 

--- a/contractcourt/interfaces.go
+++ b/contractcourt/interfaces.go
@@ -22,7 +22,7 @@ type Registry interface {
 	// byte payment hash.
 	LookupInvoice(context.Context, lntypes.Hash) (invoices.Invoice, error)
 
-	// NotifyExitHopHtlc attempts to mark an invoice as settled. If the
+	// NotifyExitHopHtlc requests settlement of an invoice. If the
 	// invoice is a debug invoice, then this method is a noop as debug
 	// invoices are never fully settled. The return value describes how the
 	// htlc should be resolved. If the htlc cannot be resolved immediately,
@@ -32,6 +32,11 @@ type Registry interface {
 		circuitKey models.CircuitKey, hodlChan chan<- interface{},
 		wireCustomRecords lnwire.CustomRecords,
 		payload invoices.Payload) (invoices.HtlcResolution, error)
+
+	// NotifyExitHopHtlcFinalized marks a previously requested exit-hop HTLC
+	// settlement as final.
+	NotifyExitHopHtlcFinalized(ctx context.Context,
+		circuitKey models.CircuitKey, settled bool) error
 
 	// HodlUnsubscribeAll unsubscribes from all htlc resolutions.
 	HodlUnsubscribeAll(subscriber chan<- interface{})

--- a/contractcourt/mock_htlcnotifier_test.go
+++ b/contractcourt/mock_htlcnotifier_test.go
@@ -7,9 +7,13 @@ import (
 
 type mockHTLCNotifier struct {
 	HtlcNotifier
+
+	// finalHtlcEvents records final HTLC events for assertions.
+	finalHtlcEvents []channeldb.FinalHtlcInfo
 }
 
 func (m *mockHTLCNotifier) NotifyFinalHtlcEvent(key models.CircuitKey,
 	info channeldb.FinalHtlcInfo) {
 
+	m.finalHtlcEvents = append(m.finalHtlcEvents, info)
 }

--- a/contractcourt/mock_htlcnotifier_test.go
+++ b/contractcourt/mock_htlcnotifier_test.go
@@ -9,11 +9,13 @@ type mockHTLCNotifier struct {
 	HtlcNotifier
 
 	// finalHtlcEvents records final HTLC events for assertions.
-	finalHtlcEvents []channeldb.FinalHtlcInfo
+	finalHtlcEvents    []channeldb.FinalHtlcInfo
+	finalHtlcEventKeys []models.CircuitKey
 }
 
 func (m *mockHTLCNotifier) NotifyFinalHtlcEvent(key models.CircuitKey,
 	info channeldb.FinalHtlcInfo) {
 
+	m.finalHtlcEventKeys = append(m.finalHtlcEventKeys, key)
 	m.finalHtlcEvents = append(m.finalHtlcEvents, info)
 }

--- a/contractcourt/mock_registry_test.go
+++ b/contractcourt/mock_registry_test.go
@@ -23,6 +23,9 @@ type mockRegistry struct {
 	notifyErr        error
 	notifyResolution invoices.HtlcResolution
 	notifyCalls      atomic.Int32
+
+	// immediateNotify records non-subscribing NotifyExitHopHtlc calls.
+	immediateNotify []notifyExitHopData
 }
 
 func (r *mockRegistry) NotifyExitHopHtlc(payHash lntypes.Hash,
@@ -35,6 +38,13 @@ func (r *mockRegistry) NotifyExitHopHtlc(payHash lntypes.Hash,
 
 	// Exit early if the notification channel is nil.
 	if hodlChan == nil {
+		r.immediateNotify = append(r.immediateNotify, notifyExitHopData{
+			payHash:       payHash,
+			paidAmount:    paidAmount,
+			expiry:        expiry,
+			currentHeight: currentHeight,
+		})
+
 		return r.notifyResolution, r.notifyErr
 	}
 

--- a/contractcourt/mock_registry_test.go
+++ b/contractcourt/mock_registry_test.go
@@ -26,6 +26,9 @@ type mockRegistry struct {
 
 	// immediateNotify records non-subscribing NotifyExitHopHtlc calls.
 	immediateNotify []notifyExitHopData
+
+	// notifyHook is called after a NotifyExitHopHtlc call is recorded.
+	notifyHook func()
 }
 
 func (r *mockRegistry) NotifyExitHopHtlc(payHash lntypes.Hash,
@@ -44,6 +47,9 @@ func (r *mockRegistry) NotifyExitHopHtlc(payHash lntypes.Hash,
 			expiry:        expiry,
 			currentHeight: currentHeight,
 		})
+		if r.notifyHook != nil {
+			r.notifyHook()
+		}
 
 		return r.notifyResolution, r.notifyErr
 	}
@@ -54,6 +60,9 @@ func (r *mockRegistry) NotifyExitHopHtlc(payHash lntypes.Hash,
 		paidAmount:    paidAmount,
 		expiry:        expiry,
 		currentHeight: currentHeight,
+	}
+	if r.notifyHook != nil {
+		r.notifyHook()
 	}
 
 	return r.notifyResolution, r.notifyErr

--- a/contractcourt/mock_registry_test.go
+++ b/contractcourt/mock_registry_test.go
@@ -26,9 +26,17 @@ type mockRegistry struct {
 
 	// immediateNotify records non-subscribing NotifyExitHopHtlc calls.
 	immediateNotify []notifyExitHopData
+	finalized       []finalizeExitHopData
 
 	// notifyHook is called after a NotifyExitHopHtlc call is recorded.
 	notifyHook func()
+}
+
+// finalizeExitHopData records a final exit-hop HTLC outcome delivered to the
+// mock registry.
+type finalizeExitHopData struct {
+	circuitKey models.CircuitKey
+	settled    bool
 }
 
 func (r *mockRegistry) NotifyExitHopHtlc(payHash lntypes.Hash,
@@ -69,6 +77,17 @@ func (r *mockRegistry) NotifyExitHopHtlc(payHash lntypes.Hash,
 }
 
 func (r *mockRegistry) HodlUnsubscribeAll(subscriber chan<- interface{}) {}
+
+func (r *mockRegistry) NotifyExitHopHtlcFinalized(_ context.Context,
+	circuitKey models.CircuitKey, settled bool) error {
+
+	r.finalized = append(r.finalized, finalizeExitHopData{
+		circuitKey: circuitKey,
+		settled:    settled,
+	})
+
+	return nil
+}
 
 func (r *mockRegistry) LookupInvoice(context.Context, lntypes.Hash) (
 	invoices.Invoice, error) {

--- a/docs/release-notes/release-notes-0.21.2.md
+++ b/docs/release-notes/release-notes-0.21.2.md
@@ -1,0 +1,70 @@
+# Release Notes
+- [Bug Fixes](#bug-fixes)
+- [New Features](#new-features)
+    - [Functional Enhancements](#functional-enhancements)
+    - [RPC Additions](#rpc-additions)
+    - [lncli Additions](#lncli-additions)
+- [Improvements](#improvements)
+    - [Functional Updates](#functional-updates)
+    - [RPC Updates](#rpc-updates)
+    - [lncli Updates](#lncli-updates)
+    - [Breaking Changes](#breaking-changes)
+    - [Performance Improvements](#performance-improvements)
+    - [Deprecations](#deprecations)
+- [Technical and Architectural Updates](#technical-and-architectural-updates)
+    - [BOLT Spec Updates](#bolt-spec-updates)
+    - [Testing](#testing)
+    - [Database](#database)
+    - [Code Health](#code-health)
+    - [Robustness](#robustness)
+    - [Tooling and Documentation](#tooling-and-documentation)
+- [Contributors (Alphabetical Order)](#contributors-alphabetical-order)
+
+# Bug Fixes
+
+* [Fixed an issue](https://github.com/lightningnetwork/lnd/pull/10869)
+  where an incoming HTLC resolver could treat a foreign spend of the commitment
+  HTLC output as its own success transaction, causing a phantom second-level
+  input to be offered to the sweeper. The resolver now validates the spending
+  transaction's expected output before sweeping it, and avoids launching the
+  success path for incoming HTLCs that are already expired.
+
+# New Features
+
+## Functional Enhancements
+
+## RPC Additions
+
+## lncli Additions
+
+# Improvements
+
+## Functional Updates
+
+## RPC Updates
+
+## lncli Updates
+
+## Breaking Changes
+
+## Performance Improvements
+
+## Deprecations
+
+# Technical and Architectural Updates
+
+## BOLT Spec Updates
+
+## Testing
+
+## Database
+
+## Code Health
+
+## Robustness
+
+## Tooling and Documentation
+
+# Contributors (Alphabetical Order)
+
+* Yong Yu

--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -42,6 +42,15 @@
   regardless of peer connectivity. Uptime is now seeded from the peer's
   actual connection state.
 
+* [Fixed issue #7463](https://github.com/lightningnetwork/lnd/issues/7463)
+  by keeping invoices accepted until the corresponding HTLC reaches a final
+  settle or fail outcome. This introduces a persisted `ContractPendingSettle`
+  invoice state, so operators should not downgrade to older binaries while
+  invoices may remain in that intermediate state. Restart recovery is
+  best-effort: if a restart interrupts finalization after the HTLC's final
+  outcome was reached, the invoice can remain `ContractPendingSettle` (shown
+  as `ACCEPTED` over RPC) and may require support-guided reconciliation.
+
 # New Features
 
 ## Functional Enhancements

--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -25,7 +25,7 @@ type InvoiceDatabase interface {
 	// byte payment hash.
 	LookupInvoice(context.Context, lntypes.Hash) (invoices.Invoice, error)
 
-	// NotifyExitHopHtlc attempts to mark an invoice as settled. If the
+	// NotifyExitHopHtlc requests settlement of an invoice. If the
 	// invoice is a debug invoice, then this method is a noop as debug
 	// invoices are never fully settled. The return value describes how the
 	// htlc should be resolved. If the htlc cannot be resolved immediately,
@@ -37,6 +37,11 @@ type InvoiceDatabase interface {
 		circuitKey models.CircuitKey, hodlChan chan<- interface{},
 		wireCustomRecords lnwire.CustomRecords,
 		payload invoices.Payload) (invoices.HtlcResolution, error)
+
+	// NotifyExitHopHtlcFinalized marks a previously requested exit-hop HTLC
+	// settlement as final.
+	NotifyExitHopHtlcFinalized(ctx context.Context,
+		circuitKey models.CircuitKey, settled bool) error
 
 	// CancelInvoice attempts to cancel the invoice corresponding to the
 	// passed payment hash.

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -4408,11 +4408,21 @@ func (l *channelLink) processRemoteCommitSig(ctx context.Context,
 
 	// Notify the incoming htlcs of which the resolutions were locked in.
 	for id, settled := range finalHTLCs {
+		circuitKey := models.CircuitKey{
+			ChanID: l.ShortChanID(),
+			HtlcID: id,
+		}
+
+		err := l.cfg.Registry.NotifyExitHopHtlcFinalized(
+			ctx, circuitKey, settled,
+		)
+		if err != nil {
+			l.log.Warnf("Unable to finalize exit-hop htlc %v: %v",
+				circuitKey, err)
+		}
+
 		l.cfg.HtlcNotifier.NotifyFinalHtlcEvent(
-			models.CircuitKey{
-				ChanID: l.ShortChanID(),
-				HtlcID: id,
-			},
+			circuitKey,
 			channeldb.FinalHtlcInfo{
 				Settled:  settled,
 				Offchain: true,

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -1395,13 +1395,23 @@ func TestUpdateForwardingPolicy(t *testing.T) {
 
 	// Carol's invoice should now be shown as settled as the payment
 	// succeeded.
-	invoice, err := n.carolServer.registry.LookupInvoice(
-		t.Context(), payResp,
-	)
-	require.NoError(t, err, "unable to get invoice")
-	if invoice.State != invpkg.ContractSettled {
-		t.Fatal("carol invoice haven't been settled")
-	}
+	err = wait.NoError(func() error {
+		invoice, err := n.carolServer.registry.LookupInvoice(
+			t.Context(), payResp,
+		)
+		if err != nil {
+			return fmt.Errorf("unable to get invoice: %w", err)
+		}
+
+		if invoice.State != invpkg.ContractSettled {
+			return fmt.Errorf(
+				"carol invoice state: %v", invoice.State,
+			)
+		}
+
+		return nil
+	}, time.Minute)
+	require.NoError(t, err)
 
 	expectedAliceBandwidth := aliceBandwidthBefore - htlcAmt
 	if expectedAliceBandwidth != n.aliceChannelLink.Bandwidth() {

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -1018,6 +1018,7 @@ func newMockRegistry(t testing.TB) *mockInvoiceRegistry {
 		&invoices.RegistryConfig{
 			FinalCltvRejectDelta: 5,
 			HtlcInterceptor:      modifierMock,
+			Clock:                clock.NewDefaultClock(),
 		},
 	)
 	registry.Start()
@@ -1057,6 +1058,14 @@ func (i *mockInvoiceRegistry) NotifyExitHopHtlc(rhash lntypes.Hash,
 	}
 
 	return event, nil
+}
+
+// NotifyExitHopHtlcFinalized forwards a final HTLC outcome to the invoice
+// registry.
+func (i *mockInvoiceRegistry) NotifyExitHopHtlcFinalized(ctx context.Context,
+	circuitKey models.CircuitKey, settled bool) error {
+
+	return i.registry.NotifyExitHopHtlcFinalized(ctx, circuitKey, settled)
 }
 
 func (i *mockInvoiceRegistry) CancelInvoice(ctx context.Context,

--- a/invoices/invoiceregistry.go
+++ b/invoices/invoiceregistry.go
@@ -346,11 +346,9 @@ func (i *InvoiceRegistry) invoiceEventLoop() {
 		// dispatch notifications to all registered clients.
 		case event := <-i.invoiceEvents:
 			// For backwards compatibility, do not notify all
-			// invoice subscribers of cancel and accept events.
-			state := event.invoice.State
-			if state != ContractCanceled &&
-				state != ContractAccepted {
-
+			// invoice subscribers of cancel, accept and
+			// pending-settle events.
+			if !event.suppressedForAllClients() {
 				i.dispatchToClients(event)
 			}
 			i.dispatchToSingleClients(event)
@@ -382,6 +380,31 @@ func (i *InvoiceRegistry) invoiceEventLoop() {
 			return
 		}
 	}
+}
+
+// suppressedForAllClients returns true for invoice events that should only be
+// sent to single-invoice subscribers for backwards compatibility.
+func (e *invoiceEvent) suppressedForAllClients() bool {
+	state := e.invoice.State
+	if state == ContractCanceled || state == ContractAccepted ||
+		state == ContractPendingSettle {
+
+		// These non-terminal or cancel events are only delivered to
+		// single-invoice subscribers for backwards compatibility.
+		return true
+	}
+
+	if e.setID == nil || state != ContractOpen {
+		// Open base invoices are new-invoice events, and settled events
+		// are safe for all-invoice subscribers.
+		return false
+	}
+
+	ampState, ok := e.invoice.AMPState[SetID(*e.setID)]
+
+	// AMP set updates keep the base invoice open until the AMP set settles.
+	// Suppress accepted, canceled and pending-settle set updates.
+	return ok && ampState.State != HtlcStateSettled
 }
 
 // dispatchToSingleClients passes the supplied event to all notification
@@ -922,7 +945,7 @@ func (i *InvoiceRegistry) processAMP(ctx invoiceUpdateCtx) error {
 	}
 }
 
-// NotifyExitHopHtlc attempts to mark an invoice as settled. The return value
+// NotifyExitHopHtlc requests settlement of an invoice. The return value
 // describes how the htlc should be resolved.
 //
 // When the preimage of the invoice is not yet known (hodl invoice), this
@@ -1038,6 +1061,97 @@ func (i *InvoiceRegistry) NotifyExitHopHtlc(rHash lntypes.Hash,
 	default:
 		return nil, errors.New("invalid resolution type")
 	}
+}
+
+// NotifyExitHopHtlcFinalized marks a previously requested exit-hop HTLC
+// settlement as final. The invoice is only reported as settled after the HTLC
+// settle is locked in off-chain or claimed on-chain.
+//
+// Crash recovery before the settle/fail response is forwarding-package acked is
+// handled by the switch's replay: replayed exit-hop adds re-enter
+// NotifyExitHopHtlc, receive the pending-settle resolution again, and trigger a
+// new finalization callback once the response locks in. After that response is
+// acked, a failed finalization is retried from the registry's in-memory queue.
+// Recovery is best-effort: a restart can leave an invoice in
+// ContractPendingSettle if finalization did not complete. Channel finality
+// itself must not wait on invoice DB health.
+func (i *InvoiceRegistry) NotifyExitHopHtlcFinalized(ctx context.Context,
+	circuitKey CircuitKey, settled bool) error {
+
+	return i.notifyExitHopHtlcFinalized(ctx, circuitKey, settled)
+}
+
+// notifyExitHopHtlcFinalized applies the final outcome of a pending-settle
+// HTLC without queuing a retry on failure.
+func (i *InvoiceRegistry) notifyExitHopHtlcFinalized(ctx context.Context,
+	circuitKey CircuitKey, settled bool) error {
+
+	i.Lock()
+	defer i.Unlock()
+
+	pendingRef, ok := i.pendingSettleRefs[circuitKey]
+	if !ok {
+		return nil
+	}
+
+	var (
+		oldInvoiceState ContractState
+		oldAMPState     HtlcState
+		oldAMPStateOk   bool
+		updated         bool
+	)
+	updateInvoice := func(invoice *Invoice) (*InvoiceUpdateDesc, error) {
+		htlc, ok := invoice.Htlcs[circuitKey]
+		if !ok || htlc.State != HtlcStatePendingSettle {
+			return nil, nil
+		}
+
+		updated = true
+		oldInvoiceState = invoice.State
+		if pendingRef.setID != nil {
+			ampState, ok := invoice.AMPState[*pendingRef.setID]
+			oldAMPStateOk = ok
+			oldAMPState = ampState.State
+		}
+
+		outcome := HtlcStateCanceled
+		if settled {
+			outcome = HtlcStateSettled
+		}
+
+		return &InvoiceUpdateDesc{
+			UpdateType: FinalizeHTLCsUpdate,
+			FinalizeHtlcs: map[CircuitKey]HtlcState{
+				circuitKey: outcome,
+			},
+			SetID: pendingRef.setID,
+		}, nil
+	}
+
+	invoice, err := i.idb.UpdateInvoice(
+		ctx, pendingRef.invoiceRef, pendingRef.setID, updateInvoice,
+	)
+	if err != nil {
+		return err
+	}
+	i.removeResolvedPendingSettleRefsLocked(invoice)
+	delete(i.pendingSettleRefs, circuitKey)
+
+	updateSubscribers := updated && invoice.State != oldInvoiceState
+	if updated && pendingRef.setID != nil {
+		ampState, ok := invoice.AMPState[*pendingRef.setID]
+		updateSubscribers = oldAMPStateOk != ok ||
+			(ok && ampState.State != oldAMPState)
+	}
+
+	if updateSubscribers {
+		i.notifyClients(
+			pendingRef.eventHash, invoice,
+			(*[32]byte)(pendingRef.setID),
+		)
+	}
+
+	return nil
 }
 
 // recordPendingSettleRefsLocked indexes all pending-settle HTLCs on an invoice

--- a/invoices/invoiceregistry.go
+++ b/invoices/invoiceregistry.go
@@ -1142,7 +1142,12 @@ func (i *InvoiceRegistry) NotifyExitHopHtlc(rHash lntypes.Hash,
 func (i *InvoiceRegistry) NotifyExitHopHtlcFinalized(ctx context.Context,
 	circuitKey CircuitKey, settled bool) error {
 
-	return i.notifyExitHopHtlcFinalized(ctx, circuitKey, settled)
+	err := i.notifyExitHopHtlcFinalized(ctx, circuitKey, settled)
+	if err != nil {
+		i.queueHtlcFinalizationRetry(circuitKey, settled)
+	}
+
+	return err
 }
 
 // notifyExitHopHtlcFinalized applies the final outcome of a pending-settle
@@ -1216,6 +1221,72 @@ func (i *InvoiceRegistry) notifyExitHopHtlcFinalized(ctx context.Context,
 	}
 
 	return nil
+}
+
+// queueHtlcFinalizationRetry queues a retry for an exit-hop HTLC finalization
+// that failed after the HTLC outcome was already known.
+func (i *InvoiceRegistry) queueHtlcFinalizationRetry(circuitKey CircuitKey,
+	settled bool) {
+
+	// Retries are processed by the invoice event loop, so there is nothing
+	// to queue before startup or after shutdown has begun.
+	if !i.started.Load() || i.stopped.Load() {
+		return
+	}
+
+	i.Lock()
+	if _, ok := i.htlcFinalizationRetries[circuitKey]; ok {
+		i.Unlock()
+		return
+	}
+	i.htlcFinalizationRetries[circuitKey] = struct{}{}
+	i.Unlock()
+
+	event := &htlcFinalizationRetryEvent{
+		key:       circuitKey,
+		settled:   settled,
+		retryTime: i.cfg.Clock.Now().Add(htlcFinalizationRetryDelay(0)),
+	}
+
+	i.enqueueHtlcFinalizationRetry(event)
+}
+
+// clearHtlcFinalizationRetry removes an HTLC from the retry de-duplication
+// index.
+func (i *InvoiceRegistry) clearHtlcFinalizationRetry(
+	circuitKey CircuitKey) {
+
+	i.Lock()
+	delete(i.htlcFinalizationRetries, circuitKey)
+	i.Unlock()
+}
+
+// enqueueHtlcFinalizationRetry queues a finalization retry.
+func (i *InvoiceRegistry) enqueueHtlcFinalizationRetry(
+	event *htlcFinalizationRetryEvent) {
+
+	select {
+	case i.htlcFinalizationRetryChan <- event:
+	case <-i.quit:
+		i.clearHtlcFinalizationRetry(event.key)
+	default:
+		log.Warnf("Finalization retry queue full for %v", event.key)
+		i.clearHtlcFinalizationRetry(event.key)
+	}
+}
+
+// htlcFinalizationRetryDelay returns the exponential backoff delay for a
+// failed finalization retry.
+func htlcFinalizationRetryDelay(attempts uint32) time.Duration {
+	delay := DefaultHtlcFinalizationRetryDelay
+	for ; attempts > 0; attempts-- {
+		delay *= 2
+		if delay >= DefaultHtlcFinalizationRetryMaxDelay {
+			return DefaultHtlcFinalizationRetryMaxDelay
+		}
+	}
+
+	return delay
 }
 
 // recordPendingSettleRefsLocked indexes all pending-settle HTLCs on an invoice

--- a/invoices/invoiceregistry.go
+++ b/invoices/invoiceregistry.go
@@ -1682,10 +1682,13 @@ func (i *InvoiceRegistry) notifyExitHopHtlcLocked(
 			res.Outcome, res.AcceptHeight))
 
 		// Also settle any previously accepted htlcs. If a htlc is
-		// marked as settled, we should follow now and settle the htlc
-		// with our peer.
+		// marked as pending settle, we should follow now and settle the
+		// htlc with our peer. The invoice will only become settled
+		// after the link or resolver reports a final outcome.
 		setID := ctx.setID()
-		settledHtlcSet := invoice.HTLCSet(setID, HtlcStateSettled)
+		settledHtlcSet := invoice.HTLCSet(
+			setID, HtlcStatePendingSettle,
+		)
 		for key, htlc := range settledHtlcSet {
 			preimage := res.Preimage
 			if htlc.AMP != nil && htlc.AMP.Preimage != nil {
@@ -1807,12 +1810,18 @@ func (i *InvoiceRegistry) SettleHodlInvoice(ctx context.Context,
 
 		case ContractSettled:
 			return nil, ErrInvoiceAlreadySettled
+
+		// A settle request is already in flight. Surface this as
+		// already settled to keep SettleHodlInvoice idempotent for
+		// callers.
+		case ContractPendingSettle:
+			return nil, ErrInvoiceAlreadySettled
 		}
 
 		return &InvoiceUpdateDesc{
 			UpdateType: SettleHodlInvoiceUpdate,
 			State: &InvoiceStateUpdateDesc{
-				NewState: ContractSettled,
+				NewState: ContractPendingSettle,
 				Preimage: &preimage,
 			},
 		}, nil
@@ -1840,14 +1849,14 @@ func (i *InvoiceRegistry) SettleHodlInvoice(ctx context.Context,
 		invoice.Terms.PaymentPreimage)
 	i.recordPendingSettleRefsLocked(hash, invoiceRef, invoice)
 
-	// In the callback, we marked the invoice as settled. UpdateInvoice will
-	// have seen this and should have moved all htlcs that were accepted to
-	// the settled state. In the loop below, we go through all of these and
-	// notify links and resolvers that are waiting for resolution. Any htlcs
-	// that were already settled before, will be notified again. This isn't
-	// necessary but doesn't hurt either.
+	// In the callback, we marked the invoice as pending settle.
+	// UpdateInvoice will have seen this and should have moved all htlcs
+	// that were accepted to the pending-settle state. In the loop below, we
+	// go through all of these and notify links and resolvers that are
+	// waiting for resolution. Any htlcs that were already pending before,
+	// will be notified again. This isn't necessary but doesn't hurt either.
 	for key, htlc := range invoice.Htlcs {
-		if htlc.State != HtlcStateSettled {
+		if htlc.State != HtlcStatePendingSettle {
 			continue
 		}
 

--- a/invoices/invoiceregistry.go
+++ b/invoices/invoiceregistry.go
@@ -1870,18 +1870,40 @@ func (i *InvoiceRegistry) CancelInvoice(ctx context.Context,
 	return i.cancelInvoiceImpl(ctx, payHash, true)
 }
 
-// shouldCancel examines the state of an invoice and whether we want to
+// shouldCancel examines the invoice and whether we want to
 // cancel already accepted invoices, taking our force cancel boolean into
 // account. This is pulled out into its own function so that tests that mock
 // cancelInvoiceImpl can reuse this logic.
-func shouldCancel(state ContractState, cancelAccepted bool) bool {
-	if state != ContractAccepted {
+func shouldCancel(invoice *Invoice, cancelAccepted bool) bool {
+	if invoice.State == ContractPendingSettle {
+		return false
+	}
+
+	if hasPendingSettleHTLC(invoice) {
+		return false
+	}
+
+	if invoice.State != ContractAccepted {
 		return true
 	}
 
-	// If the invoice is accepted, we should only cancel if we want to
-	// force cancellation of accepted invoices.
+	// Accepted invoices are only canceled when callers explicitly force
+	// cancellation of HTLC-bearing invoices. Once settlement is pending,
+	// the final HTLC outcome decides whether the invoice settles or
+	// cancels.
 	return cancelAccepted
+}
+
+// hasPendingSettleHTLC returns true when any HTLC on the invoice is waiting for
+// channel finality before it can resolve.
+func hasPendingSettleHTLC(invoice *Invoice) bool {
+	for _, htlc := range invoice.Htlcs {
+		if htlc.State == HtlcStatePendingSettle {
+			return true
+		}
+	}
+
+	return false
 }
 
 // cancelInvoice attempts to cancel the invoice corresponding to the passed
@@ -1898,7 +1920,7 @@ func (i *InvoiceRegistry) cancelInvoiceImpl(ctx context.Context,
 	log.Debugf("Invoice%v: canceling invoice", ref)
 
 	updateInvoice := func(invoice *Invoice) (*InvoiceUpdateDesc, error) {
-		if !shouldCancel(invoice.State, cancelAccepted) {
+		if !shouldCancel(invoice, cancelAccepted) {
 			return nil, nil
 		}
 
@@ -1932,9 +1954,20 @@ func (i *InvoiceRegistry) cancelInvoiceImpl(ctx context.Context,
 		return err
 	}
 
-	// Return without cancellation if the invoice state is ContractAccepted.
+	// Return without cancellation once settlement is pending. At this
+	// point, the final HTLC outcome decides whether the invoice settles or
+	// cancels.
+	if invoice.State == ContractPendingSettle ||
+		hasPendingSettleHTLC(invoice) {
+
+		log.Debugf("Invoice%v: remains pending settle", ref)
+		return nil
+	}
+
+	// Return without cancellation if the invoice has accepted HTLCs and
+	// cancelAccepted wasn't set.
 	if invoice.State == ContractAccepted {
-		log.Debugf("Invoice%v: remains accepted as cancel wasn't"+
+		log.Debugf("Invoice%v: remains accepted as cancel wasn't "+
 			"explicitly requested.", ref)
 		return nil
 	}

--- a/invoices/invoiceregistry.go
+++ b/invoices/invoiceregistry.go
@@ -396,6 +396,9 @@ func (i *InvoiceRegistry) invoiceEventLoop() {
 	// Set up a heap for htlc auto-releases.
 	autoReleaseHeap := &queue.PriorityQueue{}
 
+	// Set up a heap for failed HTLC finalization retries.
+	finalizationRetryHeap := &queue.PriorityQueue{}
+
 	for {
 		// If there is something to release, set up a release tick
 		// channel.
@@ -403,6 +406,20 @@ func (i *InvoiceRegistry) invoiceEventLoop() {
 		if autoReleaseHeap.Len() > 0 {
 			head := autoReleaseHeap.Top().(*htlcReleaseEvent)
 			nextReleaseTick = i.tickAt(head.releaseTime)
+		}
+
+		// If there is something to retry, set up a retry tick channel.
+		var nextFinalizationRetryTick <-chan time.Time
+		if finalizationRetryHeap.Len() > 0 {
+			retryItem := finalizationRetryHeap.Top()
+			head, ok := retryItem.(*htlcFinalizationRetryEvent)
+			if !ok {
+				log.Errorf("Unexpected retry event")
+				finalizationRetryHeap.Pop()
+				continue
+			}
+
+			nextFinalizationRetryTick = i.tickAt(head.retryTime)
 		}
 
 		select {
@@ -430,6 +447,14 @@ func (i *InvoiceRegistry) invoiceEventLoop() {
 			// channel is force closed.
 			autoReleaseHeap.Push(event)
 
+		// A failed final HTLC outcome needs to be retried later.
+		case event := <-i.htlcFinalizationRetryChan:
+			log.Debugf("Scheduling finalization retry for htlc: "+
+				"key=%v, settled=%v at %v",
+				event.key, event.settled, event.retryTime)
+
+			finalizationRetryHeap.Push(event)
+
 		// The htlc at the top of the heap needs to be auto-released.
 		case <-nextReleaseTick:
 			event := autoReleaseHeap.Pop().(*htlcReleaseEvent)
@@ -439,6 +464,18 @@ func (i *InvoiceRegistry) invoiceEventLoop() {
 			if err != nil {
 				log.Errorf("HTLC timer: %v", err)
 			}
+
+		// The htlc at the top of the retry heap needs to be retried.
+		case <-nextFinalizationRetryTick:
+			retryItem := finalizationRetryHeap.Pop()
+			event, ok := retryItem.(*htlcFinalizationRetryEvent)
+			if !ok {
+				log.Errorf("Unexpected retry event")
+				continue
+			}
+
+			i.wg.Add(1)
+			go i.retryHtlcFinalization(event)
 
 		case <-i.quit:
 			return
@@ -1261,7 +1298,54 @@ func (i *InvoiceRegistry) clearHtlcFinalizationRetry(
 	i.Unlock()
 }
 
-// enqueueHtlcFinalizationRetry queues a finalization retry.
+// retryHtlcFinalization retries a failed HTLC finalization from the registry
+// event loop.
+func (i *InvoiceRegistry) retryHtlcFinalization(
+	event *htlcFinalizationRetryEvent) {
+
+	defer i.wg.Done()
+	i.retryHtlcFinalizationOnce(event)
+}
+
+// retryHtlcFinalizationAfterDelay retries a failed HTLC finalization when the
+// event loop queue is full.
+func (i *InvoiceRegistry) retryHtlcFinalizationAfterDelay(
+	event *htlcFinalizationRetryEvent) {
+
+	defer i.wg.Done()
+
+	select {
+	case <-i.tickAt(event.retryTime):
+		i.retryHtlcFinalizationOnce(event)
+
+	case <-i.quit:
+		i.clearHtlcFinalizationRetry(event.key)
+	}
+}
+
+// retryHtlcFinalizationOnce applies one retry attempt and reschedules the HTLC
+// if the finalization still fails.
+func (i *InvoiceRegistry) retryHtlcFinalizationOnce(
+	event *htlcFinalizationRetryEvent) {
+
+	err := i.notifyExitHopHtlcFinalized(
+		context.Background(), event.key, event.settled,
+	)
+	if err == nil {
+		i.clearHtlcFinalizationRetry(event.key)
+		return
+	}
+
+	event.attempts++
+	delay := htlcFinalizationRetryDelay(event.attempts)
+	logHtlcFinalizationRetryError(event, delay, err)
+
+	event.retryTime = i.cfg.Clock.Now().Add(delay)
+	i.enqueueHtlcFinalizationRetry(event)
+}
+
+// enqueueHtlcFinalizationRetry queues a finalization retry with a direct
+// delayed fallback if the event loop queue is full.
 func (i *InvoiceRegistry) enqueueHtlcFinalizationRetry(
 	event *htlcFinalizationRetryEvent) {
 
@@ -1270,8 +1354,11 @@ func (i *InvoiceRegistry) enqueueHtlcFinalizationRetry(
 	case <-i.quit:
 		i.clearHtlcFinalizationRetry(event.key)
 	default:
-		log.Warnf("Finalization retry queue full for %v", event.key)
-		i.clearHtlcFinalizationRetry(event.key)
+		log.Warnf("Finalization retry queue full for %v; scheduling "+
+			"direct retry",
+			event.key)
+		i.wg.Add(1)
+		go i.retryHtlcFinalizationAfterDelay(event)
 	}
 }
 
@@ -1287,6 +1374,31 @@ func htlcFinalizationRetryDelay(attempts uint32) time.Duration {
 	}
 
 	return delay
+}
+
+// logHtlcFinalizationRetryError logs retry failures with escalation to avoid
+// repeatedly emitting errors for a persistent database issue.
+func logHtlcFinalizationRetryError(event *htlcFinalizationRetryEvent,
+	delay time.Duration, err error) {
+
+	switch {
+	case event.attempts == htlcFinalizationRetryEscalateAttempts:
+		fallthrough
+	case event.attempts > htlcFinalizationRetryEscalateAttempts &&
+		event.attempts%htlcFinalizationRetryLogInterval == 0:
+
+		log.Errorf("Unable to finalize exit-hop htlc %v after %d "+
+			"attempts: %v; retrying in %v", event.key,
+			event.attempts, err, delay)
+
+	case event.attempts == 1:
+		log.Warnf("Unable to retry exit-hop htlc finalization for %v: "+
+			"%v; retrying in %v", event.key, err, delay)
+
+	default:
+		log.Debugf("Unable to retry htlc finalization for %v: "+
+			"%v; retrying in %v", event.key, err, delay)
+	}
 }
 
 // recordPendingSettleRefsLocked indexes all pending-settle HTLCs on an invoice
@@ -1328,6 +1440,7 @@ func pendingSettleSetID(htlc *InvoiceHTLC) *SetID {
 	}
 
 	setID := SetID(htlc.AMP.Record.SetID())
+
 	return &setID
 }
 

--- a/invoices/invoiceregistry.go
+++ b/invoices/invoiceregistry.go
@@ -36,6 +36,22 @@ const (
 	// DefaultHtlcHoldDuration defines the default for how long mpp htlcs
 	// are held while waiting for the other set members to arrive.
 	DefaultHtlcHoldDuration = 120 * time.Second
+
+	// DefaultHtlcFinalizationRetryDelay defines how long to wait before
+	// retrying a failed invoice HTLC finalization.
+	DefaultHtlcFinalizationRetryDelay = time.Second
+
+	// DefaultHtlcFinalizationRetryMaxDelay defines the maximum delay
+	// between failed invoice HTLC finalization retries.
+	DefaultHtlcFinalizationRetryMaxDelay = time.Minute
+
+	// htlcFinalizationRetryEscalateAttempts is the number of failed retry
+	// attempts after which failures are logged as errors.
+	htlcFinalizationRetryEscalateAttempts = 5
+
+	// htlcFinalizationRetryLogInterval limits repeated error logs after the
+	// retry loop has escalated.
+	htlcFinalizationRetryLogInterval = 10
 )
 
 // RegistryConfig contains the configuration parameters for invoice registry.
@@ -94,12 +110,45 @@ type htlcReleaseEvent struct {
 	releaseTime time.Time
 }
 
+// htlcFinalizationRetryEvent describes an exit-hop HTLC finalization retry.
+type htlcFinalizationRetryEvent struct {
+	// key identifies the exit-hop HTLC to finalize.
+	key CircuitKey
+
+	// settled is the final outcome to record for the HTLC.
+	settled bool
+
+	// retryTime is when the retry should next be attempted.
+	retryTime time.Time
+
+	// attempts is the number of failed finalization attempts so far.
+	attempts uint32
+}
+
 // Less is used to order PriorityQueueItem's by their release time such that
 // items with the older release time are at the top of the queue.
 //
 // NOTE: Part of the queue.PriorityQueueItem interface.
 func (r *htlcReleaseEvent) Less(other queue.PriorityQueueItem) bool {
 	return r.releaseTime.Before(other.(*htlcReleaseEvent).releaseTime)
+}
+
+// Less is used to order finalization retries by their retry time.
+//
+// NOTE: Part of the queue.PriorityQueueItem interface.
+// Ensure htlcFinalizationRetryEvent implements the PriorityQueueItem
+// interface.
+var _ queue.PriorityQueueItem = (*htlcFinalizationRetryEvent)(nil)
+
+func (r *htlcFinalizationRetryEvent) Less(
+	other queue.PriorityQueueItem) bool {
+
+	retry, ok := other.(*htlcFinalizationRetryEvent)
+	if !ok {
+		return false
+	}
+
+	return r.retryTime.Before(retry.retryTime)
 }
 
 // InvoiceRegistry is a central registry of all the outstanding invoices
@@ -153,9 +202,18 @@ type InvoiceRegistry struct {
 	// reported.
 	pendingSettleRefs map[CircuitKey]pendingSettleRef
 
+	// htlcFinalizationRetries tracks exit-hop HTLCs that already have a
+	// retry queued so transient finalization errors don't enqueue
+	// duplicates.
+	htlcFinalizationRetries map[CircuitKey]struct{}
+
 	// htlcAutoReleaseChan contains the new htlcs that need to be
 	// auto-released.
 	htlcAutoReleaseChan chan *htlcReleaseEvent
+
+	// htlcFinalizationRetryChan contains exit-hop HTLC finalization
+	// retries.
+	htlcFinalizationRetryChan chan *htlcFinalizationRetryEvent
 
 	expiryWatcher *InvoiceExpiryWatcher
 
@@ -196,11 +254,17 @@ func NewRegistry(idb InvoiceDB, expiryWatcher *InvoiceExpiryWatcher,
 		hodlReverseSubscriptions: make(
 			map[chan<- interface{}]map[CircuitKey]struct{},
 		),
-		pendingSettleRefs:   make(map[CircuitKey]pendingSettleRef),
+		pendingSettleRefs: make(map[CircuitKey]pendingSettleRef),
+		htlcFinalizationRetries: make(
+			map[CircuitKey]struct{},
+		),
 		cfg:                 cfg,
 		htlcAutoReleaseChan: make(chan *htlcReleaseEvent),
-		expiryWatcher:       expiryWatcher,
-		quit:                make(chan struct{}),
+		htlcFinalizationRetryChan: make(
+			chan *htlcFinalizationRetryEvent, 100,
+		),
+		expiryWatcher: expiryWatcher,
+		quit:          make(chan struct{}),
 	}
 }
 

--- a/invoices/invoiceregistry.go
+++ b/invoices/invoiceregistry.go
@@ -148,6 +148,11 @@ type InvoiceRegistry struct {
 	// subscriber. This is used to unsubscribe from all hashes efficiently.
 	hodlReverseSubscriptions map[chan<- interface{}]map[CircuitKey]struct{}
 
+	// pendingSettleRefs maps pending-settle HTLCs back to the invoice
+	// update reference that should be used when their final outcome is
+	// reported.
+	pendingSettleRefs map[CircuitKey]pendingSettleRef
+
 	// htlcAutoReleaseChan contains the new htlcs that need to be
 	// auto-released.
 	htlcAutoReleaseChan chan *htlcReleaseEvent
@@ -156,6 +161,19 @@ type InvoiceRegistry struct {
 
 	wg   sync.WaitGroup
 	quit chan struct{}
+}
+
+// pendingSettleRef records the invoice reference needed to finalize a pending
+// settle HTLC without scanning all pending invoices.
+type pendingSettleRef struct {
+	// invoiceRef identifies the invoice that owns the pending-settle HTLC.
+	invoiceRef InvoiceRef
+
+	// eventHash is the payment hash used for invoice notifications.
+	eventHash lntypes.Hash
+
+	// setID identifies the AMP set for AMP HTLCs.
+	setID *SetID
 }
 
 // NewRegistry creates a new invoice registry. The invoice registry
@@ -178,6 +196,7 @@ func NewRegistry(idb InvoiceDB, expiryWatcher *InvoiceExpiryWatcher,
 		hodlReverseSubscriptions: make(
 			map[chan<- interface{}]map[CircuitKey]struct{},
 		),
+		pendingSettleRefs:   make(map[CircuitKey]pendingSettleRef),
 		cfg:                 cfg,
 		htlcAutoReleaseChan: make(chan *htlcReleaseEvent),
 		expiryWatcher:       expiryWatcher,
@@ -196,6 +215,12 @@ func (i *InvoiceRegistry) scanInvoicesOnStart(ctx context.Context) error {
 
 	var pending []invoiceExpiry
 	for paymentHash, invoice := range pendingInvoices {
+		i.Lock()
+		i.recordPendingSettleRefsLocked(
+			paymentHash, InvoiceRefByHash(paymentHash), &invoice,
+		)
+		i.Unlock()
+
 		expiryRef := makeInvoiceExpiry(paymentHash, &invoice)
 		if expiryRef != nil {
 			pending = append(pending, expiryRef)
@@ -1015,6 +1040,48 @@ func (i *InvoiceRegistry) NotifyExitHopHtlc(rHash lntypes.Hash,
 	}
 }
 
+// recordPendingSettleRefsLocked indexes all pending-settle HTLCs on an invoice
+// so that their final outcomes can be applied by circuit key.
+func (i *InvoiceRegistry) recordPendingSettleRefsLocked(eventHash lntypes.Hash,
+	invoiceRef InvoiceRef, invoice *Invoice) {
+
+	for key, htlc := range invoice.Htlcs {
+		if htlc.State != HtlcStatePendingSettle {
+			continue
+		}
+
+		i.pendingSettleRefs[key] = pendingSettleRef{
+			invoiceRef: invoiceRef,
+			eventHash:  eventHash,
+			setID:      pendingSettleSetID(htlc),
+		}
+	}
+}
+
+// removeResolvedPendingSettleRefsLocked removes index entries for HTLCs that
+// are no longer waiting for a final settle/fail outcome.
+func (i *InvoiceRegistry) removeResolvedPendingSettleRefsLocked(
+	invoice *Invoice) {
+
+	for key, htlc := range invoice.Htlcs {
+		if htlc.State == HtlcStatePendingSettle {
+			continue
+		}
+
+		delete(i.pendingSettleRefs, key)
+	}
+}
+
+// pendingSettleSetID returns the AMP set ID for a pending-settle HTLC.
+func pendingSettleSetID(htlc *InvoiceHTLC) *SetID {
+	if htlc.AMP == nil {
+		return nil
+	}
+
+	setID := SetID(htlc.AMP.Record.SetID())
+	return &setID
+}
+
 // notifyExitHopHtlcLocked is the internal implementation of NotifyExitHopHtlc
 // that should be executed inside the registry lock. The returned invoiceExpiry
 // (if not nil) needs to be added to the expiry watcher outside of the lock.
@@ -1203,6 +1270,7 @@ func (i *InvoiceRegistry) notifyExitHopHtlcLocked(
 		ctx.log(err.Error())
 		return nil, nil, err
 	}
+	i.recordPendingSettleRefsLocked(ctx.hash, invoiceRef, invoice)
 
 	var invoiceToExpire invoiceExpiry
 
@@ -1408,6 +1476,7 @@ func (i *InvoiceRegistry) SettleHodlInvoice(ctx context.Context,
 
 	log.Debugf("Invoice%v: settled with preimage %v", invoiceRef,
 		invoice.Terms.PaymentPreimage)
+	i.recordPendingSettleRefsLocked(hash, invoiceRef, invoice)
 
 	// In the callback, we marked the invoice as settled. UpdateInvoice will
 	// have seen this and should have moved all htlcs that were accepted to
@@ -1509,6 +1578,7 @@ func (i *InvoiceRegistry) cancelInvoiceImpl(ctx context.Context,
 	}
 
 	log.Debugf("Invoice%v: canceled", ref)
+	i.removeResolvedPendingSettleRefsLocked(invoice)
 
 	// In the callback, some htlcs may have been moved to the canceled
 	// state. We now go through all of these and notify links and resolvers

--- a/invoices/invoiceregistry_final_test.go
+++ b/invoices/invoiceregistry_final_test.go
@@ -554,3 +554,192 @@ func TestNotifyExitHopHtlcFinalizedRetriesError(t *testing.T) {
 	require.False(t, pending)
 	require.False(t, retrying)
 }
+
+// TestNotifyExitHopHtlcFinalizedAMPSettle verifies finalizing one pending AMP
+// HTLC settles the whole AMP set without double-counting the invoice amount.
+func TestNotifyExitHopHtlcFinalizedAMPSettle(t *testing.T) {
+	t.Parallel()
+
+	hash, payAddr, setID, circuitKey, invoice :=
+		newPendingSettleAMPTestInvoice()
+	secondKey := CircuitKey{
+		ChanID: lnwire.NewShortChanIDFromInt(1),
+		HtlcID: 3,
+	}
+	secondPreimage := lntypes.Preimage{16, 17, 18}
+	secondRecord := record.NewAMP(
+		[32]byte{19, 20, 21}, [32]byte(setID), 4,
+	)
+	invoice.Htlcs[secondKey] = &InvoiceHTLC{
+		Amt:   2000,
+		State: HtlcStatePendingSettle,
+		AMP: &InvoiceHtlcAMPData{
+			Record:   *secondRecord,
+			Hash:     secondPreimage.Hash(),
+			Preimage: &secondPreimage,
+		},
+	}
+	ampState := invoice.AMPState[setID]
+	ampState.InvoiceKeys[secondKey] = struct{}{}
+	ampState.AmtPaid += 2000
+	invoice.AMPState[setID] = ampState
+
+	settledSetID := SetID{22, 23, 24}
+	settledKey := CircuitKey{
+		ChanID: lnwire.NewShortChanIDFromInt(1),
+		HtlcID: 4,
+	}
+	settledPreimage := lntypes.Preimage{25, 26, 27}
+	settledRecord := record.NewAMP(
+		[32]byte{28, 29, 30}, [32]byte(settledSetID), 5,
+	)
+	invoice.Htlcs[settledKey] = &InvoiceHTLC{
+		Amt:   4000,
+		State: HtlcStateSettled,
+		AMP: &InvoiceHtlcAMPData{
+			Record:   *settledRecord,
+			Hash:     settledPreimage.Hash(),
+			Preimage: &settledPreimage,
+		},
+	}
+	invoice.AMPState[settledSetID] = InvoiceStateAMP{
+		State: HtlcStateSettled,
+		InvoiceKeys: map[CircuitKey]struct{}{
+			settledKey: {},
+		},
+		AmtPaid: 4000,
+	}
+	// The top-level AMP amount already includes every accepted set.
+	invoice.AmtPaid = 7000
+
+	db := &finalTestDB{
+		hash:       hash,
+		invoice:    invoice,
+		updateTime: time.Now(),
+	}
+	registry := NewRegistry(db, nil, &RegistryConfig{})
+	registerPendingSettleTestInvoice(
+		registry, hash, &invoice,
+	)
+	registry.Lock()
+	registry.pendingSettleRefs[circuitKey] = pendingSettleRef{
+		invoiceRef: InvoiceRefByAddr(payAddr),
+		eventHash:  hash,
+		setID:      &setID,
+	}
+	registry.pendingSettleRefs[secondKey] = pendingSettleRef{
+		invoiceRef: InvoiceRefByAddr(payAddr),
+		eventHash:  hash,
+		setID:      &setID,
+	}
+	registry.Unlock()
+
+	err := registry.NotifyExitHopHtlcFinalized(
+		t.Context(), circuitKey, true,
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t, HtlcStateSettled, db.invoice.Htlcs[circuitKey].State,
+	)
+	require.Equal(
+		t, HtlcStatePendingSettle, db.invoice.Htlcs[secondKey].State,
+	)
+	require.Equal(
+		t, HtlcStatePendingSettle, db.invoice.AMPState[setID].State,
+	)
+	require.Equal(
+		t, HtlcStateSettled, db.invoice.AMPState[settledSetID].State,
+	)
+	require.Equal(t, ContractOpen, db.invoice.State)
+	require.Equal(t, lnwire.MilliSatoshi(7000), db.invoice.AmtPaid)
+	require.Equal(t, payAddr, *db.updateRef.payAddr)
+	require.Equal(t, setID, *db.updateSetID)
+	assertNoInvoiceEvent(t, registry)
+
+	registry.Lock()
+	_, firstPending := registry.pendingSettleRefs[circuitKey]
+	_, secondPending := registry.pendingSettleRefs[secondKey]
+	registry.Unlock()
+	require.False(t, firstPending)
+	require.True(t, secondPending)
+
+	err = registry.NotifyExitHopHtlcFinalized(
+		t.Context(), secondKey, true,
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t, HtlcStateSettled, db.invoice.Htlcs[secondKey].State,
+	)
+	require.Equal(t, HtlcStateSettled, db.invoice.AMPState[setID].State)
+	require.Equal(t, ContractOpen, db.invoice.State)
+	require.Equal(t, lnwire.MilliSatoshi(7000), db.invoice.AmtPaid)
+
+	select {
+	case event := <-registry.invoiceEvents:
+		require.NotNil(t, event.setID)
+		require.Equal(t, setID, SetID(*event.setID))
+		require.False(t, event.suppressedForAllClients())
+
+	case <-time.After(time.Second):
+		t.Fatal("invoice notification not received")
+	}
+
+	registry.Lock()
+	_, ok := registry.pendingSettleRefs[secondKey]
+	registry.Unlock()
+	require.False(t, ok)
+}
+
+// TestNotifyExitHopHtlcFinalizedAMPFail verifies a failed final outcome cancels
+// the pending AMP set while leaving the base AMP invoice open.
+func TestNotifyExitHopHtlcFinalizedAMPFail(t *testing.T) {
+	t.Parallel()
+
+	hash, payAddr, setID, circuitKey, invoice :=
+		newPendingSettleAMPTestInvoice()
+	db := &finalTestDB{
+		hash:       hash,
+		invoice:    invoice,
+		updateTime: time.Now(),
+	}
+	registry := NewRegistry(db, nil, &RegistryConfig{})
+	registerPendingSettleTestInvoice(registry, hash, &invoice)
+	registry.Lock()
+	registry.pendingSettleRefs[circuitKey] = pendingSettleRef{
+		invoiceRef: InvoiceRefByAddr(payAddr),
+		eventHash:  hash,
+		setID:      &setID,
+	}
+	registry.Unlock()
+
+	err := registry.NotifyExitHopHtlcFinalized(
+		t.Context(), circuitKey, false,
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t, HtlcStateCanceled, db.invoice.Htlcs[circuitKey].State,
+	)
+	require.Equal(t, HtlcStateCanceled, db.invoice.AMPState[setID].State)
+	require.Equal(
+		t, lnwire.MilliSatoshi(0), db.invoice.AMPState[setID].AmtPaid,
+	)
+	require.Zero(t, db.invoice.AmtPaid)
+	require.Equal(t, ContractOpen, db.invoice.State)
+	require.Equal(t, payAddr, *db.updateRef.payAddr)
+	require.Equal(t, setID, *db.updateSetID)
+
+	select {
+	case event := <-registry.invoiceEvents:
+		require.NotNil(t, event.setID)
+		require.Equal(t, setID, SetID(*event.setID))
+		require.True(t, event.suppressedForAllClients())
+
+	case <-time.After(time.Second):
+		t.Fatal("invoice notification not received")
+	}
+
+	registry.Lock()
+	_, ok := registry.pendingSettleRefs[circuitKey]
+	registry.Unlock()
+	require.False(t, ok)
+}

--- a/invoices/invoiceregistry_final_test.go
+++ b/invoices/invoiceregistry_final_test.go
@@ -274,3 +274,185 @@ func TestInvoiceEventSuppressesAMPNonSettled(t *testing.T) {
 	invoice.AMPState[setID] = ampState
 	require.False(t, event.suppressedForAllClients())
 }
+
+// TestNotifyExitHopHtlcFinalizedSettle finalizes a pending-settle HTLC as
+// settled and verifies the invoice reaches its terminal settled state.
+func TestNotifyExitHopHtlcFinalizedSettle(t *testing.T) {
+	t.Parallel()
+
+	hash, circuitKey, invoice := newPendingSettleTestInvoice()
+	db := &finalTestDB{
+		hash:       hash,
+		invoice:    invoice,
+		updateTime: time.Now(),
+	}
+	registry := NewRegistry(db, nil, &RegistryConfig{})
+	registerPendingSettleTestInvoice(registry, hash, &invoice)
+
+	err := registry.NotifyExitHopHtlcFinalized(
+		t.Context(), circuitKey, true,
+	)
+	require.NoError(t, err)
+	require.Equal(t, ContractSettled, db.invoice.State)
+	require.Equal(
+		t, HtlcStateSettled, db.invoice.Htlcs[circuitKey].State,
+	)
+	require.Zero(t, db.fetchPendingCalls)
+}
+
+// TestNotifyExitHopHtlcFinalizedFail finalizes a pending-settle HTLC as failed
+// and verifies the invoice is canceled.
+func TestNotifyExitHopHtlcFinalizedFail(t *testing.T) {
+	t.Parallel()
+
+	hash, circuitKey, invoice := newPendingSettleTestInvoice()
+	db := &finalTestDB{
+		hash:       hash,
+		invoice:    invoice,
+		updateTime: time.Now(),
+	}
+	registry := NewRegistry(db, nil, &RegistryConfig{})
+	registerPendingSettleTestInvoice(registry, hash, &invoice)
+
+	err := registry.NotifyExitHopHtlcFinalized(
+		t.Context(), circuitKey, false,
+	)
+	require.NoError(t, err)
+	require.Equal(t, ContractCanceled, db.invoice.State)
+	require.Equal(
+		t, HtlcStateCanceled, db.invoice.Htlcs[circuitKey].State,
+	)
+	require.Zero(t, db.fetchPendingCalls)
+}
+
+// TestNotifyExitHopHtlcFinalizedSettleWaitsForSibling verifies a settled HTLC
+// does not finalize the invoice while another HTLC in the same set is still
+// pending finality.
+func TestNotifyExitHopHtlcFinalizedSettleWaitsForSibling(t *testing.T) {
+	t.Parallel()
+
+	hash, circuitKey, invoice := newPendingSettleTestInvoice()
+	secondKey := CircuitKey{
+		ChanID: lnwire.NewShortChanIDFromInt(1),
+		HtlcID: 3,
+	}
+	invoice.Htlcs[secondKey] = &InvoiceHTLC{
+		Amt:   2000,
+		State: HtlcStatePendingSettle,
+	}
+	invoice.AmtPaid += 2000
+	db := &finalTestDB{
+		hash:       hash,
+		invoice:    invoice,
+		updateTime: time.Now(),
+	}
+	registry := NewRegistry(db, nil, &RegistryConfig{})
+	registerPendingSettleTestInvoice(registry, hash, &invoice)
+
+	err := registry.NotifyExitHopHtlcFinalized(
+		t.Context(), circuitKey, true,
+	)
+	require.NoError(t, err)
+	require.Equal(t, ContractPendingSettle, db.invoice.State)
+	require.Equal(
+		t, HtlcStateSettled, db.invoice.Htlcs[circuitKey].State,
+	)
+	require.Equal(
+		t, HtlcStatePendingSettle, db.invoice.Htlcs[secondKey].State,
+	)
+	assertNoInvoiceEvent(t, registry)
+
+	registry.Lock()
+	_, firstPending := registry.pendingSettleRefs[circuitKey]
+	_, secondPending := registry.pendingSettleRefs[secondKey]
+	registry.Unlock()
+	require.False(t, firstPending)
+	require.True(t, secondPending)
+
+	err = registry.NotifyExitHopHtlcFinalized(
+		t.Context(), secondKey, true,
+	)
+	require.NoError(t, err)
+	require.Equal(t, ContractSettled, db.invoice.State)
+	require.Equal(
+		t, HtlcStateSettled, db.invoice.Htlcs[secondKey].State,
+	)
+	require.Equal(t, lnwire.MilliSatoshi(3000), db.invoice.AmtPaid)
+}
+
+// TestNotifyExitHopHtlcFinalizedFailWaitsForSibling verifies a failed HTLC does
+// not cancel sibling pending-settle HTLCs, and a later settled sibling can
+// still settle the invoice if it satisfies the invoice amount.
+func TestNotifyExitHopHtlcFinalizedFailWaitsForSibling(t *testing.T) {
+	t.Parallel()
+
+	hash, circuitKey, invoice := newPendingSettleTestInvoice()
+	secondKey := CircuitKey{
+		ChanID: lnwire.NewShortChanIDFromInt(1),
+		HtlcID: 3,
+	}
+	invoice.Htlcs[secondKey] = &InvoiceHTLC{
+		Amt:   2000,
+		State: HtlcStatePendingSettle,
+	}
+	invoice.AmtPaid += 2000
+	db := &finalTestDB{
+		hash:       hash,
+		invoice:    invoice,
+		updateTime: time.Now(),
+	}
+	registry := NewRegistry(db, nil, &RegistryConfig{})
+	registerPendingSettleTestInvoice(registry, hash, &invoice)
+
+	err := registry.NotifyExitHopHtlcFinalized(
+		t.Context(), circuitKey, false,
+	)
+	require.NoError(t, err)
+	require.Equal(t, ContractPendingSettle, db.invoice.State)
+	require.Equal(
+		t, HtlcStateCanceled, db.invoice.Htlcs[circuitKey].State,
+	)
+	require.Equal(
+		t, HtlcStatePendingSettle, db.invoice.Htlcs[secondKey].State,
+	)
+	assertNoInvoiceEvent(t, registry)
+
+	err = registry.NotifyExitHopHtlcFinalized(
+		t.Context(), secondKey, true,
+	)
+	require.NoError(t, err)
+	require.Equal(t, ContractSettled, db.invoice.State)
+	require.Equal(
+		t, HtlcStateSettled, db.invoice.Htlcs[secondKey].State,
+	)
+	require.Equal(t, lnwire.MilliSatoshi(2000), db.invoice.AmtPaid)
+}
+
+// TestScanInvoicesOnStartIndexesPendingSettle verifies startup scans rebuild
+// the pending-settle circuit index.
+func TestScanInvoicesOnStartIndexesPendingSettle(t *testing.T) {
+	t.Parallel()
+
+	hash, circuitKey, invoice := newPendingSettleTestInvoice()
+	db := &finalTestDB{
+		hash:       hash,
+		invoice:    invoice,
+		updateTime: time.Now(),
+	}
+	registry := NewRegistry(db, nil, &RegistryConfig{})
+
+	err := registry.scanInvoicesOnStart(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, 1, db.fetchPendingCalls)
+
+	registry.Lock()
+	_, ok := registry.pendingSettleRefs[circuitKey]
+	registry.Unlock()
+	require.True(t, ok)
+
+	err = registry.NotifyExitHopHtlcFinalized(
+		t.Context(), circuitKey, true,
+	)
+	require.NoError(t, err)
+	require.Equal(t, ContractSettled, db.invoice.State)
+}

--- a/invoices/invoiceregistry_final_test.go
+++ b/invoices/invoiceregistry_final_test.go
@@ -2,9 +2,11 @@ package invoices
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
+	"github.com/lightningnetwork/lnd/clock"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/record"
@@ -455,4 +457,100 @@ func TestScanInvoicesOnStartIndexesPendingSettle(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Equal(t, ContractSettled, db.invoice.State)
+}
+
+// TestHtlcFinalizationRetryDelay verifies retry delays back off exponentially
+// up to the configured maximum.
+func TestHtlcFinalizationRetryDelay(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(
+		t, time.Second, htlcFinalizationRetryDelay(0),
+	)
+	require.Equal(
+		t, 2*time.Second, htlcFinalizationRetryDelay(1),
+	)
+	require.Equal(
+		t, 4*time.Second, htlcFinalizationRetryDelay(2),
+	)
+	require.Equal(
+		t, DefaultHtlcFinalizationRetryMaxDelay,
+		htlcFinalizationRetryDelay(10),
+	)
+}
+
+// TestNotifyExitHopHtlcFinalizedErrorKeepsIndex verifies failed finalization
+// leaves the pending-settle index intact for retry.
+func TestNotifyExitHopHtlcFinalizedErrorKeepsIndex(t *testing.T) {
+	t.Parallel()
+
+	hash, circuitKey, invoice := newPendingSettleTestInvoice()
+	dbErr := errors.New("update failed")
+	db := &finalTestDB{
+		hash:       hash,
+		invoice:    invoice,
+		updateTime: time.Now(),
+		updateErr:  dbErr,
+	}
+	registry := NewRegistry(db, nil, &RegistryConfig{})
+	registerPendingSettleTestInvoice(registry, hash, &invoice)
+
+	err := registry.NotifyExitHopHtlcFinalized(
+		t.Context(), circuitKey, true,
+	)
+	require.ErrorIs(t, err, dbErr)
+
+	registry.Lock()
+	_, ok := registry.pendingSettleRefs[circuitKey]
+	registry.Unlock()
+	require.True(t, ok)
+}
+
+// TestNotifyExitHopHtlcFinalizedRetriesError verifies a transient finalization
+// failure is retried and clears both pending and retry indexes on success.
+func TestNotifyExitHopHtlcFinalizedRetriesError(t *testing.T) {
+	hash, circuitKey, invoice := newPendingSettleTestInvoice()
+	dbErr := errors.New("update failed")
+	db := &finalTestDB{
+		hash:         hash,
+		invoice:      invoice,
+		updateTime:   time.Now(),
+		updateErr:    dbErr,
+		updateSignal: make(chan struct{}, 1),
+	}
+	tickSignal := make(chan time.Duration, 1)
+	testClock := clock.NewTestClockWithTickSignal(
+		time.Unix(1, 0), tickSignal,
+	)
+	registry := NewRegistry(db, nil, &RegistryConfig{
+		Clock: testClock,
+	})
+	registerPendingSettleTestInvoice(registry, hash, &invoice)
+	startRegistryEventLoop(t, registry)
+
+	err := registry.NotifyExitHopHtlcFinalized(
+		t.Context(), circuitKey, true,
+	)
+	require.ErrorIs(t, err, dbErr)
+	require.Equal(t, DefaultHtlcFinalizationRetryDelay, <-tickSignal)
+
+	db.updateErr = nil
+	testClock.SetTime(
+		testClock.Now().Add(DefaultHtlcFinalizationRetryDelay),
+	)
+
+	select {
+	case <-db.updateSignal:
+	case <-time.After(time.Second):
+		t.Fatal("finalization retry not received")
+	}
+
+	require.Equal(t, ContractSettled, db.invoice.State)
+
+	registry.Lock()
+	_, pending := registry.pendingSettleRefs[circuitKey]
+	_, retrying := registry.htlcFinalizationRetries[circuitKey]
+	registry.Unlock()
+	require.False(t, pending)
+	require.False(t, retrying)
 }

--- a/invoices/invoiceregistry_final_test.go
+++ b/invoices/invoiceregistry_final_test.go
@@ -1,0 +1,276 @@
+package invoices
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/record"
+	"github.com/stretchr/testify/require"
+)
+
+// finalTestDB is a minimal InvoiceDB implementation for pending-settle
+// finalization tests.
+type finalTestDB struct {
+	hash              lntypes.Hash
+	invoice           Invoice
+	updateTime        time.Time
+	updateErr         error
+	updateRef         InvoiceRef
+	updateSetID       *SetID
+	updateSignal      chan struct{}
+	fetchPendingCalls int
+}
+
+// AddInvoice satisfies the InvoiceDB interface. These tests do not add
+// invoices through the test DB.
+func (f *finalTestDB) AddInvoice(context.Context, *Invoice,
+	lntypes.Hash) (uint64, error) {
+
+	return 0, nil
+}
+
+// InvoicesAddedSince satisfies the InvoiceDB interface. These tests do not
+// scan added invoice events.
+func (f *finalTestDB) InvoicesAddedSince(context.Context,
+	uint64) ([]Invoice, error) {
+
+	return nil, nil
+}
+
+// LookupInvoice returns the test invoice.
+func (f *finalTestDB) LookupInvoice(context.Context, InvoiceRef) (Invoice,
+	error) {
+
+	return f.invoice, nil
+}
+
+// FetchPendingInvoices returns the test invoice and records the scan count.
+func (f *finalTestDB) FetchPendingInvoices(context.Context) (
+	map[lntypes.Hash]Invoice, error) {
+
+	f.fetchPendingCalls++
+
+	return map[lntypes.Hash]Invoice{
+		f.hash: f.invoice,
+	}, nil
+}
+
+// QueryInvoices satisfies the InvoiceDB interface. These tests do not query
+// arbitrary invoice ranges.
+func (f *finalTestDB) QueryInvoices(context.Context,
+	InvoiceQuery) (InvoiceSlice, error) {
+
+	return InvoiceSlice{}, nil
+}
+
+// UpdateInvoice applies the callback to the in-memory test invoice.
+func (f *finalTestDB) UpdateInvoice(_ context.Context, ref InvoiceRef,
+	setID *SetID, callback InvoiceUpdateCallback) (*Invoice, error) {
+
+	if f.updateErr != nil {
+		return nil, f.updateErr
+	}
+	f.updateRef = ref
+	f.updateSetID = setID
+
+	updater := finalTestUpdater{}
+	invoice, err := UpdateInvoice(
+		&f.hash, &f.invoice, f.updateTime, callback, updater,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	f.invoice = *invoice
+	if f.updateSignal != nil {
+		select {
+		case f.updateSignal <- struct{}{}:
+		default:
+		}
+	}
+
+	return &f.invoice, nil
+}
+
+// InvoicesSettledSince satisfies the InvoiceDB interface. These tests do not
+// scan settled invoice events.
+func (f *finalTestDB) InvoicesSettledSince(context.Context,
+	uint64) ([]Invoice, error) {
+
+	return nil, nil
+}
+
+// DeleteInvoice satisfies the InvoiceDB interface. These tests do not delete
+// invoices.
+func (f *finalTestDB) DeleteInvoice(context.Context,
+	[]InvoiceDeleteRef) error {
+
+	return nil
+}
+
+// DeleteCanceledInvoices satisfies the InvoiceDB interface. These tests do not
+// garbage collect canceled invoices.
+func (f *finalTestDB) DeleteCanceledInvoices(context.Context) error {
+	return nil
+}
+
+// newPendingSettleTestInvoice creates a non-AMP invoice with one pending-settle
+// HTLC.
+func newPendingSettleTestInvoice() (lntypes.Hash, CircuitKey, Invoice) {
+	preimage := lntypes.Preimage{1, 2, 3}
+	hash := preimage.Hash()
+	circuitKey := CircuitKey{
+		ChanID: lnwire.NewShortChanIDFromInt(1),
+		HtlcID: 2,
+	}
+
+	invoice := Invoice{
+		Terms: ContractTerm{
+			PaymentPreimage: &preimage,
+			Features:        lnwire.EmptyFeatureVector(),
+			Value:           1000,
+		},
+		State:   ContractPendingSettle,
+		AmtPaid: 1000,
+		Htlcs: map[CircuitKey]*InvoiceHTLC{
+			circuitKey: {
+				Amt:   1000,
+				State: HtlcStatePendingSettle,
+			},
+		},
+	}
+
+	return hash, circuitKey, invoice
+}
+
+// newPendingSettleAMPTestInvoice creates an AMP invoice with one
+// pending-settle HTLC.
+func newPendingSettleAMPTestInvoice() (lntypes.Hash, [32]byte, SetID,
+	CircuitKey, Invoice) {
+
+	preimage := lntypes.Preimage{4, 5, 6}
+	hash := preimage.Hash()
+	payAddr := [32]byte{7, 8, 9}
+	setID := SetID{10, 11, 12}
+	ampRecord := record.NewAMP(
+		[32]byte{13, 14, 15}, [32]byte(setID), 3,
+	)
+	circuitKey := CircuitKey{
+		ChanID: lnwire.NewShortChanIDFromInt(1),
+		HtlcID: 2,
+	}
+	features := lnwire.NewFeatureVector(
+		lnwire.NewRawFeatureVector(lnwire.AMPRequired),
+		lnwire.Features,
+	)
+
+	invoice := Invoice{
+		Terms: ContractTerm{
+			PaymentAddr: payAddr,
+			Features:    features,
+		},
+		State:   ContractOpen,
+		AmtPaid: 1000,
+		AMPState: AMPInvoiceState{
+			setID: {
+				State: HtlcStatePendingSettle,
+				InvoiceKeys: map[CircuitKey]struct{}{
+					circuitKey: {},
+				},
+				AmtPaid: 1000,
+			},
+		},
+		Htlcs: map[CircuitKey]*InvoiceHTLC{
+			circuitKey: {
+				Amt:   1000,
+				State: HtlcStatePendingSettle,
+				AMP: &InvoiceHtlcAMPData{
+					Record:   *ampRecord,
+					Hash:     hash,
+					Preimage: &preimage,
+				},
+			},
+		},
+	}
+
+	return hash, payAddr, setID, circuitKey, invoice
+}
+
+// registerPendingSettleTestInvoice indexes a test invoice's pending-settle
+// HTLCs in the registry.
+func registerPendingSettleTestInvoice(registry *InvoiceRegistry,
+	hash lntypes.Hash, invoice *Invoice) {
+
+	registry.Lock()
+	registry.recordPendingSettleRefsLocked(
+		hash, InvoiceRefByHash(hash), invoice,
+	)
+	registry.Unlock()
+}
+
+// startRegistryEventLoop starts the registry event loop for retry tests.
+func startRegistryEventLoop(t *testing.T, registry *InvoiceRegistry) {
+	t.Helper()
+
+	registry.started.Store(true)
+	registry.wg.Add(1)
+	go registry.invoiceEventLoop()
+
+	t.Cleanup(func() {
+		close(registry.quit)
+		registry.wg.Wait()
+	})
+}
+
+func assertNoInvoiceEvent(t *testing.T, registry *InvoiceRegistry) {
+	t.Helper()
+
+	select {
+	case event := <-registry.invoiceEvents:
+		t.Fatalf("unexpected invoice event: %v", event)
+
+	default:
+	}
+}
+
+// TestShouldCancelPendingSettle asserts pending-settle invoices cannot be
+// canceled by external cancellation paths.
+func TestShouldCancelPendingSettle(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, shouldCancel(&Invoice{
+		State: ContractPendingSettle,
+	}, false))
+	require.False(t, shouldCancel(&Invoice{
+		State: ContractPendingSettle,
+	}, true))
+
+	_, _, _, _, ampInvoice := newPendingSettleAMPTestInvoice()
+	require.False(t, shouldCancel(&ampInvoice, true))
+}
+
+// TestInvoiceEventSuppressesAMPNonSettled verifies all-invoice subscribers do
+// not see AMP set updates before final settlement.
+func TestInvoiceEventSuppressesAMPNonSettled(t *testing.T) {
+	t.Parallel()
+
+	_, _, setID, _, invoice := newPendingSettleAMPTestInvoice()
+	event := &invoiceEvent{
+		invoice: &invoice,
+		setID:   (*[32]byte)(&setID),
+	}
+	require.True(t, event.suppressedForAllClients())
+
+	ampState := invoice.AMPState[setID]
+	ampState.State = HtlcStateCanceled
+	invoice.AMPState[setID] = ampState
+	require.True(t, event.suppressedForAllClients())
+
+	ampState.State = HtlcStateSettled
+	ampState.SettleIndex = 1
+	invoice.AMPState[setID] = ampState
+	require.False(t, event.suppressedForAllClients())
+}

--- a/invoices/invoiceregistry_test.go
+++ b/invoices/invoiceregistry_test.go
@@ -278,12 +278,30 @@ func testSettleInvoice(t *testing.T,
 	)
 	require.Equal(t, invpkg.ResultSettled, settleResolution.Outcome)
 
-	// We expect the settled state to be sent to the single invoice
+	// Try to settle again with a new higher-valued HTLC before the first
+	// HTLC finalizes. This payment should be accepted as a duplicate, just
+	// like duplicates to settled invoices.
+	duplicatePendingAmt := amtPaid + 600
+	resolution, err = ctx.registry.NotifyExitHopHtlc(
+		testInvoicePaymentHash, duplicatePendingAmt, testHtlcExpiry,
+		testCurrentHeight, getCircuitKey(1), hodlChan,
+		nil, testPayload,
+	)
+	require.NoError(t, err, "unexpected NotifyExitHopHtlc error")
+	require.NotNil(t, resolution)
+	settleResolution = checkSettleResolution(
+		t, resolution, testInvoicePreimage,
+	)
+	require.Equal(
+		t, invpkg.ResultDuplicateToSettled, settleResolution.Outcome,
+	)
+
+	// We expect the pending-settle state to be sent to the single invoice
 	// subscriber.
 	select {
 	case update := <-subscription.Updates:
-		if update.State != invpkg.ContractSettled {
-			t.Fatalf("expected state ContractOpen, but got %v",
+		if update.State != invpkg.ContractPendingSettle {
+			t.Fatalf("expected state PendingSettle, but got %v",
 				update.State)
 		}
 		if update.AmtPaid != amtPaid {
@@ -293,11 +311,31 @@ func testSettleInvoice(t *testing.T,
 		t.Fatal("no update received")
 	}
 
-	// We expect a settled notification to be sent out.
+	// The invoice is only reported as settled once the HTLC settle is
+	// final.
+	err = ctx.registry.NotifyExitHopHtlcFinalized(
+		ctxb, getCircuitKey(0), true,
+	)
+	require.NoError(t, err)
+
+	// We expect the settled state to be sent to the single invoice
+	// subscriber.
+	select {
+	case update := <-subscription.Updates:
+		if update.State != invpkg.ContractSettled {
+			t.Fatalf("expected state ContractSettled, but got %v",
+				update.State)
+		}
+	case <-time.After(testTimeout):
+		t.Fatal("no update received")
+	}
+
+	// We expect a settled notification to be sent out for all invoice
+	// subscribers.
 	select {
 	case settledInvoice := <-allSubscriptions.SettledInvoices:
 		if settledInvoice.State != invpkg.ContractSettled {
-			t.Fatalf("expected state ContractOpen, but got %v",
+			t.Fatalf("expected state ContractSettled, but got %v",
 				settledInvoice.State)
 		}
 	case <-time.After(testTimeout):
@@ -321,9 +359,10 @@ func testSettleInvoice(t *testing.T,
 	// Try to settle again with a new higher-valued htlc. This payment
 	// should also be accepted, to prevent any change in behaviour for a
 	// paid invoice that may open up a probe vector.
+	duplicateSettledAmt := amtPaid + 700
 	resolution, err = ctx.registry.NotifyExitHopHtlc(
-		testInvoicePaymentHash, amtPaid+600, testHtlcExpiry,
-		testCurrentHeight, getCircuitKey(1), hodlChan,
+		testInvoicePaymentHash, duplicateSettledAmt, testHtlcExpiry,
+		testCurrentHeight, getCircuitKey(2), hodlChan,
 		nil, testPayload,
 	)
 	require.NoError(t, err, "unexpected NotifyExitHopHtlc error")
@@ -339,7 +378,7 @@ func testSettleInvoice(t *testing.T,
 	// would have failed if it were the first payment.
 	resolution, err = ctx.registry.NotifyExitHopHtlc(
 		testInvoicePaymentHash, amtPaid-600, testHtlcExpiry,
-		testCurrentHeight, getCircuitKey(2), hodlChan,
+		testCurrentHeight, getCircuitKey(3), hodlChan,
 		nil, testPayload,
 	)
 	require.NoError(t, err, "unexpected NotifyExitHopHtlc error")
@@ -347,14 +386,15 @@ func testSettleInvoice(t *testing.T,
 	checkFailResolution(t, resolution, invpkg.ResultAmountTooLow)
 
 	// Check that settled amount is equal to the sum of values of the htlcs
-	// 0 and 1.
+	// 0, 1 and 2.
 	inv, err := ctx.registry.LookupInvoice(ctxb, testInvoicePaymentHash)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if inv.AmtPaid != amtPaid+amtPaid+600 {
+	expectedAmtPaid := amtPaid + duplicatePendingAmt + duplicateSettledAmt
+	if inv.AmtPaid != expectedAmtPaid {
 		t.Fatalf("amount incorrect: expected %v got %v",
-			amtPaid+amtPaid+600, inv.AmtPaid)
+			expectedAmtPaid, inv.AmtPaid)
 	}
 
 	// Try to cancel.
@@ -660,6 +700,21 @@ func testSettleHoldInvoice(t *testing.T,
 	require.Equal(t, testCurrentHeight, settleResolution.AcceptHeight)
 	require.Equal(t, invpkg.ResultSettled, settleResolution.Outcome)
 
+	// We expect a pending-settle notification for the single invoice
+	// subscriber. All invoice subscribers are only notified after finality.
+	update = <-subscription.Updates
+	if update.State != invpkg.ContractPendingSettle {
+		t.Fatalf("expected state ContractPendingSettle, but got %v",
+			update.State)
+	}
+
+	// Idempotency.
+	err = registry.SettleHodlInvoice(ctxb, testInvoicePreimage)
+	require.ErrorIs(t, err, invpkg.ErrInvoiceAlreadySettled)
+
+	err = registry.NotifyExitHopHtlcFinalized(ctxb, getCircuitKey(0), true)
+	require.NoError(t, err)
+
 	// We expect a settled notification to be sent out for both all and
 	// single invoice subscribers.
 	settledInvoice := <-allSubscriptions.SettledInvoices
@@ -677,10 +732,6 @@ func testSettleHoldInvoice(t *testing.T,
 		t.Fatalf("expected state ContractSettled, but got %v",
 			update.State)
 	}
-
-	// Idempotency.
-	err = registry.SettleHodlInvoice(ctxb, testInvoicePreimage)
-	require.ErrorIs(t, err, invpkg.ErrInvoiceAlreadySettled)
 
 	// Try to cancel.
 	err = registry.CancelInvoice(ctxb, testInvoicePaymentHash)
@@ -820,9 +871,10 @@ func testKeySendImpl(t *testing.T, keySendEnabled bool,
 	cfg := defaultRegistryConfig()
 	cfg.AcceptKeySend = keySendEnabled
 	ctx := newTestContext(t, &cfg, makeDB)
+	ctxb := t.Context()
 
 	allSubscriptions, err := ctx.registry.SubscribeNotifications(
-		t.Context(), 0, 0,
+		ctxb, 0, 0,
 	)
 	require.NoError(t, err)
 	defer allSubscriptions.Cancel()
@@ -880,10 +932,15 @@ func testKeySendImpl(t *testing.T, keySendEnabled bool,
 		return
 	}
 
-	checkSubscription := func() {
+	checkSubscription := func(circuitKey invpkg.CircuitKey) {
 		// We expect a new invoice notification to be sent out.
 		newInvoice := <-allSubscriptions.NewInvoices
 		require.Equal(t, newInvoice.State, invpkg.ContractOpen)
+
+		// The settled notification is only sent after HTLC finality.
+		require.NoError(t, ctx.registry.NotifyExitHopHtlcFinalized(
+			ctxb, circuitKey, true,
+		))
 
 		// We expect a settled notification to be sent out.
 		settledInvoice := <-allSubscriptions.SettledInvoices
@@ -891,7 +948,7 @@ func testKeySendImpl(t *testing.T, keySendEnabled bool,
 	}
 
 	checkSettleResolution(t, resolution, preimage)
-	checkSubscription()
+	checkSubscription(getCircuitKey(10))
 
 	// Replay the same keysend payment. We expect an identical resolution,
 	// but no event should be generated.
@@ -926,7 +983,7 @@ func testKeySendImpl(t *testing.T, keySendEnabled bool,
 	require.Nil(t, err)
 
 	checkSettleResolution(t, resolution, preimage2)
-	checkSubscription()
+	checkSubscription(getCircuitKey(20))
 }
 
 // testHoldKeysend tests receiving a spontaneous payment that is held.
@@ -1030,7 +1087,19 @@ func testHoldKeysendImpl(t *testing.T, timeoutKeysend bool,
 		ctxb, *newInvoice.Terms.PaymentPreimage,
 	))
 
-	// We expect a settled notification to be sent out.
+	htlcResolution, _ := (<-hodlChan).(invpkg.HtlcResolution)
+	require.NotNil(t, htlcResolution)
+	checkSettleResolution(t, htlcResolution, preimage)
+
+	inv, err := ctx.registry.LookupInvoice(ctxb, hash)
+	require.NoError(t, err)
+	require.Equal(t, invpkg.ContractPendingSettle, inv.State)
+
+	require.NoError(t, ctx.registry.NotifyExitHopHtlcFinalized(
+		ctxb, getCircuitKey(10), true,
+	))
+
+	// We expect a settled notification to be sent out after finality.
 	settledInvoice := <-allSubscriptions.SettledInvoices
 	require.Equal(t, settledInvoice.State, invpkg.ContractSettled)
 }
@@ -1120,6 +1189,10 @@ func testMppPayment(t *testing.T,
 			settleResolution.Outcome)
 	}
 
+	require.NoError(t, ctx.registry.NotifyExitHopHtlcFinalized(
+		ctxb, getCircuitKey(12), true,
+	))
+
 	// Check that settled amount is equal to the sum of values of the htlcs
 	// 2 and 3.
 	inv, err := ctx.registry.LookupInvoice(ctxb, testInvoicePaymentHash)
@@ -1194,6 +1267,10 @@ func testMppPaymentWithOverpayment(t *testing.T,
 			t.Fatalf("expected result settled, got: %v",
 				settleResolution.Outcome)
 		}
+
+		require.NoError(t, ctx.registry.NotifyExitHopHtlcFinalized(
+			ctxb, getCircuitKey(12), true,
+		))
 
 		// Check that settled amount is equal to the sum of values of
 		// the htlcs 1 and 2.
@@ -1518,7 +1595,7 @@ func testHeightExpiryWithRegistryImpl(t *testing.T, numParts int, settle bool,
 
 	// If we did not settle the invoice before its expiry, we now expect
 	// a cancellation.
-	expectedState := invpkg.ContractSettled
+	expectedState := invpkg.ContractPendingSettle
 	if !settle {
 		expectedState = invpkg.ContractCanceled
 
@@ -1815,12 +1892,12 @@ func testSettleInvoicePaymentAddrRequiredOptionalGrace(t *testing.T,
 	}
 	require.Equal(t, settleResolution.Outcome, invpkg.ResultSettled)
 
-	// We expect the settled state to be sent to the single invoice
+	// We expect the pending-settle state to be sent to the single invoice
 	// subscriber.
 	select {
 	case update := <-subscription.Updates:
-		if update.State != invpkg.ContractSettled {
-			t.Fatalf("expected state ContractOpen, but got %v",
+		if update.State != invpkg.ContractPendingSettle {
+			t.Fatalf("expected state PendingSettle, but got %v",
 				update.State)
 		}
 		if update.AmtPaid != invoice.Terms.Value {
@@ -1830,11 +1907,27 @@ func testSettleInvoicePaymentAddrRequiredOptionalGrace(t *testing.T,
 		t.Fatal("no update received")
 	}
 
+	require.NoError(t, ctx.registry.NotifyExitHopHtlcFinalized(
+		ctxb, getCircuitKey(10), true,
+	))
+
+	// We expect the settled state to be sent to the single invoice
+	// subscriber.
+	select {
+	case update := <-subscription.Updates:
+		if update.State != invpkg.ContractSettled {
+			t.Fatalf("expected state ContractSettled, but got %v",
+				update.State)
+		}
+	case <-time.After(testTimeout):
+		t.Fatal("no update received")
+	}
+
 	// We expect a settled notification to be sent out.
 	select {
 	case settledInvoice := <-allSubscriptions.SettledInvoices:
 		if settledInvoice.State != invpkg.ContractSettled {
-			t.Fatalf("expected state ContractOpen, but got %v",
+			t.Fatalf("expected state ContractSettled, but got %v",
 				settledInvoice.State)
 		}
 	case <-time.After(testTimeout):
@@ -2076,7 +2169,7 @@ func testSpontaneousAmpPaymentImpl(
 
 		// Assert the behavior of the Open and Settle notifications.
 		// There should always be an open (keysend is enabled) followed
-		// by settle for valid AMP payments.
+		// by settle for valid AMP payments after finality.
 		//
 		// NOTE: The cases are split in separate if conditions, rather
 		// than else-if, to properly handle the case when there is only
@@ -2088,6 +2181,12 @@ func testSpontaneousAmpPaymentImpl(
 			if failReconstruction {
 				checkNoSettleSubscription()
 			} else {
+				circuitKey := getCircuitKey(uint64(i))
+				require.NoError(t,
+					ctx.registry.NotifyExitHopHtlcFinalized(
+						ctxb, circuitKey, true,
+					),
+				)
 				checkSettleSubscription()
 			}
 		}

--- a/invoices/invoices.go
+++ b/invoices/invoices.go
@@ -721,6 +721,10 @@ const (
 	// CancelInvoiceUpdate indicates that this update is trying to cancel
 	// an invoice.
 	CancelInvoiceUpdate
+
+	// FinalizeHTLCsUpdate indicates that this update finalizes one or more
+	// HTLCs whose settlement was previously requested.
+	FinalizeHTLCsUpdate
 )
 
 // String returns a human readable string for the UpdateType.
@@ -737,6 +741,9 @@ func (u UpdateType) String() string {
 
 	case CancelInvoiceUpdate:
 		return "CancelInvoiceUpdate"
+
+	case FinalizeHTLCsUpdate:
+		return "FinalizeHTLCsUpdate"
 
 	default:
 		return fmt.Sprintf("unknown invoice update type: %d", u)

--- a/invoices/invoices.go
+++ b/invoices/invoices.go
@@ -231,6 +231,15 @@ const (
 	// ContractAccepted means the HTLC has been accepted but not settled
 	// yet.
 	ContractAccepted ContractState = 3
+
+	// ContractPendingSettle means settlement has been requested for the
+	// invoice, but the settling HTLC has not yet reached a final locked-in
+	// outcome.
+	//
+	// NOTE: This state is persisted. Do not downgrade to a binary that does
+	// not understand ContractPendingSettle while invoices may be in this
+	// state.
+	ContractPendingSettle ContractState = 4
 )
 
 // String returns a human readable identifier for the ContractState type.
@@ -247,6 +256,9 @@ func (c ContractState) String() string {
 
 	case ContractAccepted:
 		return "Accepted"
+
+	case ContractPendingSettle:
+		return "PendingSettle"
 	}
 
 	return "Unknown"
@@ -522,6 +534,10 @@ const (
 
 	// HtlcStateSettled indicates the htlc is settled.
 	HtlcStateSettled
+
+	// HtlcStatePendingSettle indicates that the htlc has a settle
+	// resolution, but the settlement is not yet locked in.
+	HtlcStatePendingSettle
 )
 
 // InvoiceHTLC contains details about an htlc paying to this invoice.
@@ -824,9 +840,11 @@ func (i *Invoice) requiresPreimage() bool {
 	return true
 }
 
-// IsPending returns true if the invoice is in ContractOpen state.
+// IsPending returns true if the invoice is in the open, accepted, or
+// pending-settle state.
 func (i *Invoice) IsPending() bool {
-	return i.State == ContractOpen || i.State == ContractAccepted
+	return i.State == ContractOpen || i.State == ContractAccepted ||
+		i.State == ContractPendingSettle
 }
 
 // copySlice allocates a new slice and copies the source into it.

--- a/invoices/invoices.go
+++ b/invoices/invoices.go
@@ -764,6 +764,9 @@ type InvoiceUpdateDesc struct {
 	// the invoice.
 	AddHtlcs map[CircuitKey]*HtlcAcceptDesc
 
+	// FinalizeHtlcs maps HTLCs to their terminal settle/cancel outcome.
+	FinalizeHtlcs map[CircuitKey]HtlcState
+
 	// SetID is an optional set ID for AMP invoices that allows operations
 	// to be more efficient by ensuring we don't need to read out the
 	// entire HTLC set each timee an HTLC is to be cancelled.

--- a/invoices/invoices.go
+++ b/invoices/invoices.go
@@ -646,7 +646,8 @@ type InvoiceHtlcAMPData struct {
 	// Hash. The preimage will be derived either from secret share
 	// reconstruction of the shares in the AMP payload.
 	//
-	// NOTE: Preimage will only be present once the HTLC is in
+	// NOTE: Preimage will only be present once settlement has been
+	// requested and the HTLC is in HtlcStatePendingSettle or
 	// HtlcStateSettled.
 	Preimage *lntypes.Preimage
 }

--- a/invoices/invoices_test.go
+++ b/invoices/invoices_test.go
@@ -281,14 +281,15 @@ func TestInvoices(t *testing.T) {
 	}
 }
 
-// TestInvoiceIsPending tests that pending invoices are those which are either
-// in ContractOpen or in ContractAccepted state.
+// TestInvoiceIsPending tests that pending invoices are those which are open,
+// accepted or pending settle.
 func TestInvoiceIsPending(t *testing.T) {
 	t.Parallel()
 
 	contractStates := []invpkg.ContractState{
 		invpkg.ContractOpen, invpkg.ContractSettled,
 		invpkg.ContractCanceled, invpkg.ContractAccepted,
+		invpkg.ContractPendingSettle,
 	}
 
 	for _, state := range contractStates {
@@ -296,11 +297,11 @@ func TestInvoiceIsPending(t *testing.T) {
 			State: state,
 		}
 
-		// We expect that an invoice is pending if it's either in
-		// ContractOpen or ContractAccepted state.
-		open := invpkg.ContractOpen
-		accepted := invpkg.ContractAccepted
-		pending := (state == open || state == accepted)
+		// We expect that an invoice is pending if it's in ContractOpen,
+		// ContractAccepted or ContractPendingSettle state.
+		pending := state == invpkg.ContractOpen ||
+			state == invpkg.ContractAccepted ||
+			state == invpkg.ContractPendingSettle
 
 		require.Equal(t, pending, invoice.IsPending())
 	}

--- a/invoices/invoices_test.go
+++ b/invoices/invoices_test.go
@@ -1292,10 +1292,10 @@ func testFetchPendingInvoices(t *testing.T,
 }
 
 // testFetchPendingInvoicesAccepted verifies that FetchPendingInvoices returns
-// invoices in both ContractOpen (state 0) and ContractAccepted (state 3)
-// states, and that ContractSettled (state 1) and ContractCanceled (state 2)
-// invoices are excluded. This specifically exercises the `state IN (0, 3)`
-// predicate in the underlying SQL query.
+// invoices in ContractOpen (state 0), ContractAccepted (state 3), and
+// ContractPendingSettle (state 4), and that ContractSettled (state 1) and
+// ContractCanceled (state 2) invoices are excluded. This specifically exercises
+// the pending-state predicate in the underlying SQL query.
 func testFetchPendingInvoicesAccepted(t *testing.T,
 	makeDB func(t *testing.T) invpkg.InvoiceDB) {
 
@@ -1347,6 +1347,41 @@ func testFetchPendingInvoicesAccepted(t *testing.T,
 	require.NoError(t, err)
 	require.Equal(t, invpkg.ContractAccepted, dbAccepted.State)
 
+	// Add a third invoice and transition it to ContractPendingSettle.
+	pendingSettleInvoice, err := randInvoice(amt)
+	require.NoError(t, err)
+	pendingSettleHash := pendingSettleInvoice.Terms.PaymentPreimage.Hash()
+	_, err = db.AddInvoice(ctxb, pendingSettleInvoice, pendingSettleHash)
+	require.NoError(t, err)
+
+	pendingSettleKey := models.CircuitKey{HtlcID: 3}
+	pendingSettleRef := invpkg.InvoiceRefByHash(pendingSettleHash)
+	dbPendingSettle, err := db.UpdateInvoice(
+		ctxb, pendingSettleRef, nil,
+		func(inv *invpkg.Invoice) (*invpkg.InvoiceUpdateDesc, error) {
+			addHtlcs := make(
+				map[models.CircuitKey]*invpkg.HtlcAcceptDesc,
+			)
+			addHtlcs[pendingSettleKey] = &invpkg.HtlcAcceptDesc{
+				Amt: amt,
+				CustomRecords: make(
+					record.CustomSet,
+				),
+			}
+
+			return &invpkg.InvoiceUpdateDesc{
+				UpdateType: invpkg.AddHTLCsUpdate,
+				State: &invpkg.InvoiceStateUpdateDesc{
+					NewState: invpkg.ContractPendingSettle,
+					Preimage: inv.Terms.PaymentPreimage,
+				},
+				AddHtlcs: addHtlcs,
+			}, nil
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, invpkg.ContractPendingSettle, dbPendingSettle.State)
+
 	// Add a settled invoice – it must NOT appear in the pending result.
 	settledInvoice, err := randInvoice(amt)
 	require.NoError(t, err)
@@ -1361,7 +1396,7 @@ func testFetchPendingInvoicesAccepted(t *testing.T,
 
 	// Add a canceled invoice – it must also NOT appear in the pending
 	// result, verifying that state 2 (ContractCanceled) is excluded by
-	// the `state IN (0, 3)` SQL predicate.
+	// the pending-state SQL predicate.
 	canceledInvoice, err := randInvoice(amt)
 	require.NoError(t, err)
 	canceledHash := canceledInvoice.Terms.PaymentPreimage.Hash()
@@ -1380,16 +1415,21 @@ func testFetchPendingInvoicesAccepted(t *testing.T,
 	)
 	require.NoError(t, err)
 
-	// FetchPendingInvoices must return exactly the two pending invoices.
+	// FetchPendingInvoices must return exactly the three pending invoices.
 	pending, err := db.FetchPendingInvoices(ctxb)
 	require.NoError(t, err)
-	require.Len(t, pending, 2)
+	require.Len(t, pending, 3)
 
 	_, hasOpen := pending[openHash]
 	require.True(t, hasOpen, "ContractOpen invoice missing from results")
 
 	_, hasAccepted := pending[acceptedHash]
 	require.True(t, hasAccepted, "ContractAccepted invoice missing")
+
+	_, hasPendingSettle := pending[pendingSettleHash]
+	require.True(
+		t, hasPendingSettle, "ContractPendingSettle invoice missing",
+	)
 
 	require.NotContains(t, pending, settledHash,
 		"ContractSettled invoice should not appear in pending results")
@@ -1398,6 +1438,10 @@ func testFetchPendingInvoicesAccepted(t *testing.T,
 
 	require.Equal(t, invpkg.ContractOpen, pending[openHash].State)
 	require.Equal(t, invpkg.ContractAccepted, pending[acceptedHash].State)
+	require.Equal(
+		t, invpkg.ContractPendingSettle,
+		pending[pendingSettleHash].State,
+	)
 }
 
 // testDuplicateSettleInvoice tests that if we add a new invoice and settle it

--- a/invoices/sql_store.go
+++ b/invoices/sql_store.go
@@ -67,9 +67,10 @@ type SQLInvoiceQueries interface { //nolint:interfacebloat
 	InsertInvoiceHTLCCustomRecord(ctx context.Context,
 		arg sqlc.InsertInvoiceHTLCCustomRecordParams) error
 
-	// FetchPendingInvoices returns all open/accepted invoices ordered by
-	// id ascending. It replaces the old catch-all FilterInvoices for the
-	// pending-only path and lets the planner use invoices_state_idx.
+	// FetchPendingInvoices returns all open/accepted/pending-settle
+	// invoices ordered by id ascending. It replaces the old catch-all
+	// FilterInvoices for the pending-only path and lets the planner use
+	// invoices_state_idx.
 	FetchPendingInvoices(ctx context.Context,
 		arg sqlc.FetchPendingInvoicesParams) ([]sqlc.Invoice, error)
 

--- a/invoices/update.go
+++ b/invoices/update.go
@@ -127,13 +127,19 @@ func resolveReplayedHtlc(ctx *invoiceUpdateCtx, inv *Invoice) (bool,
 	case HtlcStateAccepted:
 		return true, ctx.acceptRes(resultReplayToAccepted), nil
 
-	case HtlcStateSettled:
+	// Settled and pending-settle HTLCs both replay as settle resolutions.
+	// The settled case is idempotent, while pending-settle lets forwarding
+	// replay drive the settle response back to commitment lock-in.
+	case HtlcStateSettled, HtlcStatePendingSettle:
 		pre := inv.Terms.PaymentPreimage
 
 		// Terms.PaymentPreimage will be nil for AMP invoices.
 		// Set it to the HTLCs AMP Preimage instead.
-		if pre == nil {
+		if pre == nil && htlc.AMP != nil {
 			pre = htlc.AMP.Preimage
+		}
+		if pre == nil {
+			return true, nil, errors.New("unknown preimage")
 		}
 
 		return true, ctx.settleRes(
@@ -325,7 +331,7 @@ func updateMpp(ctx *invoiceUpdateCtx, inv *Invoice) (*InvoiceUpdateDesc,
 	}
 
 	update.State = &InvoiceStateUpdateDesc{
-		NewState:      ContractSettled,
+		NewState:      ContractPendingSettle,
 		Preimage:      inv.Terms.PaymentPreimage,
 		HTLCPreimages: htlcPreimages,
 		SetID:         setID,
@@ -492,6 +498,11 @@ func updateLegacy(ctx *invoiceUpdateCtx,
 		return &update, ctx.settleRes(
 			*inv.Terms.PaymentPreimage, ResultDuplicateToSettled,
 		), nil
+
+	case ContractPendingSettle:
+		return &update, ctx.settleRes(
+			*inv.Terms.PaymentPreimage, ResultDuplicateToSettled,
+		), nil
 	}
 
 	// Check to see if we can settle or this is an hold invoice and we need
@@ -505,7 +516,7 @@ func updateLegacy(ctx *invoiceUpdateCtx,
 	}
 
 	update.State = &InvoiceStateUpdateDesc{
-		NewState: ContractSettled,
+		NewState: ContractPendingSettle,
 		Preimage: inv.Terms.PaymentPreimage,
 	}
 

--- a/invoices/update_invoice.go
+++ b/invoices/update_invoice.go
@@ -136,6 +136,14 @@ func UpdateInvoice(hash *lntypes.Hash, invoice *Invoice,
 			return nil, err
 		}
 
+	case FinalizeHTLCsUpdate:
+		err := finalizeHTLCs(
+			invoice, hash, updateTime, update, updater,
+		)
+		if err != nil {
+			return nil, err
+		}
+
 	case CancelInvoiceUpdate:
 		err := cancelInvoice(
 			invoice, hash, updateTime, update.State, updater,
@@ -508,6 +516,139 @@ func settleHodlInvoice(invoice *Invoice, hash *lntypes.Hash,
 			amtPaid += htlc.Amt
 		}
 	}
+
+	return updateInvoiceAmtPaid(invoice, amtPaid, updater)
+}
+
+// finalizeHTLCs records final HTLC outcomes and only finalizes the invoice once
+// no non-AMP HTLC is still pending finality.
+func finalizeHTLCs(invoice *Invoice, hash *lntypes.Hash,
+	updateTime time.Time, update *InvoiceUpdateDesc,
+	updater InvoiceUpdater) error {
+
+	if update == nil {
+		return fmt.Errorf("unable to finalize invoice settlement: " +
+			"nil update")
+	}
+
+	if len(update.FinalizeHtlcs) == 0 {
+		return fmt.Errorf("unable to finalize invoice settlement: " +
+			"no htlcs provided")
+	}
+
+	for key, outcome := range update.FinalizeHtlcs {
+		htlc, ok := invoice.Htlcs[key]
+		if !ok || htlc.State != HtlcStatePendingSettle {
+			continue
+		}
+
+		setID := update.SetID
+		if htlc.AMP == nil {
+			setID = nil
+		}
+
+		switch outcome {
+		case HtlcStateSettled:
+			settled, htlcState, err := getUpdatedHtlcState(
+				htlc, ContractSettled, (*[32]byte)(setID),
+			)
+			if err != nil {
+				return err
+			}
+			if !settled || htlcState != HtlcStateSettled {
+				return fmt.Errorf(
+					"unable to finalize htlc %v as "+
+						"settled", key,
+				)
+			}
+
+			err = resolveHtlc(
+				key, htlc, HtlcStateSettled, updateTime,
+				updater,
+			)
+			if err != nil {
+				return err
+			}
+
+		case HtlcStateCanceled:
+			err := resolveHtlc(
+				key, htlc, HtlcStateCanceled, updateTime,
+				updater,
+			)
+			if err != nil {
+				return err
+			}
+
+		default:
+			return fmt.Errorf(
+				"unknown final htlc outcome: %v", outcome,
+			)
+		}
+	}
+
+	if invoice.IsAMP() {
+		return nil
+	}
+
+	return finalizeInvoiceIfComplete(invoice, hash, updateTime, updater)
+}
+
+// finalizeInvoiceIfComplete derives the terminal non-AMP invoice state once all
+// pending-settle HTLCs have reported a final outcome.
+func finalizeInvoiceIfComplete(invoice *Invoice, hash *lntypes.Hash,
+	updateTime time.Time, updater InvoiceUpdater) error {
+
+	var amtPaid lnwire.MilliSatoshi
+	for _, htlc := range invoice.Htlcs {
+		switch htlc.State {
+		case HtlcStatePendingSettle:
+			return nil
+
+		case HtlcStateSettled:
+			amtPaid += htlc.Amt
+		}
+	}
+
+	paid := amtPaid > 0 && (invoice.Terms.Value == 0 ||
+		amtPaid >= invoice.Terms.Value)
+	if paid {
+		return finalizeInvoiceState(
+			invoice, hash, updateTime, ContractSettled, amtPaid,
+			updater,
+		)
+	}
+
+	return finalizeInvoiceState(
+		invoice, hash, updateTime, ContractCanceled, amtPaid, updater,
+	)
+}
+
+// finalizeInvoiceState applies the final non-AMP invoice state and amount.
+func finalizeInvoiceState(invoice *Invoice, hash *lntypes.Hash,
+	updateTime time.Time, state ContractState, amtPaid lnwire.MilliSatoshi,
+	updater InvoiceUpdater) error {
+
+	update := InvoiceStateUpdateDesc{
+		NewState: state,
+	}
+	if state == ContractSettled {
+		update.Preimage = invoice.Terms.PaymentPreimage
+	}
+
+	newState, err := getUpdatedInvoiceState(invoice, hash, update)
+	if err != nil {
+		return err
+	}
+	if newState == nil || *newState != state {
+		return fmt.Errorf("unable to finalize invoice: new computed "+
+			"state is not %v: %s", state, newState)
+	}
+
+	err = updater.UpdateInvoiceState(state, update.Preimage)
+	if err != nil {
+		return err
+	}
+	invoice.State = state
 
 	return updateInvoiceAmtPaid(invoice, amtPaid, updater)
 }

--- a/invoices/update_invoice.go
+++ b/invoices/update_invoice.go
@@ -520,8 +520,8 @@ func settleHodlInvoice(invoice *Invoice, hash *lntypes.Hash,
 	return updateInvoiceAmtPaid(invoice, amtPaid, updater)
 }
 
-// finalizeHTLCs records final HTLC outcomes and only finalizes the invoice once
-// no non-AMP HTLC is still pending finality.
+// finalizeHTLCs records final HTLC outcomes and only finalizes the invoice or
+// AMP set once no HTLC in the set is still pending finality.
 func finalizeHTLCs(invoice *Invoice, hash *lntypes.Hash,
 	updateTime time.Time, update *InvoiceUpdateDesc,
 	updater InvoiceUpdater) error {
@@ -584,6 +584,15 @@ func finalizeHTLCs(invoice *Invoice, hash *lntypes.Hash,
 				"unknown final htlc outcome: %v", outcome,
 			)
 		}
+
+		if htlc.AMP != nil {
+			err := finalizeAmpSetIfComplete(
+				invoice, htlc.AMP.Record.SetID(), key, updater,
+			)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	if invoice.IsAMP() {
@@ -593,13 +602,60 @@ func finalizeHTLCs(invoice *Invoice, hash *lntypes.Hash,
 	return finalizeInvoiceIfComplete(invoice, hash, updateTime, updater)
 }
 
+// finalizeAmpSetIfComplete updates an AMP sub-invoice after one HTLC finalizes.
+func finalizeAmpSetIfComplete(invoice *Invoice, setID SetID,
+	circuitKey models.CircuitKey, updater InvoiceUpdater) error {
+
+	ampState := invoice.AMPState[setID]
+	set := invoiceHTLCSet(invoice, (*[32]byte)(&setID))
+	allSettled := len(set) > 0
+	for _, htlc := range set {
+		switch htlc.State {
+		case HtlcStatePendingSettle:
+			ampState.State = HtlcStatePendingSettle
+			invoice.AMPState[setID] = ampState
+
+			return updater.UpdateAmpState(
+				setID, ampState, circuitKey,
+			)
+
+		case HtlcStateSettled:
+
+		default:
+			allSettled = false
+		}
+	}
+
+	if allSettled {
+		ampState.State = HtlcStateSettled
+	} else {
+		failedAmt := ampState.AmtPaid
+		amtPaid := lnwire.MilliSatoshi(0)
+		if invoice.AmtPaid > failedAmt {
+			amtPaid = invoice.AmtPaid - failedAmt
+		}
+
+		ampState.State = HtlcStateCanceled
+		ampState.AmtPaid = 0
+
+		err := updateInvoiceAmtPaid(invoice, amtPaid, updater)
+		if err != nil {
+			return err
+		}
+	}
+
+	invoice.AMPState[setID] = ampState
+
+	return updater.UpdateAmpState(setID, ampState, circuitKey)
+}
+
 // finalizeInvoiceIfComplete derives the terminal non-AMP invoice state once all
 // pending-settle HTLCs have reported a final outcome.
 func finalizeInvoiceIfComplete(invoice *Invoice, hash *lntypes.Hash,
 	updateTime time.Time, updater InvoiceUpdater) error {
 
 	var amtPaid lnwire.MilliSatoshi
-	for _, htlc := range invoice.Htlcs {
+	for _, htlc := range invoiceHTLCSet(invoice, nil) {
 		switch htlc.State {
 		case HtlcStatePendingSettle:
 			return nil
@@ -651,6 +707,21 @@ func finalizeInvoiceState(invoice *Invoice, hash *lntypes.Hash,
 	invoice.State = state
 
 	return updateInvoiceAmtPaid(invoice, amtPaid, updater)
+}
+
+// invoiceHTLCSet returns all HTLCs that belong to a non-AMP or AMP set,
+// regardless of their current state.
+func invoiceHTLCSet(invoice *Invoice,
+	setID *[32]byte) map[models.CircuitKey]*InvoiceHTLC {
+
+	set := make(map[models.CircuitKey]*InvoiceHTLC)
+	for key, htlc := range invoice.Htlcs {
+		if htlc.IsInHTLCSet(setID) {
+			set[key] = htlc
+		}
+	}
+
+	return set
 }
 
 // cancelInvoice attempts to cancel the given invoice. That includes changing

--- a/invoices/update_invoice.go
+++ b/invoices/update_invoice.go
@@ -91,6 +91,25 @@ func settleHtlcsAmp(invoice *Invoice, circuitKey models.CircuitKey,
 	return updater.UpdateAmpState(setID, newAmpState, circuitKey)
 }
 
+// pendingSettleHtlcsAmp marks an AMP HTLC set as pending settle without
+// changing the set's accepted amount.
+func pendingSettleHtlcsAmp(invoice *Invoice, circuitKey models.CircuitKey,
+	htlc *InvoiceHTLC, updater InvoiceUpdater) error {
+
+	setID := htlc.AMP.Record.SetID()
+
+	newAmpState, err := getUpdatedInvoiceAmpState(
+		invoice, setID, circuitKey, HtlcStatePendingSettle, 0,
+	)
+	if err != nil {
+		return err
+	}
+
+	invoice.AMPState[setID] = newAmpState
+
+	return updater.UpdateAmpState(setID, newAmpState, circuitKey)
+}
+
 // UpdateInvoice fetches the invoice, obtains the update descriptor from the
 // callback and applies the updates in a single db transaction.
 func UpdateInvoice(hash *lntypes.Hash, invoice *Invoice,
@@ -368,6 +387,22 @@ func addHTLCs(invoice *Invoice, hash *lntypes.Hash, updateTime time.Time,
 		// meta data state.
 		if htlcSettled && invoiceIsAMP {
 			err = settleHtlcsAmp(invoice, key, htlc, updater)
+			if err != nil {
+				return err
+			}
+		}
+
+		// Pending-settle HTLCs passed settle validation, but are
+		// not final until the link or resolver reports the committed
+		// outcome.
+		htlcPendingSettle := htlcStateChanged &&
+			htlcState == HtlcStatePendingSettle
+
+		// AMP HTLCs also need their per-set state updated because
+		// settlement metadata is stored separately from the invoice
+		// HTLC map.
+		if htlcPendingSettle && invoiceIsAMP {
+			err = pendingSettleHtlcsAmp(invoice, key, htlc, updater)
 			if err != nil {
 				return err
 			}
@@ -963,6 +998,11 @@ func getUpdatedInvoiceAmpState(invoice *Invoice, setID SetID,
 	case HtlcStateCanceled:
 		ampState.State = HtlcStateCanceled
 		ampState.AmtPaid -= amt
+
+	// Pending-settle means the AMP set has released child preimages, but
+	// the final HTLC outcome is not known yet. Do not alter AmtPaid here.
+	case HtlcStatePendingSettle:
+		ampState.State = HtlcStatePendingSettle
 
 	case HtlcStateSettled:
 		ampState.State = HtlcStateSettled

--- a/invoices/update_invoice.go
+++ b/invoices/update_invoice.go
@@ -333,8 +333,8 @@ func addHTLCs(invoice *Invoice, hash *lntypes.Hash, updateTime time.Time,
 		// while the contract state (on disk) is still in the accept
 		// state.
 		htlcContextState := invoice.State
-		if settleEligibleAMP {
-			htlcContextState = ContractSettled
+		if settleEligibleAMP && update.State != nil {
+			htlcContextState = update.State.NewState
 		}
 		htlcStateChanged, htlcState, err := getUpdatedHtlcState(
 			htlc, htlcContextState, setID,
@@ -366,8 +366,9 @@ func addHTLCs(invoice *Invoice, hash *lntypes.Hash, updateTime time.Time,
 		}
 
 		accepted := htlc.State == HtlcStateAccepted
+		pendingSettle := htlc.State == HtlcStatePendingSettle
 		settled := htlc.State == HtlcStateSettled
-		invoiceStateReady := accepted || settled
+		invoiceStateReady := accepted || pendingSettle || settled
 
 		if !invoiceIsAMP {
 			// Update the running amount paid to this invoice. We
@@ -434,7 +435,7 @@ func updateInvoiceAmtPaid(invoice *Invoice, amt lnwire.MilliSatoshi,
 	return nil
 }
 
-// settleHodlInvoice marks a hodl invoice as settled.
+// settleHodlInvoice marks a hodl invoice as pending settle.
 //
 // NOTE: Currently it is not possible to have HODL AMP invoices.
 func settleHodlInvoice(invoice *Invoice, hash *lntypes.Hash,
@@ -446,13 +447,14 @@ func settleHodlInvoice(invoice *Invoice, hash *lntypes.Hash,
 			"not a hodl invoice", invoice.AddIndex)
 	}
 
-	// TODO(positiveblue): because NewState can only be ContractSettled we
-	// can remove it from the API and set it here directly.
+	// TODO(positiveblue): hodl settlement can only transition to
+	// ContractPendingSettle now, so remove NewState from the API and set it
+	// here directly.
 	switch {
 	case update == nil:
 		fallthrough
 
-	case update.NewState != ContractSettled:
+	case update.NewState != ContractPendingSettle:
 		return fmt.Errorf("unable to settle hodl invoice: "+
 			"not valid InvoiceUpdateDesc.State: %v", update)
 
@@ -468,26 +470,27 @@ func settleHodlInvoice(invoice *Invoice, hash *lntypes.Hash,
 		return err
 	}
 
-	if newState == nil || *newState != ContractSettled {
+	if newState == nil || *newState != ContractPendingSettle {
 		return fmt.Errorf("unable to settle hodl invoice: "+
-			"new computed state is not settled: %s", newState)
+			"new computed state is not pending settle: "+
+			"%s", newState)
 	}
 
 	err = updater.UpdateInvoiceState(
-		ContractSettled, update.Preimage,
+		ContractPendingSettle, update.Preimage,
 	)
 	if err != nil {
 		return err
 	}
 
-	invoice.State = ContractSettled
+	invoice.State = ContractPendingSettle
 	invoice.Terms.PaymentPreimage = update.Preimage
 
 	// TODO(positiveblue): this logic can be further simplified.
 	var amtPaid lnwire.MilliSatoshi
 	for key, htlc := range invoice.Htlcs {
 		settled, _, err := getUpdatedHtlcState(
-			htlc, ContractSettled, nil,
+			htlc, ContractPendingSettle, nil,
 		)
 		if err != nil {
 			return err
@@ -495,7 +498,7 @@ func settleHodlInvoice(invoice *Invoice, hash *lntypes.Hash,
 
 		if settled {
 			err = resolveHtlc(
-				key, htlc, HtlcStateSettled, updateTime,
+				key, htlc, HtlcStatePendingSettle, updateTime,
 				updater,
 			)
 			if err != nil {
@@ -603,6 +606,29 @@ func getUpdatedInvoiceState(invoice *Invoice, hash *lntypes.Hash,
 	}
 
 	switch invoice.State {
+	// Once settlement is pending, only the final HTLC outcome may move the
+	// invoice to settled or canceled.
+	case ContractPendingSettle:
+		if update.NewState == ContractPendingSettle {
+			return nil, ErrInvoiceCannotAccept
+		}
+
+		if update.NewState == ContractCanceled {
+			return &update.NewState, nil
+		}
+
+		if update.NewState == ContractSettled {
+			if update.SetID == nil &&
+				invoice.Terms.PaymentPreimage == nil {
+
+				return nil, errors.New("unknown preimage")
+			}
+
+			return &update.NewState, nil
+		}
+
+		return nil, errors.New("unknown state transition")
+
 	// Once a contract is accepted, we can only transition to settled or
 	// canceled. Forbid transitioning back into this state. Otherwise this
 	// state is identical to ContractOpen, so we fallthrough to apply the
@@ -614,9 +640,10 @@ func getUpdatedInvoiceState(invoice *Invoice, hash *lntypes.Hash,
 
 		fallthrough
 
-	// If a contract is open, permit a state transition to accepted, settled
-	// or canceled. The only restriction is on transitioning to settled
-	// where we ensure the preimage is valid.
+		// If a contract is open, permit a state transition to accepted,
+		// pending-settle, settled or canceled. The only restriction is
+		// on transitioning to a settle state where we ensure the
+		// preimage is valid.
 	case ContractOpen:
 		if update.NewState == ContractCanceled {
 			return &update.NewState, nil
@@ -625,6 +652,11 @@ func getUpdatedInvoiceState(invoice *Invoice, hash *lntypes.Hash,
 		// Sanity check that the user isn't trying to settle or accept a
 		// non-existent HTLC set.
 		set := invoice.HTLCSet(update.SetID, HtlcStateAccepted)
+		if len(set) == 0 && update.NewState == ContractSettled {
+			set = invoice.HTLCSet(
+				update.SetID, HtlcStatePendingSettle,
+			)
+		}
 		if len(set) == 0 {
 			return nil, ErrEmptyHTLCSet
 		}
@@ -660,7 +692,8 @@ func getUpdatedInvoiceState(invoice *Invoice, hash *lntypes.Hash,
 
 		// Fail if we still don't have a preimage when transitioning to
 		// settle the non-AMP invoice.
-		case update.NewState == ContractSettled &&
+		case (update.NewState == ContractSettled ||
+			update.NewState == ContractPendingSettle) &&
 			invoice.Terms.PaymentPreimage == nil:
 
 			return nil, errors.New("unknown preimage")
@@ -740,7 +773,9 @@ func canCancelSingleHtlc(htlc *InvoiceHTLC,
 	}
 
 	// It is only possible if the htlc is still pending.
-	if htlc.State != HtlcStateAccepted {
+	if htlc.State != HtlcStateAccepted &&
+		htlc.State != HtlcStatePendingSettle {
+
 		return fmt.Errorf("htlc canceled in state %v", htlc.State)
 	}
 
@@ -754,8 +789,10 @@ func getUpdatedHtlcState(htlc *InvoiceHTLC,
 	invoiceState ContractState, setID *[32]byte) (
 	bool, HtlcState, error) {
 
-	trySettle := func(persist bool) (bool, HtlcState, error) {
-		if htlc.State != HtlcStateAccepted {
+	trySettle := func(newState HtlcState) (bool, HtlcState, error) {
+		if htlc.State != HtlcStateAccepted &&
+			htlc.State != HtlcStatePendingSettle {
+
 			return false, htlc.State, nil
 		}
 
@@ -794,27 +831,21 @@ func getUpdatedHtlcState(htlc *InvoiceHTLC,
 			settled = true
 		}
 
-		// Only persist the changes if the invoice is moving to the
-		// settled state, and we're actually updating the state to
-		// settled.
-		newState := htlc.State
-		if settled {
-			newState = HtlcStateSettled
+		if !settled || htlc.State == newState {
+			return false, htlc.State, nil
 		}
 
-		return persist && settled, newState, nil
+		return true, newState, nil
 	}
 
 	if invoiceState == ContractSettled {
 		// Check that we can settle the HTLCs. For legacy and MPP HTLCs
 		// this will be a NOP, but for AMP HTLCs this asserts that we
-		// have a valid hash/preimage pair. Passing true permits the
-		// method to update the HTLC to HtlcStateSettled.
-		return trySettle(true)
+		// have a valid hash/preimage pair.
+		return trySettle(HtlcStateSettled)
 	}
 
-	// We should never find a settled HTLC on an invoice that isn't in
-	// ContractSettled.
+	// We should never find a settled HTLC on an invoice that isn't final.
 	if htlc.State == HtlcStateSettled {
 		return false, htlc.State, ErrHTLCAlreadySettled
 	}
@@ -824,14 +855,22 @@ func getUpdatedHtlcState(htlc *InvoiceHTLC,
 		htlcAlreadyCanceled := htlc.State == HtlcStateCanceled
 		return !htlcAlreadyCanceled, HtlcStateCanceled, nil
 
-	// TODO(roasbeef): never fully passed thru now?
+	// Pending-settle validates settle eligibility but keeps HTLCs in a
+	// non-final state until the link or resolver reports the outcome.
+	case ContractPendingSettle:
+		return trySettle(HtlcStatePendingSettle)
+
 	case ContractAccepted:
-		// Check that we can settle the HTLCs. For legacy and MPP HTLCs
-		// this will be a NOP, but for AMP HTLCs this asserts that we
-		// have a valid hash/preimage pair. Passing false prevents the
-		// method from putting the HTLC in HtlcStateSettled, leaving it
-		// in HtlcStateAccepted.
-		return trySettle(false)
+		if htlc.State == HtlcStatePendingSettle {
+			return false, htlc.State, nil
+		}
+
+		// Check that we can settle the HTLCs. For legacy and MPP
+		// HTLCs this will be a NOP, but for AMP HTLCs this asserts
+		// that we have a valid hash/preimage pair. The method is
+		// called with the current state, leaving the HTLC in
+		// HtlcStateAccepted.
+		return trySettle(HtlcStateAccepted)
 
 	case ContractOpen:
 		return false, htlc.State, nil

--- a/invoices/update_invoice_test.go
+++ b/invoices/update_invoice_test.go
@@ -138,6 +138,96 @@ func TestUpdateHTLC(t *testing.T) {
 			expErr: nil,
 		},
 		{
+			name: "MPP pending settle",
+			input: InvoiceHTLC{
+				Amt:               5000,
+				MppTotalAmt:       5000,
+				AcceptHeight:      100,
+				AcceptTime:        testNow,
+				ResolveTime:       time.Time{},
+				Expiry:            40,
+				State:             HtlcStateAccepted,
+				CustomRecords:     make(record.CustomSet),
+				WireCustomRecords: make(lnwire.CustomRecords),
+				AMP:               nil,
+			},
+			invState: ContractPendingSettle,
+			setID:    nil,
+			output: InvoiceHTLC{
+				Amt:               5000,
+				MppTotalAmt:       5000,
+				AcceptHeight:      100,
+				AcceptTime:        testNow,
+				ResolveTime:       testNow,
+				Expiry:            40,
+				State:             HtlcStatePendingSettle,
+				CustomRecords:     make(record.CustomSet),
+				WireCustomRecords: make(lnwire.CustomRecords),
+				AMP:               nil,
+			},
+			expErr: nil,
+		},
+		{
+			name: "MPP finalize pending settle",
+			input: InvoiceHTLC{
+				Amt:               5000,
+				MppTotalAmt:       5000,
+				AcceptHeight:      100,
+				AcceptTime:        testNow,
+				ResolveTime:       testAlreadyNow,
+				Expiry:            40,
+				State:             HtlcStatePendingSettle,
+				CustomRecords:     make(record.CustomSet),
+				WireCustomRecords: make(lnwire.CustomRecords),
+				AMP:               nil,
+			},
+			invState: ContractSettled,
+			setID:    nil,
+			output: InvoiceHTLC{
+				Amt:               5000,
+				MppTotalAmt:       5000,
+				AcceptHeight:      100,
+				AcceptTime:        testNow,
+				ResolveTime:       testNow,
+				Expiry:            40,
+				State:             HtlcStateSettled,
+				CustomRecords:     make(record.CustomSet),
+				WireCustomRecords: make(lnwire.CustomRecords),
+				AMP:               nil,
+			},
+			expErr: nil,
+		},
+		{
+			name: "MPP cancel pending settle",
+			input: InvoiceHTLC{
+				Amt:               5000,
+				MppTotalAmt:       5000,
+				AcceptHeight:      100,
+				AcceptTime:        testNow,
+				ResolveTime:       testAlreadyNow,
+				Expiry:            40,
+				State:             HtlcStatePendingSettle,
+				CustomRecords:     make(record.CustomSet),
+				WireCustomRecords: make(lnwire.CustomRecords),
+				AMP:               nil,
+			},
+			invState: ContractCanceled,
+			setID:    nil,
+			output: InvoiceHTLC{
+				Amt:               5000,
+				MppTotalAmt:       5000,
+				AcceptHeight:      100,
+				AcceptTime:        testNow,
+				ResolveTime:       testNow,
+				Expiry:            40,
+				State:             HtlcStateCanceled,
+				CustomRecords:     make(record.CustomSet),
+				WireCustomRecords: make(lnwire.CustomRecords),
+				AMP:               nil,
+			},
+			expErr: nil,
+		},
+		{
 			name: "MPP cancel",
 			input: InvoiceHTLC{
 				Amt:               5000,
@@ -826,6 +916,9 @@ func TestUpdateHTLC(t *testing.T) {
 	}
 }
 
+// TestUpdateInvoiceAMPPendingSettleState verifies AMP settle requests move the
+// AMP set to pending-settle without changing the amount already counted at
+// acceptance.
 func TestUpdateInvoiceAMPPendingSettleState(t *testing.T) {
 	t.Parallel()
 
@@ -869,6 +962,9 @@ func TestUpdateInvoiceAMPPendingSettleState(t *testing.T) {
 	}
 	updater := &ampStateTestUpdater{}
 	updateTime := time.Now()
+	htlcPreimages := map[CircuitKey]lntypes.Preimage{
+		circuitKey: preimage,
+	}
 
 	updatedInvoice, err := UpdateInvoice(
 		&hash, invoice, updateTime, func(*Invoice) (*InvoiceUpdateDesc,
@@ -877,11 +973,9 @@ func TestUpdateInvoiceAMPPendingSettleState(t *testing.T) {
 			return &InvoiceUpdateDesc{
 				UpdateType: AddHTLCsUpdate,
 				State: &InvoiceStateUpdateDesc{
-					NewState: ContractPendingSettle,
-					HTLCPreimages: map[CircuitKey]lntypes.Preimage{
-						circuitKey: preimage,
-					},
-					SetID: (*[32]byte)(&setID),
+					NewState:      ContractPendingSettle,
+					HTLCPreimages: htlcPreimages,
+					SetID:         (*[32]byte)(&setID),
 				},
 			}, nil
 		}, updater,
@@ -898,6 +992,60 @@ func TestUpdateInvoiceAMPPendingSettleState(t *testing.T) {
 	require.Equal(t, lnwire.MilliSatoshi(1000), updatedInvoice.AmtPaid)
 	require.Equal(t, lnwire.MilliSatoshi(1000), updater.ampState.AmtPaid)
 	require.Equal(t, HtlcStatePendingSettle, updater.ampState.State)
+}
+
+// TestUpdateLegacyPendingSettleDuplicate verifies legacy/keysend duplicate
+// HTLCs can still receive the known preimage while an invoice is
+// pending-settle.
+func TestUpdateLegacyPendingSettleDuplicate(t *testing.T) {
+	t.Parallel()
+
+	preimage := lntypes.Preimage{1, 2, 3}
+	hash := preimage.Hash()
+	existingKey := CircuitKey{
+		ChanID: lnwire.NewShortChanIDFromInt(1),
+		HtlcID: 2,
+	}
+	duplicateKey := CircuitKey{
+		ChanID: lnwire.NewShortChanIDFromInt(1),
+		HtlcID: 3,
+	}
+	invoice := &Invoice{
+		Terms: ContractTerm{
+			PaymentPreimage: &preimage,
+			Features:        lnwire.EmptyFeatureVector(),
+			Value:           1000,
+			FinalCltvDelta:  4,
+		},
+		State: ContractPendingSettle,
+		Htlcs: map[CircuitKey]*InvoiceHTLC{
+			existingKey: {
+				Amt:   1000,
+				State: HtlcStatePendingSettle,
+			},
+		},
+	}
+	ctx := &invoiceUpdateCtx{
+		hash:                 hash,
+		circuitKey:           duplicateKey,
+		amtPaid:              1500,
+		expiry:               100,
+		currentHeight:        10,
+		finalCltvRejectDelta: 5,
+		customRecords:        record.CustomSet{},
+		wireCustomRecords:    lnwire.CustomRecords{},
+	}
+
+	update, resolution, err := updateInvoice(ctx, invoice)
+	require.NoError(t, err)
+	require.NotNil(t, update)
+	require.Nil(t, update.State)
+	require.Contains(t, update.AddHtlcs, duplicateKey)
+
+	settleResolution, ok := resolution.(*HtlcSettleResolution)
+	require.True(t, ok)
+	require.Equal(t, ResultDuplicateToSettled, settleResolution.Outcome)
+	require.Equal(t, preimage, settleResolution.Preimage)
 }
 
 // finalTestUpdater is a no-op InvoiceUpdater for tests that exercise in-memory
@@ -960,6 +1108,8 @@ type ampStateTestUpdater struct {
 	ampState InvoiceStateAMP
 }
 
+// UpdateAmpState records the AMP state that UpdateInvoice writes through the
+// updater.
 func (u *ampStateTestUpdater) UpdateAmpState(_ [32]byte,
 	newState InvoiceStateAMP, _ CircuitKey) error {
 

--- a/invoices/update_invoice_test.go
+++ b/invoices/update_invoice_test.go
@@ -434,6 +434,82 @@ func TestUpdateHTLC(t *testing.T) {
 			expErr: nil,
 		},
 		{
+			name: "AMP pending settle valid preimage",
+			input: InvoiceHTLC{
+				Amt:               5000,
+				MppTotalAmt:       5000,
+				AcceptHeight:      100,
+				AcceptTime:        testNow,
+				ResolveTime:       time.Time{},
+				Expiry:            40,
+				State:             HtlcStateAccepted,
+				CustomRecords:     make(record.CustomSet),
+				WireCustomRecords: make(lnwire.CustomRecords),
+				AMP: &InvoiceHtlcAMPData{
+					Record:   *ampRecord,
+					Hash:     hash,
+					Preimage: &preimage,
+				},
+			},
+			invState: ContractPendingSettle,
+			setID:    &setID,
+			output: InvoiceHTLC{
+				Amt:               5000,
+				MppTotalAmt:       5000,
+				AcceptHeight:      100,
+				AcceptTime:        testNow,
+				ResolveTime:       testNow,
+				Expiry:            40,
+				State:             HtlcStatePendingSettle,
+				CustomRecords:     make(record.CustomSet),
+				WireCustomRecords: make(lnwire.CustomRecords),
+				AMP: &InvoiceHtlcAMPData{
+					Record:   *ampRecord,
+					Hash:     hash,
+					Preimage: &preimage,
+				},
+			},
+			expErr: nil,
+		},
+		{
+			name: "AMP finalize pending settle",
+			input: InvoiceHTLC{
+				Amt:               5000,
+				MppTotalAmt:       5000,
+				AcceptHeight:      100,
+				AcceptTime:        testNow,
+				ResolveTime:       testAlreadyNow,
+				Expiry:            40,
+				State:             HtlcStatePendingSettle,
+				CustomRecords:     make(record.CustomSet),
+				WireCustomRecords: make(lnwire.CustomRecords),
+				AMP: &InvoiceHtlcAMPData{
+					Record:   *ampRecord,
+					Hash:     hash,
+					Preimage: &preimage,
+				},
+			},
+			invState: ContractSettled,
+			setID:    &setID,
+			output: InvoiceHTLC{
+				Amt:               5000,
+				MppTotalAmt:       5000,
+				AcceptHeight:      100,
+				AcceptTime:        testNow,
+				ResolveTime:       testNow,
+				Expiry:            40,
+				State:             HtlcStateSettled,
+				CustomRecords:     make(record.CustomSet),
+				WireCustomRecords: make(lnwire.CustomRecords),
+				AMP: &InvoiceHtlcAMPData{
+					Record:   *ampRecord,
+					Hash:     hash,
+					Preimage: &preimage,
+				},
+			},
+			expErr: nil,
+		},
+		{
 			// With the newer AMP logic, this is now valid, as we
 			// want to be able to accept multiple settle attempts
 			// to a given pay_addr. In this case, the HTLC should
@@ -748,6 +824,147 @@ func TestUpdateHTLC(t *testing.T) {
 			testUpdateHTLC(t, test, testNow)
 		})
 	}
+}
+
+func TestUpdateInvoiceAMPPendingSettleState(t *testing.T) {
+	t.Parallel()
+
+	setID := SetID{1, 2, 3}
+	preimage := lntypes.Preimage{4, 5, 6}
+	hash := preimage.Hash()
+	ampRecord := record.NewAMP([32]byte{7, 8, 9}, [32]byte(setID), 4)
+	circuitKey := CircuitKey{
+		ChanID: lnwire.NewShortChanIDFromInt(1),
+		HtlcID: 2,
+	}
+
+	invoice := &Invoice{
+		Terms: ContractTerm{
+			Features: lnwire.NewFeatureVector(
+				lnwire.NewRawFeatureVector(lnwire.AMPRequired),
+				lnwire.Features,
+			),
+		},
+		State:   ContractOpen,
+		AmtPaid: 1000,
+		AMPState: AMPInvoiceState{
+			setID: {
+				State: HtlcStateAccepted,
+				InvoiceKeys: map[CircuitKey]struct{}{
+					circuitKey: {},
+				},
+				AmtPaid: 1000,
+			},
+		},
+		Htlcs: map[CircuitKey]*InvoiceHTLC{
+			circuitKey: {
+				Amt:   1000,
+				State: HtlcStateAccepted,
+				AMP: &InvoiceHtlcAMPData{
+					Record: *ampRecord,
+					Hash:   hash,
+				},
+			},
+		},
+	}
+	updater := &ampStateTestUpdater{}
+	updateTime := time.Now()
+
+	updatedInvoice, err := UpdateInvoice(
+		&hash, invoice, updateTime, func(*Invoice) (*InvoiceUpdateDesc,
+			error) {
+
+			return &InvoiceUpdateDesc{
+				UpdateType: AddHTLCsUpdate,
+				State: &InvoiceStateUpdateDesc{
+					NewState: ContractPendingSettle,
+					HTLCPreimages: map[CircuitKey]lntypes.Preimage{
+						circuitKey: preimage,
+					},
+					SetID: (*[32]byte)(&setID),
+				},
+			}, nil
+		}, updater,
+	)
+	require.NoError(t, err)
+
+	require.Equal(
+		t, HtlcStatePendingSettle,
+		updatedInvoice.Htlcs[circuitKey].State,
+	)
+	require.Equal(
+		t, HtlcStatePendingSettle, updatedInvoice.AMPState[setID].State,
+	)
+	require.Equal(t, lnwire.MilliSatoshi(1000), updatedInvoice.AmtPaid)
+	require.Equal(t, lnwire.MilliSatoshi(1000), updater.ampState.AmtPaid)
+	require.Equal(t, HtlcStatePendingSettle, updater.ampState.State)
+}
+
+// finalTestUpdater is a no-op InvoiceUpdater for tests that exercise in-memory
+// invoice transitions.
+type finalTestUpdater struct{}
+
+// AddHtlc satisfies InvoiceUpdater. The in-memory invoice is updated directly.
+func (f finalTestUpdater) AddHtlc(CircuitKey, *InvoiceHTLC) error {
+	return nil
+}
+
+// ResolveHtlc satisfies InvoiceUpdater. The in-memory invoice is updated
+// directly.
+func (f finalTestUpdater) ResolveHtlc(CircuitKey, HtlcState,
+	time.Time) error {
+
+	return nil
+}
+
+// AddAmpHtlcPreimage satisfies InvoiceUpdater. The in-memory invoice is
+// updated directly.
+func (f finalTestUpdater) AddAmpHtlcPreimage([32]byte, CircuitKey,
+	lntypes.Preimage) error {
+
+	return nil
+}
+
+// UpdateInvoiceState satisfies InvoiceUpdater. The in-memory invoice is updated
+// directly.
+func (f finalTestUpdater) UpdateInvoiceState(ContractState,
+	*lntypes.Preimage) error {
+
+	return nil
+}
+
+// UpdateInvoiceAmtPaid satisfies InvoiceUpdater. The in-memory invoice is
+// updated directly.
+func (f finalTestUpdater) UpdateInvoiceAmtPaid(lnwire.MilliSatoshi) error {
+	return nil
+}
+
+// UpdateAmpState satisfies InvoiceUpdater. The in-memory invoice is updated
+// directly.
+func (f finalTestUpdater) UpdateAmpState([32]byte, InvoiceStateAMP,
+	CircuitKey) error {
+
+	return nil
+}
+
+// Finalize satisfies InvoiceUpdater. No flush is needed for the in-memory test
+// updater.
+func (f finalTestUpdater) Finalize(UpdateType) error {
+	return nil
+}
+
+// ampStateTestUpdater records the latest AMP state update for assertions.
+type ampStateTestUpdater struct {
+	finalTestUpdater
+
+	ampState InvoiceStateAMP
+}
+
+func (u *ampStateTestUpdater) UpdateAmpState(_ [32]byte,
+	newState InvoiceStateAMP, _ CircuitKey) error {
+
+	u.ampState = newState
+	return nil
 }
 
 func testUpdateHTLC(t *testing.T, test updateHTLCTest, now time.Time) {

--- a/itest/lnd_mpp_test.go
+++ b/itest/lnd_mpp_test.go
@@ -89,7 +89,8 @@ func testSendMultiPathPayment(ht *lntest.HarnessTest) {
 	require.GreaterOrEqual(ht, succeeded, minExpectedShards,
 		"expected shards not reached")
 
-	// Make sure Bob show the invoice as settled for the full amount.
+	// Make sure Bob shows the invoice as settled for the full amount.
+	ht.AssertInvoiceSettled(mts.bob, invoices[0].PaymentAddr)
 	inv := mts.bob.RPC.LookupInvoice(rHash)
 
 	require.EqualValues(ht, paymentAmt, inv.AmtPaidSat,

--- a/itest/lnd_route_blinding_test.go
+++ b/itest/lnd_route_blinding_test.go
@@ -1000,7 +1000,8 @@ func testMPPToSingleBlindedPath(ht *lntest.HarnessTest) {
 	require.GreaterOrEqual(ht, succeeded, minExpectedShards,
 		"expected shards not reached")
 
-	// Make sure Dave show the invoice as settled for the full amount.
+	// Make sure Dave shows the invoice as settled for the full amount.
+	ht.AssertInvoiceSettled(dave, invoiceResp.PaymentAddr)
 	inv := dave.RPC.LookupInvoice(invoiceResp.RHash)
 
 	require.EqualValues(ht, paymentAmt, inv.AmtPaidSat,
@@ -1134,9 +1135,8 @@ func testBlindedRouteDummyHops(ht *lntest.HarnessTest) {
 		alice, []string{invoiceResp.PaymentRequest},
 	)
 
-	// Make sure Dave show the invoice as settled.
-	inv := dave.RPC.LookupInvoice(invoiceResp.RHash)
-	require.Equal(ht, lnrpc.Invoice_SETTLED, inv.State)
+	// Make sure Dave shows the invoice as settled.
+	ht.AssertInvoiceSettled(dave, invoiceResp.PaymentAddr)
 
 	// Let's also test the case where Dave is not the introduction node.
 	// We restart Carol so that she supports route blinding.
@@ -1176,9 +1176,8 @@ func testBlindedRouteDummyHops(ht *lntest.HarnessTest) {
 		alice, []string{invoiceResp.PaymentRequest},
 	)
 
-	// Make sure Dave show the invoice as settled.
-	inv = dave.RPC.LookupInvoice(invoiceResp.RHash)
-	require.Equal(ht, lnrpc.Invoice_SETTLED, inv.State)
+	// Make sure Dave shows the invoice as settled.
+	ht.AssertInvoiceSettled(dave, invoiceResp.PaymentAddr)
 }
 
 // testMPPToMultipleBlindedPaths tests that a two-shard MPP payment can be sent
@@ -1316,7 +1315,8 @@ func testMPPToMultipleBlindedPaths(ht *lntest.HarnessTest) {
 	require.GreaterOrEqual(ht, succeeded, minExpectedShards,
 		"expected shards not reached")
 
-	// Make sure Dave show the invoice as settled for the full amount.
+	// Make sure Dave shows the invoice as settled for the full amount.
+	ht.AssertInvoiceSettled(dave, invoiceResp.PaymentAddr)
 	inv := dave.RPC.LookupInvoice(invoiceResp.RHash)
 
 	require.EqualValues(ht, paymentAmt, inv.AmtPaidSat,

--- a/itest/lnd_routing_test.go
+++ b/itest/lnd_routing_test.go
@@ -776,7 +776,8 @@ func testScidAliasRoutingHints(ht *lntest.HarnessTest) {
 	}
 
 	// Add the invoice and retrieve the payment request.
-	payReq := dave.RPC.AddInvoice(invoice).PaymentRequest
+	invoiceResp := dave.RPC.AddInvoice(invoice)
+	payReq := invoiceResp.PaymentRequest
 
 	// Now Alice will try to pay to that payment request.
 	timeout := time.Second * 15
@@ -790,9 +791,10 @@ func testScidAliasRoutingHints(ht *lntest.HarnessTest) {
 	ht.AssertPaymentSucceedWithTimeout(stream, timeout)
 
 	// Check that Dave's invoice appears as settled.
+	ht.AssertInvoiceSettled(dave, invoiceResp.PaymentAddr)
 	invoices := dave.RPC.ListInvoices(&lnrpc.ListInvoiceRequest{})
 	require.Len(ht, invoices.Invoices, 1, "expected one invoice")
-	require.Equal(ht, invoices.Invoices[0].State, lnrpc.Invoice_SETTLED,
+	require.Equal(ht, lnrpc.Invoice_SETTLED, invoices.Invoices[0].State,
 		"expected settled invoice")
 
 	// We'll now delete the alias again, but only on Carol's end. That

--- a/itest/lnd_single_hop_invoice_test.go
+++ b/itest/lnd_single_hop_invoice_test.go
@@ -48,9 +48,7 @@ func testSingleHopInvoice(ht *lntest.HarnessTest) {
 	ht.CompletePaymentRequests(alice, []string{invoiceResp.PaymentRequest})
 
 	// Bob's invoice should now be found and marked as settled.
-	dbInvoice := bob.RPC.LookupInvoice(invoiceResp.RHash)
-	require.Equal(ht, lnrpc.Invoice_SETTLED, dbInvoice.State,
-		"bob's invoice should be marked as settled")
+	ht.AssertInvoiceSettled(bob, invoiceResp.PaymentAddr)
 
 	// With the payment completed all balance related stats should be
 	// properly updated.

--- a/itest/lnd_sweep_test.go
+++ b/itest/lnd_sweep_test.go
@@ -1909,9 +1909,11 @@ func testFeeReplacement(ht *lntest.HarnessTest) {
 	// Suspend Bob so he won't get the preimage from Carol.
 	restartBob := ht.SuspendNode(bob)
 
-	// Carol settles the first invoice.
+	// Carol requests settlement for the first invoice. Bob is offline, so
+	// the settle response cannot lock in yet and the invoice remains
+	// accepted/pending-settle.
 	carol.RPC.SettleInvoice(preimages[0])
-	ht.AssertInvoiceState(streams[0], lnrpc.Invoice_SETTLED)
+	ht.AssertInvoiceState(streams[0], lnrpc.Invoice_ACCEPTED)
 
 	// Carol goes offline so the preimage won't be sent to Bob.
 	restartCarol := ht.SuspendNode(carol)

--- a/lnrpc/invoicesrpc/utils.go
+++ b/lnrpc/invoicesrpc/utils.go
@@ -91,7 +91,7 @@ func CreateRPCInvoice(invoice *invoices.Invoice,
 	case invoices.ContractCanceled:
 		state = lnrpc.Invoice_CANCELED
 
-	case invoices.ContractAccepted:
+	case invoices.ContractAccepted, invoices.ContractPendingSettle:
 		state = lnrpc.Invoice_ACCEPTED
 
 	default:
@@ -103,7 +103,9 @@ func CreateRPCInvoice(invoice *invoices.Invoice,
 	for key, htlc := range invoice.Htlcs {
 		var state lnrpc.InvoiceHTLCState
 		switch htlc.State {
-		case invoices.HtlcStateAccepted:
+		case invoices.HtlcStateAccepted,
+			invoices.HtlcStatePendingSettle:
+
 			state = lnrpc.InvoiceHTLCState_ACCEPTED
 		case invoices.HtlcStateSettled:
 			state = lnrpc.InvoiceHTLCState_SETTLED
@@ -155,7 +157,9 @@ func CreateRPCInvoice(invoice *invoices.Invoice,
 		}
 
 		// Only report resolved times if htlc is resolved.
-		if htlc.State != invoices.HtlcStateAccepted {
+		if htlc.State != invoices.HtlcStateAccepted &&
+			htlc.State != invoices.HtlcStatePendingSettle {
+
 			rpcHtlc.ResolveTime = htlc.ResolveTime.Unix()
 		}
 
@@ -204,7 +208,9 @@ func CreateRPCInvoice(invoice *invoices.Invoice,
 
 		var state lnrpc.InvoiceHTLCState
 		switch ampState.State {
-		case invoices.HtlcStateAccepted:
+		case invoices.HtlcStateAccepted,
+			invoices.HtlcStatePendingSettle:
+
 			state = lnrpc.InvoiceHTLCState_ACCEPTED
 		case invoices.HtlcStateSettled:
 			state = lnrpc.InvoiceHTLCState_SETTLED

--- a/sqldb/sqlc/invoices.sql.go
+++ b/sqldb/sqlc/invoices.sql.go
@@ -68,7 +68,7 @@ const fetchPendingInvoices = `-- name: FetchPendingInvoices :many
 SELECT
     invoices.id, invoices.hash, invoices.preimage, invoices.settle_index, invoices.settled_at, invoices.memo, invoices.amount_msat, invoices.cltv_delta, invoices.expiry, invoices.payment_addr, invoices.payment_request, invoices.payment_request_hash, invoices.state, invoices.amount_paid_msat, invoices.is_amp, invoices.is_hodl, invoices.is_keysend, invoices.created_at
 FROM invoices
-WHERE state IN (0, 3) -- 0 = ContractOpen, 3 = ContractAccepted
+WHERE state IN (0, 3, 4) -- 0 = ContractOpen, 3 = ContractAccepted, 4 = ContractPendingSettle
   AND id > $1
 ORDER BY id ASC
 LIMIT $2
@@ -79,11 +79,12 @@ type FetchPendingInvoicesParams struct {
 	NumLimit int32
 }
 
-// FetchPendingInvoices returns all invoices in a pending state (open or
-// accepted). The invoices_state_idx index on the state column makes this a
-// fast index scan rather than a full table scan. id_cursor is an exclusive
-// lower bound on the primary key used for cursor-based pagination; the caller
-// must supply 0 when starting from the beginning.
+// FetchPendingInvoices returns all invoices in a pending state (open,
+// accepted or pending settle). The invoices_state_idx index on the state
+// column makes this a fast index scan rather than a full table scan.
+// id_cursor is an exclusive lower bound on the primary key used for
+// cursor-based pagination; the caller must supply 0 when starting from the
+// beginning.
 func (q *Queries) FetchPendingInvoices(ctx context.Context, arg FetchPendingInvoicesParams) ([]Invoice, error) {
 	rows, err := q.db.QueryContext(ctx, fetchPendingInvoices, arg.IDCursor, arg.NumLimit)
 	if err != nil {
@@ -256,7 +257,7 @@ SELECT
     invoices.id, invoices.hash, invoices.preimage, invoices.settle_index, invoices.settled_at, invoices.memo, invoices.amount_msat, invoices.cltv_delta, invoices.expiry, invoices.payment_addr, invoices.payment_request, invoices.payment_request_hash, invoices.state, invoices.amount_paid_msat, invoices.is_amp, invoices.is_hodl, invoices.is_keysend, invoices.created_at
 FROM invoices
 WHERE id >= $1
-  AND (NOT $2 OR state IN (0, 3)) -- 0 = ContractOpen, 3 = ContractAccepted
+  AND (NOT $2 OR state IN (0, 3, 4)) -- 0 = ContractOpen, 3 = ContractAccepted, 4 = ContractPendingSettle
   AND created_at >= $3
   AND created_at < $4
 ORDER BY id ASC
@@ -334,7 +335,7 @@ SELECT
     invoices.id, invoices.hash, invoices.preimage, invoices.settle_index, invoices.settled_at, invoices.memo, invoices.amount_msat, invoices.cltv_delta, invoices.expiry, invoices.payment_addr, invoices.payment_request, invoices.payment_request_hash, invoices.state, invoices.amount_paid_msat, invoices.is_amp, invoices.is_hodl, invoices.is_keysend, invoices.created_at
 FROM invoices
 WHERE id <= $1
-  AND (NOT $2 OR state IN (0, 3)) -- 0 = ContractOpen, 3 = ContractAccepted
+  AND (NOT $2 OR state IN (0, 3, 4)) -- 0 = ContractOpen, 3 = ContractAccepted, 4 = ContractPendingSettle
   AND created_at >= $3
   AND created_at < $4
 ORDER BY id DESC

--- a/sqldb/sqlc/querier.go
+++ b/sqldb/sqlc/querier.go
@@ -63,11 +63,12 @@ type Querier interface {
 	// Migration-specific batch fetch that returns payment data along with HTLC
 	// attempt counts for structural validation during KV to SQL migration.
 	FetchPaymentsByIDsMig(ctx context.Context, paymentIds []int64) ([]FetchPaymentsByIDsMigRow, error)
-	// FetchPendingInvoices returns all invoices in a pending state (open or
-	// accepted). The invoices_state_idx index on the state column makes this a
-	// fast index scan rather than a full table scan. id_cursor is an exclusive
-	// lower bound on the primary key used for cursor-based pagination; the caller
-	// must supply 0 when starting from the beginning.
+	// FetchPendingInvoices returns all invoices in a pending state (open,
+	// accepted or pending settle). The invoices_state_idx index on the state
+	// column makes this a fast index scan rather than a full table scan.
+	// id_cursor is an exclusive lower bound on the primary key used for
+	// cursor-based pagination; the caller must supply 0 when starting from the
+	// beginning.
 	FetchPendingInvoices(ctx context.Context, arg FetchPendingInvoicesParams) ([]Invoice, error)
 	FetchRouteLevelFirstHopCustomRecords(ctx context.Context, htlcAttemptIndices []int64) ([]PaymentAttemptFirstHopCustomRecord, error)
 	FetchSettledAMPSubInvoices(ctx context.Context, arg FetchSettledAMPSubInvoicesParams) ([]FetchSettledAMPSubInvoicesRow, error)

--- a/sqldb/sqlc/queries/invoices.sql
+++ b/sqldb/sqlc/queries/invoices.sql
@@ -48,15 +48,16 @@ INNER JOIN amp_sub_invoices a
 ON i.id = a.invoice_id AND a.set_id = $1;
 
 -- name: FetchPendingInvoices :many
--- FetchPendingInvoices returns all invoices in a pending state (open or
--- accepted). The invoices_state_idx index on the state column makes this a
--- fast index scan rather than a full table scan. id_cursor is an exclusive
--- lower bound on the primary key used for cursor-based pagination; the caller
--- must supply 0 when starting from the beginning.
+-- FetchPendingInvoices returns all invoices in a pending state (open,
+-- accepted or pending settle). The invoices_state_idx index on the state
+-- column makes this a fast index scan rather than a full table scan.
+-- id_cursor is an exclusive lower bound on the primary key used for
+-- cursor-based pagination; the caller must supply 0 when starting from the
+-- beginning.
 SELECT
     invoices.*
 FROM invoices
-WHERE state IN (0, 3) -- 0 = ContractOpen, 3 = ContractAccepted
+WHERE state IN (0, 3, 4) -- 0 = ContractOpen, 3 = ContractAccepted, 4 = ContractPendingSettle
   AND id > @id_cursor
 ORDER BY id ASC
 LIMIT @num_limit;
@@ -103,7 +104,7 @@ SELECT
     invoices.*
 FROM invoices
 WHERE id >= @add_index_get
-  AND (NOT @pending_only OR state IN (0, 3)) -- 0 = ContractOpen, 3 = ContractAccepted
+  AND (NOT @pending_only OR state IN (0, 3, 4)) -- 0 = ContractOpen, 3 = ContractAccepted, 4 = ContractPendingSettle
   AND created_at >= @created_after
   AND created_at < @created_before
 ORDER BY id ASC
@@ -119,7 +120,7 @@ SELECT
     invoices.*
 FROM invoices
 WHERE id <= @add_index_let
-  AND (NOT @pending_only OR state IN (0, 3)) -- 0 = ContractOpen, 3 = ContractAccepted
+  AND (NOT @pending_only OR state IN (0, 3, 4)) -- 0 = ContractOpen, 3 = ContractAccepted, 4 = ContractPendingSettle
   AND created_at >= @created_after
   AND created_at < @created_before
 ORDER BY id DESC


### PR DESCRIPTION
## Summary

Fixes lightningnetwork/lnd#7463 by splitting invoice settlement into two phases:

- add internal pending-settle invoice and HTLC states for HTLCs whose preimage has been released but whose final outcome is not locked in yet
- only report invoices as settled after htlcswitch or contractcourt confirms the exit-hop HTLC reached a final outcome
- keep RPC and subscriber behavior from exposing SETTLED before finality
- rebuild the pending-settle circuit index from pending invoices on startup
- retry transient invoice-finalization failures while the process is live
- cover AMP, hodl, KV/SQL pending invoice queries, off-chain finality, on-chain finality, and incoming dust finality paths

## Testing

- `make fmt`
- cached-image `custom-gcl run -v`: `0 issues`
- focused `GOWORK=off go test` coverage for `./invoices`, `./contractcourt`, and `./htlcswitch`
- compile-only `GOWORK=off go test` checks for `./channeldb`, `./contractcourt`, `./htlcswitch`, `./lnrpc/invoicesrpc`, and root
- `scripts/check-release-notes.sh`
- `git diff --check upstream/pr-10869...HEAD`

Note: full `make lint` was blocked locally by Docker Hub timeouts while rebuilding `lnd-tools`; the cached repo linter image completed source lint successfully.