### PR TITLE
Recover DLP remote-close HTLCs

### DIFF
--- a/contractcourt/chain_watcher.go
+++ b/contractcourt/chain_watcher.go
@@ -2,6 +2,7 @@ package contractcourt
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"slices"
 	"sync"
@@ -25,6 +26,7 @@ import (
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnutils"
 	"github.com/lightningnetwork/lnd/lnwallet"
+	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 	"github.com/lightningnetwork/lnd/lnwallet/types"
 	"github.com/lightningnetwork/lnd/lnwire"
 )
@@ -1227,39 +1229,93 @@ func (c *chainWatcher) handleUnknownRemoteState(
 		"state #%v!!! Attempting recovery...",
 		broadcastStateNum, chainSet.remoteStateNum)
 
-	// If this isn't a tweakless commitment, then we'll need to wait for
-	// the remote party's latest unrevoked commitment point to be presented
-	// to us as we need this to sweep. Otherwise, we can dispatch the
-	// remote close and sweep immediately using a fake commitPoint as it
-	// isn't actually needed for recovery anymore.
+	// If the DLP commit point is already available, use it for exact HTLC
+	// output matching. Static-remote-key commitments can still recover the
+	// to-local output without it, so do not block startup waiting for the
+	// point in that case.
 	commitPoint := c.cfg.chanState.RemoteCurrentRevocation
+	matchDlpHtlcs := false
 	tweaklessCommit := c.cfg.chanState.ChanType.IsTweakless()
-	if !tweaklessCommit {
+	dlpPoint, err := c.cfg.chanState.DataLossCommitPoint()
+	switch {
+	case err == nil:
+		commitPoint = dlpPoint
+		matchDlpHtlcs = true
+
+		log.Infof("Recovered commit point(%x) for channel(%v)! Now "+
+			"attempting to use it to sweep our funds...",
+			commitPoint.SerializeCompressed(),
+			c.cfg.chanState.FundingOutpoint)
+
+	case !tweaklessCommit:
 		commitPoint = c.waitForCommitmentPoint()
 		if commitPoint == nil {
 			return false, fmt.Errorf("unable to get commit point")
 		}
 
-		log.Infof("Recovered commit point(%x) for "+
-			"channel(%v)! Now attempting to use it to "+
-			"sweep our funds...",
+		matchDlpHtlcs = true
+
+		log.Infof("Recovered commit point(%x) for channel(%v)! Now "+
+			"attempting to use it to sweep our funds...",
 			commitPoint.SerializeCompressed(),
 			c.cfg.chanState.FundingOutpoint)
-	} else {
-		log.Infof("ChannelPoint(%v) is tweakless, "+
-			"moving to sweep directly on chain",
-			c.cfg.chanState.FundingOutpoint)
+
+	default:
+		log.Infof("ChannelPoint(%v) is tweakless, moving to sweep "+
+			"directly on chain without HTLC recovery: %v",
+			c.cfg.chanState.FundingOutpoint, err)
 	}
 
-	// Since we don't have the commitment stored for this state, we'll just
-	// pass an empty commitment within the commitment set. Note that this
-	// means we won't be able to recover any HTLC funds.
-	//
-	// TODO(halseth): can we try to recover some HTLCs?
-	chainSet.commitSet.ConfCommitKey = fn.Some(RemoteHtlcSet)
-	err := c.dispatchRemoteForceClose(
-		commitSpend, channeldb.ChannelCommitment{},
-		chainSet.commitSet, commitPoint,
+	// Since we don't have the commitment stored for this state, we'll pass
+	// a synthetic commitment containing only HTLCs that exactly match the
+	// confirmed remote close transaction.
+	remoteCommit := channeldb.ChannelCommitment{}
+	commitSet := CommitSet{
+		ConfCommitKey: fn.Some(RemoteHtlcSet),
+		HtlcSets: map[HtlcSetKey][]channeldb.HTLC{
+			RemoteHtlcSet: nil,
+		},
+	}
+
+	if matchDlpHtlcs {
+		matchedHtlcs, err := lnwallet.MatchDlpRemoteCommitHtlcs(
+			c.cfg.chanState, commitSpend.SpendingTx, commitPoint,
+		)
+		switch {
+		case errors.Is(err, lnwallet.ErrDlpTaprootUnsupported):
+			log.Infof("ChannelPoint(%v): taproot DLP HTLC "+
+				"recovery unsupported",
+				c.cfg.chanState.FundingOutpoint)
+
+		case err != nil:
+			log.Warnf("ChannelPoint(%v): unable to match DLP "+
+				"HTLCs: %v", c.cfg.chanState.FundingOutpoint,
+				err)
+
+		case len(matchedHtlcs) == 0:
+			log.Infof("ChannelPoint(%v): no DLP HTLC outputs "+
+				"matched", c.cfg.chanState.FundingOutpoint)
+
+		default:
+			recoveredHtlcs := append(
+				[]channeldb.HTLC(nil), matchedHtlcs...,
+			)
+			remoteCommit = channeldb.ChannelCommitment{
+				FeePerKw: btcutil.Amount(
+					chainfee.FeePerKwFloor,
+				),
+				Htlcs: recoveredHtlcs,
+			}
+			commitSet.HtlcSets[RemoteHtlcSet] = recoveredHtlcs
+
+			log.Infof("ChannelPoint(%v): matched %v DLP HTLC "+
+				"outputs", c.cfg.chanState.FundingOutpoint,
+				len(recoveredHtlcs))
+		}
+	}
+
+	err = c.dispatchRemoteForceClose(
+		commitSpend, remoteCommit, commitSet, commitPoint,
 	)
 	if err != nil {
 		return false, fmt.Errorf("unable to handle remote "+

--- a/contractcourt/chain_watcher_test.go
+++ b/contractcourt/chain_watcher_test.go
@@ -509,6 +509,187 @@ func TestChainWatcherDataLossProtect(t *testing.T) {
 	}
 }
 
+// TestChainWatcherDataLossProtectTweaklessNoPoint tests that tweakless DLP
+// recovery does not block if the peer has not delivered a commit point yet.
+func TestChainWatcherDataLossProtectTweaklessNoPoint(t *testing.T) {
+	t.Parallel()
+
+	aliceChannel, bobChannel, err := lnwallet.CreateTestChannels(
+		t, channeldb.SingleFunderTweaklessBit,
+	)
+	require.NoError(t, err, "unable to create test channels")
+
+	const htlcAmt = 1000
+	states, err := executeStateTransitions(
+		t, htlcAmt, aliceChannel, bobChannel, 2,
+	)
+	require.NoError(t, err, "unable to trigger state transition")
+	aliceChanState := states[1]
+
+	confRegistered := make(chan struct{}, 1)
+	aliceNotifier := &lnmock.ChainNotifier{
+		SpendChan:      make(chan *chainntnfs.SpendDetail, 1),
+		EpochChan:      make(chan *chainntnfs.BlockEpoch),
+		ConfChan:       make(chan *chainntnfs.TxConfirmation, 1),
+		ConfRegistered: confRegistered,
+	}
+	aliceChainWatcher, err := newChainWatcher(chainWatcherConfig{
+		chanState: aliceChanState,
+		notifier:  aliceNotifier,
+		signer:    aliceChannel.Signer,
+		extractStateNumHint: func(*wire.MsgTx,
+			[lnwallet.StateHintSize]byte) uint64 {
+
+			return 2
+		},
+		chanCloseConfs: fn.Some(uint32(1)),
+	})
+	require.NoError(t, err, "unable to create chain watcher")
+	require.NoError(t, aliceChainWatcher.Start())
+	defer func() {
+		require.NoError(t, aliceChainWatcher.Stop())
+	}()
+
+	chanEvents := aliceChainWatcher.SubscribeChannelEvents()
+	bobCommit := bobChannel.State().LocalCommitment.CommitTx
+	bobTxHash := bobCommit.TxHash()
+	bobSpend := &chainntnfs.SpendDetail{
+		SpenderTxHash: &bobTxHash,
+		SpendingTx:    bobCommit,
+	}
+
+	mockBeat := &chainio.MockBlockbeat{}
+	mockBeat.On("logger").Return(log)
+	mockBeat.On("Height").Return(int32(1)).Maybe()
+	mockBeat.On("NotifyBlockProcessed", nil, aliceChainWatcher.quit).
+		Return().Once()
+
+	select {
+	case aliceNotifier.SpendChan <- bobSpend:
+	case <-time.After(time.Second):
+		t.Fatalf("failed to send spend notification")
+	}
+
+	select {
+	case aliceChainWatcher.BlockbeatChan <- mockBeat:
+	case <-time.After(time.Second):
+		t.Fatalf("unable to send blockbeat")
+	}
+
+	select {
+	case uniClose := <-chanEvents.RemoteUnilateralClosure:
+		require.NotNil(t, uniClose.CommitResolution)
+		require.Empty(t, uniClose.RemoteCommit.Htlcs)
+
+	case <-time.After(time.Second * 5):
+		t.Fatalf("didn't receive unilateral close event")
+	}
+}
+
+// TestChainWatcherDataLossProtectHtlcRecovery tests that the DLP remote close
+// path recovers exact outgoing HTLC matches from the confirmed commitment.
+func TestChainWatcherDataLossProtectHtlcRecovery(t *testing.T) {
+	t.Parallel()
+
+	aliceChannel, bobChannel, err := lnwallet.CreateTestChannels(
+		t, channeldb.SingleFunderBit,
+	)
+	require.NoError(t, err, "unable to create test channels")
+
+	htlcAmount := lnwire.NewMSatFromSatoshis(20_000)
+	addFakeHTLC(t, htlcAmount, 0, aliceChannel, bobChannel)
+	require.NoError(
+		t, lnwallet.ForceStateTransition(aliceChannel, bobChannel),
+	)
+
+	aliceChanState, err := copyChannelState(t, aliceChannel.State())
+	require.NoError(t, err)
+	require.Len(t, aliceChanState.RemoteCommitment.Htlcs, 1)
+
+	addFakeHTLC(t, htlcAmount, 1, aliceChannel, bobChannel)
+	require.NoError(
+		t, lnwallet.ForceStateTransition(aliceChannel, bobChannel),
+	)
+
+	dlpPoint := aliceChannel.State().RemoteCurrentRevocation
+	require.NoError(t, aliceChanState.MarkDataLoss(dlpPoint))
+
+	confRegistered := make(chan struct{}, 1)
+	aliceNotifier := &lnmock.ChainNotifier{
+		SpendChan:      make(chan *chainntnfs.SpendDetail, 1),
+		EpochChan:      make(chan *chainntnfs.BlockEpoch),
+		ConfChan:       make(chan *chainntnfs.TxConfirmation, 1),
+		ConfRegistered: confRegistered,
+	}
+	aliceChainWatcher, err := newChainWatcher(chainWatcherConfig{
+		chanState:           aliceChanState,
+		notifier:            aliceNotifier,
+		signer:              aliceChannel.Signer,
+		extractStateNumHint: lnwallet.GetStateNumHint,
+		chanCloseConfs:      fn.Some(uint32(1)),
+	})
+	require.NoError(t, err, "unable to create chain watcher")
+	require.NoError(t, aliceChainWatcher.Start())
+	defer func() {
+		require.NoError(t, aliceChainWatcher.Stop())
+	}()
+
+	chanEvents := aliceChainWatcher.SubscribeChannelEvents()
+	bobCommit := bobChannel.State().LocalCommitment.CommitTx
+	bobTxHash := bobCommit.TxHash()
+	bobSpend := &chainntnfs.SpendDetail{
+		SpenderTxHash: &bobTxHash,
+		SpendingTx:    bobCommit,
+	}
+
+	mockBeat := &chainio.MockBlockbeat{}
+	mockBeat.On("logger").Return(log)
+	mockBeat.On("Height").Return(int32(1)).Maybe()
+	mockBeat.On("NotifyBlockProcessed", nil, aliceChainWatcher.quit).
+		Return().Once()
+
+	select {
+	case aliceNotifier.SpendChan <- bobSpend:
+	case <-time.After(time.Second):
+		t.Fatalf("failed to send spend notification")
+	}
+
+	select {
+	case aliceChainWatcher.BlockbeatChan <- mockBeat:
+	case <-time.After(time.Second):
+		t.Fatalf("unable to send blockbeat")
+	}
+
+	var uniClose *RemoteUnilateralCloseInfo
+	select {
+	case uniClose = <-chanEvents.RemoteUnilateralClosure:
+	case <-time.After(time.Second * 15):
+		t.Fatalf("didn't receive unilateral close event")
+	}
+
+	require.Len(t, uniClose.RemoteCommit.Htlcs, 1)
+	require.NotZero(t, uniClose.RemoteCommit.FeePerKw)
+	require.NotNil(t, uniClose.HtlcResolutions)
+	require.Len(t, uniClose.HtlcResolutions.OutgoingHTLCs, 1)
+
+	commitKey := uniClose.CommitSet.ConfCommitKey.UnwrapOrFail(t)
+	require.Equal(t, RemoteHtlcSet, commitKey)
+	commitSetHtlcs := uniClose.CommitSet.HtlcSets[RemoteHtlcSet]
+	require.Equal(t, uniClose.RemoteCommit.Htlcs, commitSetHtlcs)
+	require.Empty(t, uniClose.CommitSet.HtlcSets[LocalHtlcSet])
+	require.Empty(t, uniClose.CommitSet.HtlcSets[RemotePendingHtlcSet])
+
+	resolution := uniClose.HtlcResolutions.OutgoingHTLCs[0]
+	require.Equal(t, bobTxHash, resolution.ClaimOutpoint.Hash)
+	require.Equal(
+		t, uint32(uniClose.RemoteCommit.Htlcs[0].OutputIndex),
+		resolution.ClaimOutpoint.Index,
+	)
+	require.NotEqual(
+		t, aliceChanState.FundingOutpoint, resolution.ClaimOutpoint,
+	)
+}
+
 // TestChainWatcherLocalForceCloseDetect tests we're able to always detect our
 // commitment output based on only the outputs present on the transaction.
 func TestChainWatcherLocalForceCloseDetect(t *testing.T) {

--- a/contractcourt/channel_arbitrator_test.go
+++ b/contractcourt/channel_arbitrator_test.go
@@ -625,6 +625,97 @@ func TestChannelArbitratorRemoteForceClose(t *testing.T) {
 	}
 }
 
+// TestChannelArbitratorDlpRemoteCloseUsesRemoteTrigger tests that remote-close
+// triggered DLP HTLC recovery does not skip far-from-expiry outgoing HTLCs.
+func TestChannelArbitratorDlpRemoteCloseUsesRemoteTrigger(t *testing.T) {
+	log := &mockArbitratorLog{
+		state:     StateDefault,
+		newStates: make(chan ArbitratorState, 5),
+	}
+	chanArbCtx, err := createTestChannelArbitrator(t, log)
+	require.NoError(t, err, "unable to create ChannelArbitrator")
+
+	htlc := channeldb.HTLC{
+		Incoming:      false,
+		HtlcIndex:     99,
+		OutputIndex:   3,
+		RefundTimeout: 100,
+	}
+	activeHTLCs := map[HtlcSetKey]htlcSet{
+		RemoteHtlcSet: newHtlcSet([]channeldb.HTLC{htlc}),
+	}
+
+	chainActions, err := chanArbCtx.chanArb.checkRemoteChainActions(
+		0, chainTrigger, activeHTLCs, false,
+	)
+	require.NoError(t, err)
+	require.Empty(t, chainActions)
+
+	remoteActions, err := chanArbCtx.chanArb.checkRemoteChainActions(
+		0, remoteCloseTrigger, activeHTLCs, false,
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t, []channeldb.HTLC{htlc},
+		remoteActions[HtlcOutgoingWatchAction],
+	)
+}
+
+// TestChannelArbitratorDlpRemoteHtlcResolutionLookup tests that a corrected
+// remote HTLC output index resolves to the matching outgoing resolution.
+func TestChannelArbitratorDlpRemoteHtlcResolutionLookup(t *testing.T) {
+	log := &mockArbitratorLog{
+		state:     StateDefault,
+		newStates: make(chan ArbitratorState, 5),
+	}
+	chanArbCtx, err := createTestChannelArbitrator(t, log)
+	require.NoError(t, err, "unable to create ChannelArbitrator")
+
+	commitHash := chainhash.Hash{1}
+	htlc := channeldb.HTLC{
+		Incoming:      false,
+		HtlcIndex:     99,
+		OutputIndex:   3,
+		RefundTimeout: 10,
+		Amt:           1000,
+	}
+	claimPoint := wire.OutPoint{
+		Hash:  commitHash,
+		Index: uint32(htlc.OutputIndex),
+	}
+	outgoingRes := lnwallet.OutgoingHtlcResolution{
+		Expiry:        htlc.RefundTimeout,
+		ClaimOutpoint: claimPoint,
+		SweepSignDesc: input.SignDescriptor{
+			Output: &wire.TxOut{
+				Value: int64(htlc.Amt.ToSatoshis()),
+			},
+		},
+	}
+	outgoingResolutions := []lnwallet.OutgoingHtlcResolution{
+		outgoingRes,
+	}
+
+	resolvers, err := chanArbCtx.chanArb.prepContractResolutions(
+		&ContractResolutions{
+			CommitHash: commitHash,
+			HtlcResolutions: lnwallet.HtlcResolutions{
+				OutgoingHTLCs: outgoingResolutions,
+			},
+		}, htlc.RefundTimeout, ChainActionMap{
+			HtlcTimeoutAction: []channeldb.HTLC{htlc},
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, resolvers, 1)
+
+	timeoutResolver, ok := resolvers[0].(*htlcTimeoutResolver)
+	require.True(t, ok)
+	require.Equal(
+		t, claimPoint, timeoutResolver.htlcResolution.ClaimOutpoint,
+	)
+}
+
 // TestChannelArbitratorLocalForceClose tests that the ChannelArbitrator goes
 // through the expected states in case we request it to force close the channel,
 // and the local force close event is observed in chain.

--- a/docs/recovery.md
+++ b/docs/recovery.md
@@ -241,6 +241,13 @@ right after the channel is created, as we have all the data required to make a
 backup, but lack information about the future HTLCs that the channel will
 process.
 
+If DLP is triggered while the local database still contains HTLC metadata, `lnd`
+can also recover outgoing HTLC outputs from the peer's confirmed remote
+commitment when they exactly match locally reconstructed scripts. This recovery
+only sweeps outputs from the observed remote force-close transaction; it never
+broadcasts an old commitment transaction or initiates channel closure. HTLCs
+that are absent from local state remain unrecoverable from an SCB alone.
+
 ### Obtaining SCBs
 
 #### On-Disk `channel.backup`

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -35,6 +35,10 @@ var allTestCases = []*lntest.TestCase{
 		TestFunc: testDataLossProtection,
 	},
 	{
+		Name:     "data loss protection htlc",
+		TestFunc: testDataLossProtectionHtlcRecovery,
+	},
+	{
 		Name:     "send all coins",
 		TestFunc: testSendAllCoins,
 	},

--- a/itest/lnd_channel_backup_test.go
+++ b/itest/lnd_channel_backup_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/lightningnetwork/lnd/chanbackup"
 	"github.com/lightningnetwork/lnd/funding"
 	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/lightningnetwork/lnd/lnrpc/invoicesrpc"
+	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/walletrpc"
 	"github.com/lightningnetwork/lnd/lntest"
 	"github.com/lightningnetwork/lnd/lntest/node"
@@ -1218,9 +1220,8 @@ func testDataLossProtection(ht *lntest.HarnessTest) {
 
 		// With the channel open, we'll create a few invoices for the
 		// node that Carol will pay to in order to advance the state of
-		// the channel.
-		// TODO(halseth): have dangling HTLCs on the commitment, able to
-		// retrieve funds?
+		// the channel. A separate test case covers dangling HTLC
+		// recovery.
 		payReqs, _, _ := ht.CreatePayReqs(dave, paymentAmt, numInvoices)
 
 		// Send payments from Carol using 3 of the payment hashes
@@ -1348,6 +1349,108 @@ func testDataLossProtection(ht *lntest.HarnessTest) {
 		if daveBalance <= daveStartingBalance {
 			return fmt.Errorf("expected dave to have balance "+
 				"above %d, intead had %v", daveStartingBalance,
+				daveBalance)
+		}
+
+		return nil
+	}, defaultTimeout)
+	require.NoError(ht, err, "timeout while checking dave's balance")
+}
+
+// testDataLossProtectionHtlcRecovery tests that a stale node recovers an
+// outgoing HTLC from an unknown remote commitment after local data loss.
+func testDataLossProtectionHtlcRecovery(ht *lntest.HarnessTest) {
+	const (
+		chanAmt     = btcutil.Amount(1_000_000)
+		paymentAmt  = btcutil.Amount(50_000)
+		numInvoices = 3
+		htlcAmt     = int64(80_000)
+	)
+
+	carol := ht.NewNode(
+		"CarolHtlc", []string{"--nolisten", "--minbackoff=1h"},
+	)
+	dave := ht.NewNode("DaveHtlc", nil)
+
+	ht.FundCoins(btcutil.SatoshiPerBitcoin, carol)
+	ht.EnsureConnected(carol, dave)
+	chanPoint := ht.OpenChannel(
+		carol, dave, lntest.OpenChannelParams{Amt: chanAmt},
+	)
+
+	payReqs, _, _ := ht.CreatePayReqs(dave, paymentAmt, numInvoices)
+	ht.CompletePaymentRequests(carol, payReqs)
+	daveLocalBalance := int64(paymentAmt * numInvoices)
+	ht.AssertChannelLocalBalance(dave, chanPoint, daveLocalBalance)
+
+	preimage := ht.RandomPreimage()
+	payHash := preimage.Hash()
+	invoiceReq := &invoicesrpc.AddHoldInvoiceRequest{
+		Value:      htlcAmt,
+		CltvExpiry: finalCltvDelta,
+		Hash:       payHash[:],
+	}
+	invoice := carol.RPC.AddHoldInvoice(invoiceReq)
+	stream := carol.RPC.SubscribeSingleInvoice(payHash[:])
+
+	req := &routerrpc.SendPaymentRequest{
+		PaymentRequest: invoice.PaymentRequest,
+		FeeLimitMsat:   noFeeLimitMsat,
+	}
+	ht.SendPaymentAssertInflight(dave, req)
+	ht.AssertOutgoingHTLCActive(dave, chanPoint, payHash[:])
+	ht.AssertIncomingHTLCActive(carol, chanPoint, payHash[:])
+	ht.AssertInvoiceState(stream, lnrpc.Invoice_ACCEPTED)
+
+	chanState := ht.QueryChannelByChanPoint(dave, chanPoint)
+	stateNumPreCopy := chanState.NumUpdates
+	ht.BackupDB(dave)
+	ht.EnsureConnected(carol, dave)
+
+	payReqs, _, _ = ht.CreatePayReqs(dave, paymentAmt, numInvoices)
+	ht.CompletePaymentRequests(carol, payReqs)
+
+	ht.RestartNodeAndRestoreDB(dave)
+	ht.AssertNodeNumChannels(dave, 1)
+	ht.AssertChannelNumUpdates(dave, stateNumPreCopy, chanPoint)
+	ht.AssertPaymentStatus(dave, payHash, lnrpc.Payment_IN_FLIGHT)
+	daveStartingBalance := dave.RPC.WalletBalance().ConfirmedBalance
+
+	// Reconnect so Dave receives and stores Carol's DLP commit point
+	// before the force close confirms. The channel sync causes Carol to
+	// publish her latest commitment.
+	ht.EnsureConnected(carol, dave)
+	ht.AssertNumTxsInMempool(1)
+	ht.AssertNumWaitingClose(carol, 1)
+	ht.AssertNumWaitingClose(dave, 1)
+	ht.MineBlocksAndAssertNumTxes(1, 1)
+
+	pending := ht.AssertNumPendingForceClose(dave, 1)[0]
+	require.Len(ht, pending.PendingHtlcs, 1)
+	pendingHtlc := pending.PendingHtlcs[0]
+	require.False(ht, pendingHtlc.Incoming)
+	require.Equal(ht, htlcAmt, pendingHtlc.Amount)
+
+	ht.Shutdown(carol)
+	ht.AssertNumPendingSweeps(dave, 1)
+	ht.MineBlocksAndAssertNumTxes(1, 1)
+
+	pending = ht.AssertNumPendingForceClose(dave, 1)[0]
+	require.Len(ht, pending.PendingHtlcs, 1)
+	blocksTillMaturity := pending.PendingHtlcs[0].BlocksTilMaturity
+	require.Positive(ht, blocksTillMaturity)
+
+	ht.MineEmptyBlocks(int(blocksTillMaturity))
+	ht.AssertNumPendingSweeps(dave, 1)
+	ht.MineBlocksAndAssertNumTxes(1, 1)
+	ht.AssertNumPendingForceClose(dave, 0)
+	ht.AssertPaymentStatus(dave, payHash, lnrpc.Payment_FAILED)
+
+	err := wait.NoError(func() error {
+		daveBalance := dave.RPC.WalletBalance().ConfirmedBalance
+		if daveBalance <= daveStartingBalance {
+			return fmt.Errorf("expected dave balance above %d, "+
+				"instead had %v", daveStartingBalance,
 				daveBalance)
 		}
 

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -131,6 +131,11 @@ var (
 	ErrForceCloseLocalDataLoss = errors.New("cannot force close " +
 		"channel with local data loss")
 
+	// ErrDlpTaprootUnsupported is returned when DLP HTLC recovery is
+	// attempted for a taproot channel.
+	ErrDlpTaprootUnsupported = errors.New("taproot DLP HTLC recovery " +
+		"unsupported")
+
 	// errNoNonce is returned when a nonce is required, but none is found.
 	errNoNonce = errors.New("no nonce found")
 
@@ -8158,6 +8163,127 @@ func (r *OutgoingHtlcResolution) HtlcPoint() wire.OutPoint {
 	}
 
 	return r.ClaimOutpoint
+}
+
+type dlpHtlcMatchKey struct {
+	htlcIndex uint64
+	incoming  bool
+}
+
+// MatchDlpRemoteCommitHtlcs matches recoverable outgoing HTLCs on a remote
+// commitment transaction in a local data loss scenario. The returned HTLCs are
+// copies with OutputIndex corrected to the matched on-chain output.
+func MatchDlpRemoteCommitHtlcs(chanState *channeldb.OpenChannel,
+	commitTx *wire.MsgTx, commitPoint *btcec.PublicKey) ([]channeldb.HTLC,
+	error) {
+
+	if chanState.ChanType.IsTaproot() {
+		return nil, ErrDlpTaprootUnsupported
+	}
+	if commitTx == nil {
+		return nil, errors.New("missing commitment transaction")
+	}
+	if commitPoint == nil {
+		return nil, errors.New("missing commitment point")
+	}
+
+	keyRing := DeriveCommitmentKeys(
+		commitPoint, lntypes.Remote, chanState.ChanType,
+		&chanState.LocalChanCfg, &chanState.RemoteChanCfg,
+	)
+
+	candidates := append(
+		[]channeldb.HTLC(nil), chanState.RemoteCommitment.Htlcs...,
+	)
+	if chanState.Db != nil {
+		pendingRemoteCommit, err := chanState.RemoteCommitChainTip()
+		switch {
+		case err == nil && pendingRemoteCommit != nil:
+			candidates = append(
+				candidates,
+				pendingRemoteCommit.Commitment.Htlcs...,
+			)
+		case err == nil, errors.Is(err, channeldb.ErrNoPendingCommit):
+		case err != nil:
+			return nil, err
+		}
+	}
+
+	var (
+		seen          = make(map[dlpHtlcMatchKey]struct{})
+		outputMatches = make(map[uint32][]channeldb.HTLC)
+	)
+	for _, htlc := range candidates {
+		if htlc.Incoming {
+			continue
+		}
+
+		scriptInfo, err := genHtlcScript(
+			chanState.ChanType, htlc.Incoming, lntypes.Remote,
+			htlc.RefundTimeout, htlc.RHash, keyRing,
+			fn.None[txscript.TapLeaf](),
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		var matches []uint32
+		for outputIndex, txOut := range commitTx.TxOut {
+			if txOut.Value != int64(htlc.Amt.ToSatoshis()) {
+				continue
+			}
+			if !bytes.Equal(txOut.PkScript, scriptInfo.PkScript()) {
+				continue
+			}
+
+			matches = append(matches, uint32(outputIndex))
+		}
+
+		switch len(matches) {
+		case 0:
+			continue
+		case 1:
+		default:
+			walletLog.Warnf("ChannelPoint(%v): DLP HTLC candidate "+
+				"matched multiple outputs: htlc_id=%v",
+				chanState.FundingOutpoint, htlc.HtlcIndex)
+
+			continue
+		}
+
+		matchKey := dlpHtlcMatchKey{
+			htlcIndex: htlc.HtlcIndex,
+			incoming:  htlc.Incoming,
+		}
+		if _, ok := seen[matchKey]; ok {
+			continue
+		}
+		seen[matchKey] = struct{}{}
+
+		htlc.OutputIndex = int32(matches[0])
+		outputMatches[matches[0]] = append(
+			outputMatches[matches[0]], htlc,
+		)
+	}
+
+	recoveredHtlcs := make([]channeldb.HTLC, 0, len(outputMatches))
+	for outputIndex, htlcs := range outputMatches {
+		if len(htlcs) > 1 {
+			walletLog.Warnf("ChannelPoint(%v): multiple DLP HTLC "+
+				"candidates matched output_index=%v",
+				chanState.FundingOutpoint, outputIndex)
+
+			continue
+		}
+
+		recoveredHtlcs = append(recoveredHtlcs, htlcs[0])
+	}
+
+	slices.SortFunc(recoveredHtlcs, func(a, b channeldb.HTLC) int {
+		return cmp.Compare(a.OutputIndex, b.OutputIndex)
+	})
+
+	return recoveredHtlcs, nil
 }
 
 // extractHtlcResolutions creates a series of outgoing HTLC resolutions, and

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -1005,6 +1005,128 @@ type forceCloseTestCase struct {
 	anchorAmt            btcutil.Amount
 }
 
+// newDlpHtlcMatchTestState creates a channel state with one outgoing HTLC on
+// the remote commitment transaction.
+func newDlpHtlcMatchTestState(t *testing.T) (*channeldb.OpenChannel,
+	*wire.MsgTx, *btcec.PublicKey, channeldb.HTLC) {
+
+	t.Helper()
+
+	aliceChannel, bobChannel, err := CreateTestChannels(
+		t, channeldb.SingleFunderTweaklessBit,
+	)
+	require.NoError(t, err)
+
+	htlcAmount := lnwire.NewMSatFromSatoshis(20_000)
+	htlc, _ := createHTLC(0, htlcAmount)
+	addAndReceiveHTLC(t, aliceChannel, bobChannel, htlc, nil)
+
+	require.NoError(t, ForceStateTransition(aliceChannel, bobChannel))
+
+	chanState := aliceChannel.channelState
+	require.Len(t, chanState.RemoteCommitment.Htlcs, 1)
+
+	remoteHtlc := chanState.RemoteCommitment.Htlcs[0]
+
+	return chanState, chanState.RemoteCommitment.CommitTx.Copy(),
+		chanState.RemoteCurrentRevocation, remoteHtlc
+}
+
+// TestMatchDlpRemoteCommitHtlcs tests DLP HTLC output matching.
+func TestMatchDlpRemoteCommitHtlcs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("stale output index", func(t *testing.T) {
+		t.Parallel()
+
+		chanState, commitTx, commitPoint, remoteHtlc :=
+			newDlpHtlcMatchTestState(t)
+		expectedIndex := remoteHtlc.OutputIndex
+		chanState.RemoteCommitment.Htlcs[0].OutputIndex =
+			channeldb.OutputIndexEmpty
+
+		matchedHtlcs, err := MatchDlpRemoteCommitHtlcs(
+			chanState, commitTx, commitPoint,
+		)
+
+		require.NoError(t, err)
+		require.Len(t, matchedHtlcs, 1)
+		require.Equal(t, expectedIndex, matchedHtlcs[0].OutputIndex)
+		require.Equal(t, remoteHtlc.RHash, matchedHtlcs[0].RHash)
+	})
+
+	t.Run("wrong commit point", func(t *testing.T) {
+		t.Parallel()
+
+		chanState, commitTx, _, _ := newDlpHtlcMatchTestState(t)
+		_, wrongCommitPoint := btcec.PrivKeyFromBytes(
+			bytes.Repeat([]byte{9}, 32),
+		)
+
+		matchedHtlcs, err := MatchDlpRemoteCommitHtlcs(
+			chanState, commitTx, wrongCommitPoint,
+		)
+
+		require.NoError(t, err)
+		require.Empty(t, matchedHtlcs)
+	})
+
+	t.Run("candidate matches multiple outputs", func(t *testing.T) {
+		t.Parallel()
+
+		chanState, commitTx, commitPoint, remoteHtlc :=
+			newDlpHtlcMatchTestState(t)
+		htlcOut := commitTx.TxOut[remoteHtlc.OutputIndex]
+		commitTx.AddTxOut(&wire.TxOut{
+			Value:    htlcOut.Value,
+			PkScript: append([]byte(nil), htlcOut.PkScript...),
+		})
+
+		matchedHtlcs, err := MatchDlpRemoteCommitHtlcs(
+			chanState, commitTx, commitPoint,
+		)
+
+		require.NoError(t, err)
+		require.Empty(t, matchedHtlcs)
+	})
+
+	t.Run("distinct candidates match same output", func(t *testing.T) {
+		t.Parallel()
+
+		chanState, commitTx, commitPoint, remoteHtlc :=
+			newDlpHtlcMatchTestState(t)
+		secondHtlc := remoteHtlc
+		secondHtlc.HtlcIndex++
+		chanState.RemoteCommitment.Htlcs = append(
+			chanState.RemoteCommitment.Htlcs, secondHtlc,
+		)
+
+		matchedHtlcs, err := MatchDlpRemoteCommitHtlcs(
+			chanState, commitTx, commitPoint,
+		)
+
+		require.NoError(t, err)
+		require.Empty(t, matchedHtlcs)
+	})
+
+	t.Run("taproot unsupported", func(t *testing.T) {
+		t.Parallel()
+
+		chanState := &channeldb.OpenChannel{
+			ChanType: channeldb.SimpleTaprootFeatureBit,
+		}
+		_, commitPoint := btcec.PrivKeyFromBytes(
+			bytes.Repeat([]byte{1}, 32),
+		)
+
+		_, err := MatchDlpRemoteCommitHtlcs(
+			chanState, wire.NewMsgTx(2), commitPoint,
+		)
+
+		require.ErrorIs(t, err, ErrDlpTaprootUnsupported)
+	})
+}
+
 func testForceClose(t *testing.T, testCase *forceCloseTestCase) {
 	t.Parallel()
 


### PR DESCRIPTION
Summary
- match outgoing HTLC outputs from observed remote closes using the DLP commit point
- wire matched HTLCs into the unknown remote-close path
- add unit, contractcourt, docs, and itest coverage

Tests
- go test ./lnwallet -run TestMatchDlpRemoteCommitHtlcs
- go test ./contractcourt -run 'TestChannelArbitratorDlpRemote|TestChainWatcherDataLossProtect|TestChainWatcherDataLossProtectHtlcRecovery'\n- go test ./itest -run TestDoesNotExist\n- go test -v ./itest -tags="dev autopilotrpc chainrpc invoicesrpc neutrinorpc peersrpc routerrpc signrpc verrpc walletrpc watchtowerrpc wtclientrpc integration btcd" -c -o itest/itest.test\n- make itest-only backend=btcd icase=data_loss_protection_htlc timeout=30m\n- git diff --check master..HEAD