### PR TITLE
docs: add dynamic commitments ADRs and overview

### DIFF
--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,103 @@
+# 0001. Record architecture decisions
+
+- Status: Accepted
+
+## Context
+
+`lnd` has no architecture-decision convention today. `docs/` is a flat pile of
+topic-oriented documents (for example `watchtower.md`, `musig2.md`,
+`zero_conf_channels.md`), each describing *how* a subsystem works, but there is
+no durable record of *why* a given design was chosen over the alternatives that
+were on the table at the time. As a result, the reasoning behind a decision
+tends to live in a pull-request thread, a review comment, or a maintainer's
+memory. Those sources are hard to find later, decay over time, and disappear
+entirely when the surrounding code is rewritten.
+
+This matters most for features that evolve over several years and pivot more
+than once. Dynamic commitments is the concrete example that motivated this ADR
+process: it has already changed shape several times (monolithic BOLT draft to a
+consolidated params-only draft; a `protofsm` negotiator to a scoped modular
+updater), and each pivot silently invalidated earlier design notes. Without a
+record of what was decided and why, every new contributor re-litigates settled
+questions.
+
+An Architecture Decision Record (ADR) captures a single significant decision:
+the context that forced it, the decision itself, and the consequences that
+follow. Recording decisions as small, immutable, numbered documents that live
+next to the code gives us a searchable, reviewable, version-controlled history
+of the project's architecture — one that survives refactors because it is never
+edited in place.
+
+## Decision
+
+Adopt lightweight ADRs for `lnd`, stored in `docs/adr/`, following a
+Nygard/MADR-lite structure.
+
+**File naming.** Each ADR is a Markdown file named `NNNN-slug.md`, where `NNNN`
+is a zero-padded, monotonically increasing number and `slug` is a short
+kebab-case title (for example `0004-dyn-commit-as-update-log-entry.md`). Numbers
+are never reused. This bootstrap document is ADR 0001.
+
+**Format.** Every ADR uses the following sections, in order:
+
+- **Status** — one of `Proposed`, `Accepted`, or `Superseded-by-NNNN` (see
+  lifecycle below).
+- **Context** — the forces at play: the problem, constraints, and requirements
+  that make a decision necessary. Written in the present tense, as the situation
+  seen at decision time.
+- **Decision** — the choice that was made, stated plainly and actively ("We
+  will ...").
+- **Consequences** — what becomes easier and what becomes harder as a result,
+  including follow-on work and accepted trade-offs. Both positive and negative.
+- **Alternatives considered** — the other options that were genuinely on the
+  table and why they were not chosen.
+- **Supersedes / Superseded-by** — cross-links to related ADRs, when
+  applicable. Omit when there are none.
+
+**Lifecycle.** An ADR moves through `Proposed` → `Accepted` →
+`Superseded-by-NNNN`:
+
+- A new ADR opens as **Proposed** while under review.
+- It becomes **Accepted** when merged. An accepted ADR is immutable — it is a
+  historical record of what was decided at a point in time.
+- When a later decision overrides an accepted one, do **not** edit the original.
+  Write a new ADR that captures the new decision, mark the old one
+  `Superseded-by-NNNN`, and mark the new one as superseding the old
+  (`Supersedes: NNNN`). This preserves the full lineage of the design.
+
+Only edit an accepted ADR to fix a typo or a broken link, never to change its
+meaning. Meaning changes go in a new, superseding ADR.
+
+## Consequences
+
+- The reasoning behind significant `lnd` design decisions becomes discoverable
+  in-tree, reviewable through the normal pull-request process, and durable
+  across refactors.
+- Contributors gain a template that lowers the cost of proposing and evaluating
+  a design change: reviewers can weigh the recorded alternatives instead of
+  reconstructing them.
+- The immutability rule means the ADR log grows monotonically and can contain
+  decisions that no longer reflect the current code. This is intentional — a
+  superseded ADR plus its successor together tell the story of how the design
+  changed. Readers must check the `Status` line and follow `Superseded-by`
+  links to find the currently-authoritative decision.
+- There is a small ongoing discipline cost: authors of non-trivial architectural
+  changes are expected to add or supersede an ADR alongside the code.
+- This process is deliberately scoped to *architecture* decisions. It does not
+  replace the per-feature `docs/*.md` overviews, release notes, or code
+  comments; it complements them.
+
+## Alternatives considered
+
+- **Keep the status quo (no ADRs).** Continue recording rationale in PR threads
+  and topic docs. Rejected: rationale stays scattered and ephemeral, and the
+  dynamic-commitments pivots showed concretely how quickly undocumented design
+  intent is lost.
+- **A heavier ADR template (full MADR with decision drivers, scored options,
+  pros/cons matrices).** Rejected as too much ceremony for a first adoption;
+  the friction would discourage authors. The lightweight Nygard-style form
+  captures what we need and can be extended later if it proves too thin.
+- **A single living "design decisions" document.** Rejected: a mutable
+  catch-all loses the per-decision review granularity and the immutable audit
+  trail, and it re-introduces exactly the "edit history in place" problem that
+  superseding avoids.

--- a/docs/adr/0002-params-only-scope.md
+++ b/docs/adr/0002-params-only-scope.md
@@ -1,0 +1,77 @@
+# 0002. Params-only scope for dynamic commitments
+
+- Status: Accepted
+
+## Context
+
+Dynamic commitments lets two channel peers renegotiate "static" channel
+parameters after the channel is open, executed **solely by committing a new
+channel state** — no on-chain close and reopen. This preserves the channel's
+identity, age, and graph continuity.
+
+The original design lineage (the `DynComms [0/n]…[4/n]` series and the
+monolithic BOLT draft #1117) bundled two very different kinds of change under
+one banner: renegotiating commitment parameters, and mutating the funding output
+itself (`funding_pubkey` rotation, simple-taproot conversion, other channel-type
+transitions). The latter requires a new funding transaction or a kickoff /
+reanchor transaction and a wholesale change to the on-chain output structure.
+Combining both into one milestone produced a large, deeply-coupled surface with
+a correspondingly large funds-loss blast radius.
+
+A clean line can be drawn: some updates are executable purely by signing a new
+commitment over the *same* funding output; others are not.
+
+## Decision
+
+The first production milestone of dynamic commitments is **params-only**.
+
+**In scope** — parameters that can change by committing a new state over the
+existing funding output: `dust_limit_satoshis`,
+`max_htlc_value_in_flight_msat`, `channel_reserve_satoshis`,
+`htlc_minimum_msat`, `to_self_delay`, `max_accepted_htlcs`, and `channel_flags`
+(announcement intent; the public/private gossip effect is delivered as a
+dedicated subtrack layered on top of the core commitment update).
+
+**Out of scope** — anything that requires a new funding transaction,
+funding-output change, capacity change, or channel-type transition:
+`funding_pubkey` rotation, funding-output changes, channel-type upgrades
+(including same-funding-output ones such as anchors / static-remote-key /
+zero-fee), simple-taproot conversion, and kickoff / reanchor transactions. These
+belong to splicing or a future funding-update protocol.
+
+The governing rule: **if an update needs a new funding transaction, it is not
+dynamic-commitments work.**
+
+## Consequences
+
+- The implementation surface shrinks dramatically. All kickoff / reanchor
+  machinery is removed from the effort, and the on-chain output structure never
+  changes during a dynamic update, which bounds the recovery-correctness problem
+  to script/output-rendering parameters (see ADR 0006).
+- Channel identity, age, and graph continuity are preserved by construction,
+  because the funding output is untouched.
+- Because parameters are proposer-owned (see ADR 0007), changing *both* peers'
+  values requires two successful dynamic updates.
+- `channel_type` remains static for the life of a channel under this milestone,
+  which lets recovery paths keep reading `chanState.ChanType` directly.
+- Type upgrades and funding-output mutations are deferred, not abandoned; they
+  are re-homed to splicing / a future funding-update protocol, where the
+  funding-transaction machinery already lives.
+
+## Alternatives considered
+
+- **Full dynamic commitments including channel-type and funding-output
+  changes** (the two-document #1117 structure with
+  `ext-dynamic-funding-outputs.md`). Rejected for this milestone: it couples
+  parameter renegotiation to funding-transaction construction, kickoff
+  transactions, and channel-type-aware recovery, producing a much larger and
+  riskier change than the params-only core needs.
+- **An even narrower CSV-only or dust-only scope.** Rejected as arbitrary: the
+  in-scope parameter set is exactly what a single new commitment over the same
+  funding output can express, which is a principled boundary rather than a
+  convenience cut.
+
+## Supersedes / Superseded-by
+
+- Relates to ADR 0006 (breach recovery via epoch history), ADR 0007
+  (proposer-owned params), and ADR 0008 (no HTLCs in flight).

--- a/docs/adr/0003-modular-updater.md
+++ b/docs/adr/0003-modular-updater.md
@@ -1,0 +1,72 @@
+# 0003. A modular `htlcswitch/dyn.Updater` owns negotiation
+
+- Status: Accepted
+
+## Context
+
+A dynamic-commitments update has two distinct phases. First, **negotiation**:
+the proposer sends `dyn_propose`, the responder replies with `dyn_ack` or
+`dyn_reject`, and the two sides converge on an agreed set of parameter changes.
+Second, **execution**: the agreed change is committed by running the ordinary
+commitment dance (`commitment_signed` / `revoke_and_ack`) so that both
+commitment transactions lock in the new parameters.
+
+The prior design (#8756, `[4/n]`) modeled the whole flow as a `protofsm` state
+machine — a full protocol finite-state machine driving both negotiation and
+execution. That approach is powerful but heavy: it introduces its own state,
+persistence, and event plumbing, and it partly duplicates the commitment-dance
+machinery the link already owns. It also stalled and went stale, which is
+evidence that the abstraction was more than the problem required.
+
+The `link` and `LightningChannel` already know how to run the commitment dance
+correctly, including retransmission and reestablish. The only genuinely new
+logic is the negotiation handshake.
+
+## Decision
+
+Introduce a scoped `Updater` in a new `htlcswitch/dyn` package that **owns
+negotiation only**.
+
+The `Updater` validates preconditions (both peers have exchanged
+`channel_ready`, the local node is the quiescence initiator when proposing,
+no HTLCs are in flight, no pending update / shutdown / splice / RBF), drives the
+`dyn_propose` / `dyn_ack` / `dyn_reject` exchange, signs and verifies the
+`dyn_ack` signature, and produces an agreed parameter update. Its job ends
+there.
+
+Once negotiation yields an agreed update, the update is fed into the existing
+commitment update log (see ADR 0004) and the link plus wallet perform the
+ordinary commitment dance to execute it. The `Updater` does not re-implement
+persistence, retransmission, or commitment-number accounting — those stay where
+they already live.
+
+## Consequences
+
+- The new code is small and focused: a negotiation component, not a second
+  protocol engine. Execution reuses the battle-tested commitment-dance paths.
+- Negotiation is cleanly decoupled from execution, which makes each unit-testable
+  in isolation (state-machine and race tests for the `Updater`; link-level tests
+  for the dance).
+- There is no separate FSM state to persist and reconcile at reestablish beyond
+  what the update-log model (ADR 0004) and the bundled `dyn_commit_sig` (ADR
+  0005) already imply.
+- The `Updater` must integrate with the link's message routing (dyn messages
+  route as `lnwire.LinkUpdater` via `TargetChanID()`), so the boundary between
+  "negotiation done by the updater" and "execution done by the link" has to be
+  drawn precisely — this is the main design cost of the split.
+
+## Alternatives considered
+
+- **A full `protofsm` negotiation state machine** (#8756). Rejected: it is
+  heavier than the problem warrants, duplicates commitment-dance logic the link
+  already owns, and the concrete attempt stalled. The modular updater captures
+  the only novel part — negotiation — and delegates the rest.
+- **Inlining negotiation directly into `link.go`.** Rejected: it would bloat an
+  already-large file, entangle negotiation with forwarding logic, and make the
+  handshake hard to test in isolation. A scoped package keeps the concern
+  separable.
+
+## Supersedes / Superseded-by
+
+- Relates to ADR 0004 (dyn_commit as an update-log entry) and ADR 0005 (bundled
+  dyn_commit_sig).

--- a/docs/adr/0004-dyn-commit-as-update-log-entry.md
+++ b/docs/adr/0004-dyn-commit-as-update-log-entry.md
@@ -1,0 +1,70 @@
+# 0004. Model `dyn_commit` as an update-log entry
+
+- Status: Accepted
+
+## Context
+
+Once negotiation (ADR 0003) produces an agreed parameter change, that change has
+to be applied atomically to both commitment transactions and persisted so it
+survives restarts and reconnects. The question is *how* the agreed update is
+represented inside the channel state machine on the way to being committed.
+
+`lnd`'s commitment state machine already has a well-understood mechanism for
+"a change that is proposed on one commitment and locks in as the dance
+progresses": the **update log**. `update_add_htlc`, `update_fulfill_htlc`,
+`update_fee`, and friends are all update-log entries that ride the ordinary
+`commitment_signed` / `revoke_and_ack` exchange and take effect at
+deterministic commitment heights on each side. `update_fee` in particular is a
+close analogue: a single non-HTLC value that changes and locks in through the
+dance.
+
+The alternative would be to invent a bespoke persistence path for the pending
+parameter change — a new bucket, new reestablish logic, new lock-in accounting —
+running alongside the existing one.
+
+## Decision
+
+Model the agreed dynamic update (`dyn_commit`) as an **update-log entry**, in
+the same spirit as `update_fee`.
+
+The agreed parameter change is added to the commitment update log and rides the
+existing commitment dance. It is proposed on a commitment, signed over as part
+of the normal `commitment_signed` flow (bundled into `dyn_commit_sig`; see ADR
+0005), and locks in at the corresponding commitment height on each side. The
+commitment state machine records *when* the parameters changed relative to each
+chain's commit height, which is exactly what the recovery epoch history (ADR
+0006) needs.
+
+## Consequences
+
+- No new persistence bucket is required. The pending parameter change is carried
+  by the same machinery that already carries HTLC and fee updates, and is
+  persisted by the same commitment-state writes.
+- Channel reestablish stays largely unchanged: the update rides the dance, so
+  the existing retransmission and lock-in logic covers most of the reconnect
+  behavior (the dyn-specific reconnect rules are additive; see ADR 0005).
+- Because update-log entries lock in at deterministic per-side heights, the
+  local and remote commitment chains adopt the new parameters at *different*
+  heights. This is the correctness basis for the per-side (`Dual`) epoch history
+  in ADR 0006.
+- The update-log representation must faithfully encode the full parameter set and
+  its proposer-owned semantics (ADR 0007), and the link must apply each side's
+  config exactly when that side's chain locks in — so the lock-in accounting has
+  to be precise.
+
+## Alternatives considered
+
+- **A dedicated persistence bucket and bespoke reestablish path for the pending
+  parameter update.** Rejected: it duplicates the update-log machinery, adds a
+  second lock-in accounting scheme to keep in sync with the first, and enlarges
+  the reestablish surface — all to represent something the update log already
+  represents well.
+- **Applying parameters immediately on agreement, outside the commitment
+  dance.** Rejected: it breaks atomicity with the committed state and leaves the
+  two commitment chains transiently disagreeing about the active parameters,
+  which is unsafe for recovery.
+
+## Supersedes / Superseded-by
+
+- Relates to ADR 0003 (modular updater), ADR 0005 (bundled dyn_commit_sig), and
+  ADR 0006 (breach recovery via epoch history).

--- a/docs/adr/0005-bundled-dyn-commit-sig.md
+++ b/docs/adr/0005-bundled-dyn-commit-sig.md
@@ -1,0 +1,79 @@
+# 0005. Bundle the proposer commit sig into `dyn_commit_sig`
+
+- Status: Accepted
+
+## Context
+
+After the responder accepts a proposal with `dyn_ack`, the proposer must commit
+the agreed change. An earlier design separated this into two messages: a
+`dyn_commit` message that carried the accepted proposal, followed by an ordinary
+`commitment_signed` carrying the commitment signature. That sequence has two
+problems.
+
+First, it costs an extra round trip: the proposer sends `dyn_commit`, then
+`commitment_signed`, where the two could travel together since there are no
+HTLCs in flight (ADR 0008) and the committed state is fully determined by the
+accepted proposal.
+
+Second, splitting the accepted-proposal payload from the signature opens a race:
+the two peers can disagree about exactly which proposal the signature covers if
+messages interleave with other state, and the responder's acceptance signature
+(`dyn_ack`) is a separate artifact that has to be re-associated with the
+commitment.
+
+The `dyn_ack` signature itself is domain-separated: a 64-byte low-S ECDSA
+signature over the **double-SHA256** digest of a domain-tagged payload
+(`"lightning-dynamic-commitments-dyn-ack-v1"`) covering the chain hash, channel
+id, next commitment number, and the exact proposal TLVs.
+
+## Decision
+
+Bundle everything the responder needs to commit into a single message,
+`dyn_commit_sig` (wire type 117):
+
+1. the **proposer's** commitment signature over the new commitment (a
+   zero-HTLC commitment, since no HTLCs are in flight), computed over the
+   domain-separated double-SHA256 digest;
+2. the responder's `dyn_ack` signature; and
+3. the accepted proposal TLVs.
+
+Because there are no HTLCs, this is a single commit signature with no
+accompanying HTLC signatures. `dyn_commit_sig` is treated as the
+`commitment_signed`-equivalent for the update: it counts toward
+`next_commitment_number` / `next_revocation_number` accounting, and it is
+persisted (together with the accepted TLVs and the resulting state) before the
+responder sends `revoke_and_ack`.
+
+## Consequences
+
+- One message replaces two: a full round trip is removed from the happy path.
+- The race is closed: the signature, the accepted proposal it signs over, and
+  the responder's acceptance signature travel as one atomic unit, so there is no
+  window in which the peers disagree about what was signed.
+- Reestablish must treat `dyn_commit_sig` as the corresponding
+  `commitment_signed`: it is retransmitted when the peer's
+  `channel_reestablish` expects it, and it is permitted before any other update
+  even though quiescence has already ended.
+- The terminology must stay precise: `dyn_commit_sig` carries the **proposer's**
+  commitment signature. "Proposer" is a dynamic-commitments role and must not be
+  conflated with the channel funder/opener or with the quiescence initiator,
+  even though the proposer is required to be the quiescence initiator.
+- Crash-safety hinges on ordering: a received `dyn_ack` must not be used after
+  reconnect unless a `dyn_commit_sig` was persisted before disconnect, and a
+  received `dyn_commit_sig` plus its TLVs must be persisted before
+  `revoke_and_ack`.
+
+## Alternatives considered
+
+- **Separate `dyn_commit` followed by `commitment_signed`** (the earlier
+  sequence). Rejected: it adds a round and admits the accepted-proposal /
+  signature race, for no benefit given the no-HTLC precondition.
+- **Sending the `dyn_ack` signature only in the ack and never echoing it.**
+  Rejected: re-including it in `dyn_commit_sig` lets the responder verify, in a
+  single step, that the commitment being signed corresponds exactly to the
+  proposal it acknowledged.
+
+## Supersedes / Superseded-by
+
+- Relates to ADR 0004 (dyn_commit as an update-log entry) and ADR 0008 (no
+  HTLCs in flight, which is what makes the single bundled commit sig sufficient).

--- a/docs/adr/0006-breach-recovery-epoch-history.md
+++ b/docs/adr/0006-breach-recovery-epoch-history.md
@@ -1,0 +1,95 @@
+# 0006. Breach recovery via local epoch history
+
+- Status: Accepted
+
+## Context
+
+When a dynamic update changes a parameter that affects on-chain **script or
+output rendering** — chiefly `to_self_delay` (CSV), and also `dust_limit` for
+output presence — the recovery paths that reconstruct *historical* commitment
+transactions and scripts must use the parameter values that were in effect **at
+that historical commitment height**, not the current ones.
+
+Today this is fully static. Breach reconstruction in `lnwallet` (for example
+`NewBreachRetribution`, `createHtlcRetribution`, and
+`findOutputIndexesFromRemote`) rebuilds a revoked state's witness scripts from
+the *live* channel config CSV. The `RevocationLog` entry stores only output
+indices, the commit-tx hash, balances, and HTLCs — no CSV, no channel type.
+
+The failure mode is concrete and costs funds: change CSV via a dynamic update,
+then have a peer breach with a *pre-change* revoked state. The justice
+transaction's witness scripts get rebuilt with the *new* CSV, produce the wrong
+witness script, and the justice transaction is unspendable — funds are lost.
+
+Which parameters actually need history is narrow. CSV is embedded in the
+`to_local` and HTLC second-level witness scripts, so it is the hard requirement.
+Dust decides output *presence* (trimming); it is cheap to retain so historical
+commitment rendering stays fully specified, but note that
+`NewBreachRetribution` works from the actual broadcast transaction and the
+stored output indices and does not re-run trimming, so dust is retained for
+completeness rather than as a breach blocker. `channel_type` is static under the
+params-only scope (ADR 0002), so it needs no history.
+
+## Decision
+
+Maintain a **per-side local epoch history** of script/output-rendering
+parameters, keyed by commitment height, and route every historical
+reconstruction through it.
+
+Adopt a `CommitChainEpoch` / `CommitChainEpochHistory` structure (reusing the
+concept from #9158, re-implemented on the modular design) storing
+`{DustLimit, CsvDelay}` per epoch. It is tracked per side with `lntypes.Dual`,
+because the local and remote commitment chains lock in new parameters at
+*different* heights (the responder chain at the height signed by
+`dyn_commit_sig`; the proposer chain at the height signed by the responder's
+`commitment_signed` — see ADR 0004 and ADR 0005). On execution, the current
+epoch is closed at the per-side lock-in height and a new one is opened. The
+history is persisted as optional channel TLV data in `channeldb`, and existing
+channels migrate to a single "epoch 0" covering all prior heights with their
+current static params.
+
+This decision **gates** a required audit: every CSV/dust read in `lnwallet` must
+be classified as either "reconstructs a historical state → MUST use epoch
+lookup" or "operates on the current/latest state → current config is correct."
+Because *any* historical-reconstruction site that reads current config is a
+funds-loss risk once CSV/dust are mutable, this is a codebase-wide audit, not a
+single-site fix. No mutable CSV/dust may ship until that audit lands.
+
+Epoch history lives in **local on-disk channel state only** — it is **not**
+placed in SCBs. SCBs drive DLP, and DLP recovers only the `to_remote` output,
+whose script does not depend on `to_self_delay`; so CSV changes do not affect
+DLP-based recovery. Instead, a fresh SCB is re-emitted on successful execution so
+the backup reflects the current params.
+
+## Consequences
+
+- Breach and force-close recovery remain correct across parameter changes: each
+  historical script is rebuilt with the CSV/dust that were live at that height.
+- Space cost is proportional to the number of *upgrades* (rare), not the number
+  of *states* (millions): roughly 18 bytes per epoch. Storing CSV per revoked
+  state would have undone the revocation-log space optimization.
+- The revocation-log format is left unchanged unless tests prove more per-state
+  data is genuinely needed.
+- The historical-param audit is a hard prerequisite and a safety gate: the
+  feature (or per-parameter, CSV specifically) stays disabled until it lands
+  together with the reconnect hardening.
+- SCBs stay small and portable; the only backup change is re-emission on
+  execution, matching #9158's minimal `chanbackup` touch. The trade-off is that
+  a stale SCB after an upgrade is the ordinary "use your latest backup" problem,
+  which epochs-in-the-SCB would only have masked.
+
+## Alternatives considered
+
+- **Store CSV (and dust) per revoked state in the revocation log.** Rejected:
+  space blows up with the number of states and defeats the revocation-log size
+  optimization, to record a value that only changes on rare upgrades.
+- **Embed epoch history in the SCB.** Rejected: DLP recovers only the
+  CSV-independent `to_remote` output, so the SCB does not need it; adding it
+  would bloat a deliberately tiny, portable artifact and would merely mask the
+  restoration of an out-of-date backup.
+
+## Supersedes / Superseded-by
+
+- Relates to ADR 0002 (params-only scope, which keeps `channel_type` static),
+  ADR 0004 (per-side lock-in heights), and ADR 0005 (which height each chain
+  locks in at).

--- a/docs/adr/0007-proposer-owned-params.md
+++ b/docs/adr/0007-proposer-owned-params.md
@@ -1,0 +1,64 @@
+# 0007. Proposals update the proposer's own params
+
+- Status: Accepted
+
+## Context
+
+Most channel parameters are inherently one-sided: they constrain what the
+*remote* peer may do to the local peer. `channel_reserve_satoshis`,
+`htlc_minimum_msat`, `to_self_delay`, `max_accepted_htlcs`, and
+`max_htlc_value_in_flight_msat` are all declared by one side about the other in
+the original `open_channel` / `accept_channel` handshake, producing two
+independent sets of values (the funder's constraints on the fundee and vice
+versa).
+
+When a dynamic update renegotiates these values, the protocol must decide whose
+values a single proposal changes. One option is a symmetric proposal that
+rewrites both peers' values at once; the other is that each proposal only
+touches the proposer's own declared parameters. The choice affects validation,
+the meaning of `dyn_ack`, and how a "both sides change" outcome is reached.
+
+`channel_flags` is different in kind: it expresses channel-wide announcement
+intent (public vs. private), which is not a per-side constraint.
+
+## Decision
+
+A dynamic proposal updates the **proposer's own declared parameters**. The
+responder accepts (`dyn_ack`) or rejects (`dyn_reject`) that one-sided change;
+it does not simultaneously alter its own values in the same proposal.
+
+Changing *both* peers' values therefore requires **two successful dynamic
+updates**, one proposed by each side.
+
+`channel_flags` is the exception: it is channel-wide announcement intent, not a
+per-side constraint, so a proposal that changes it changes the shared channel
+flag rather than the proposer's private value.
+
+## Consequences
+
+- Validation is simpler and local: the responder checks a single side's new
+  values for BOLT-2 and LND-policy validity (and cross-coupling, e.g. reserve
+  must not fall below dust after applying), rather than reconciling two
+  simultaneous mutations.
+- The semantics match the wire model, in which `dyn_propose` carries the
+  proposer's declared values and `dyn_ack` acknowledges exactly those.
+- Achieving a symmetric change (both sides lower their reserve, say) takes two
+  rounds. This is an accepted cost; symmetric changes are expected to be rare and
+  are cleanly expressible as two ordinary proposals.
+- `channel_flags` needs distinct handling from the per-side parameters
+  throughout the stack, since it is the one channel-wide value in the set; its
+  public/private gossip effect is delivered as a dedicated subtrack.
+
+## Alternatives considered
+
+- **A single symmetric proposal that rewrites both peers' parameters at once.**
+  Rejected: it complicates validation and the meaning of acknowledgement (the
+  responder would have to both accept the proposer's changes and assert its own
+  in one message), and it does not match the naturally one-sided structure of
+  the parameters. Two one-sided updates express the same outcome with simpler
+  semantics.
+
+## Supersedes / Superseded-by
+
+- Relates to ADR 0002 (params-only scope) and ADR 0005 (bundled
+  `dyn_commit_sig`, which carries the accepted proposal TLVs).

--- a/docs/adr/0008-no-htlcs-in-flight.md
+++ b/docs/adr/0008-no-htlcs-in-flight.md
@@ -1,0 +1,66 @@
+# 0008. No dynamic update while HTLCs are in flight
+
+- Status: Accepted
+
+## Context
+
+A dynamic update commits a new channel state with different parameters. Several
+of those parameters shape how HTLCs are rendered on the commitment transaction:
+`dust_limit` decides whether an HTLC is trimmed, `to_self_delay` sets the CSV in
+second-level HTLC scripts, and the value/count limits constrain what may be
+outstanding. If HTLCs were present on either commitment while parameters
+changed, the new commitment would have to re-render existing in-flight HTLCs
+under the new parameters, and the two commitment chains — which lock in the
+change at different heights (ADR 0004) — could transiently disagree about how a
+given HTLC should be trimmed or scripted. That is a correctness minefield for
+both the live state machine and later historical reconstruction.
+
+Quiescence (`stfu`) freezes *new* updates from being added, and the proposer is
+required to be the quiescence initiator. But quiescence on its own does not
+guarantee the commitments are *empty*: HTLCs that were already committed —
+including **trimmed** HTLCs that do not appear as outputs but still exist as
+commitment-log entries — can remain in flight when quiescence is reached.
+
+## Decision
+
+A dynamic update may proceed only when **no HTLC exists in either commitment**,
+including trimmed HTLCs, on both the local and remote chains. Quiescence is
+necessary but **not sufficient**; the no-HTLC precondition is an additional,
+explicit gate.
+
+The channel must be quiescent *and* have zero HTLCs (trimmed or not) in both
+commitment states before negotiation is allowed to execute. The `Updater` (ADR
+0003) enforces this precondition before sending or accepting a proposal.
+
+## Consequences
+
+- The committed state being signed by `dyn_commit_sig` is a **zero-HTLC**
+  commitment, which is precisely what lets the bundled message carry a single
+  commit signature with no HTLC signatures (ADR 0005).
+- There is no need to re-render in-flight HTLCs under changed parameters, and no
+  window in which the two commitment chains disagree about an HTLC's trimming or
+  script during the parameter transition.
+- A node that wants to run a dynamic update may have to wait for in-flight HTLCs
+  to resolve first. Under automatic orchestration this manifests as the update
+  waiting until the channel drains; it does not fail outright merely because the
+  channel is momentarily busy, but it will fail safely if it cannot reach the
+  no-HTLC state within the negotiation window.
+- The check must count trimmed HTLCs and inspect both commitments; checking only
+  visible outputs on one side would be an unsafe under-approximation.
+
+## Alternatives considered
+
+- **Gate on quiescence alone.** Rejected: quiescence stops new updates but does
+  not empty the commitments, so trimmed or already-committed HTLCs could still be
+  present when parameters change — exactly the case that produces mixed-parameter
+  HTLC rendering.
+- **Allow updates with HTLCs in flight, re-rendering them under the new
+  parameters.** Rejected for this milestone: it adds substantial complexity to
+  both the live state machine and historical reconstruction for little
+  near-term benefit. The restriction is relaxable in a future iteration if a
+  need arises.
+
+## Supersedes / Superseded-by
+
+- Relates to ADR 0005 (bundled `dyn_commit_sig`, which relies on the zero-HTLC
+  commitment) and ADR 0003 (the `Updater` enforces this precondition).

--- a/docs/dynamic_commitments.md
+++ b/docs/dynamic_commitments.md
@@ -1,0 +1,131 @@
+# Dynamic Commitments
+
+Dynamic commitments let two channel peers renegotiate "static" channel
+parameters *after* the channel is open, without an on-chain close and reopen.
+The agreed change is applied **solely by committing a new channel state** over
+the existing funding output, so the channel keeps its identity, age, and place
+in the graph. Only the parameters change; the funding transaction is untouched.
+
+This document describes *how* the feature works. The *why* — the design
+decisions behind it — lives in the Architecture Decision Records under
+[`docs/adr/`](./adr), linked from the "Design decisions" section below.
+
+## Scope
+
+Dynamic commitments is **params-only**. It covers exactly those parameters that
+can be changed by signing a new commitment over the same funding output:
+
+- `dust_limit_satoshis`
+- `max_htlc_value_in_flight_msat`
+- `channel_reserve_satoshis`
+- `htlc_minimum_msat`
+- `to_self_delay`
+- `max_accepted_htlcs`
+- `channel_flags` (announcement intent; the public/private gossip effect is
+  handled as a dedicated subtrack)
+
+Anything that requires a new funding transaction — `funding_pubkey` rotation,
+funding-output changes, capacity changes, or channel-type transitions (including
+simple-taproot conversion and other same-funding-output type upgrades) — is
+**out of scope** and belongs to splicing or a future funding-update protocol.
+The governing rule is simple: if an update needs a new funding transaction, it
+is not dynamic-commitments work.
+
+## Roles and terminology
+
+Dynamic commitments has two roles:
+
+- The **proposer** sends `dyn_propose` and, in `dyn_commit_sig`, the proposer's
+  commitment signature over the new state.
+- The **responder** accepts (`dyn_ack`) or rejects (`dyn_reject`) the proposal.
+
+These are distinct from two other roles that appear in the flow. The
+**initiator** is the *quiescence* initiator (the peer that sends `stfu`); the
+proposer must be the quiescence initiator, but "proposer" is a
+dynamic-commitments role, not a quiescence role. The **funder** / **opener** is
+the peer that originally opened the channel. None of these should be conflated:
+in particular, the `dyn_commit_sig` signature is the *proposer's* commitment
+signature, which has nothing to do with who funded or opened the channel.
+
+Parameters are **proposer-owned**: a proposal changes the proposer's own
+declared parameters (`channel_flags` excepted — it is channel-wide). Changing
+both peers' values therefore takes two successful updates, one from each side.
+
+## Protocol flow
+
+A dynamic update runs automatically under the hood once requested. The happy
+path is:
+
+1. **Quiescence.** The proposer initiates quiescence with `stfu`, freezing new
+   updates on the channel. A dynamic update additionally requires that **no
+   HTLC** — including trimmed HTLCs — exists in either commitment; quiescence
+   alone is not sufficient.
+2. **`dyn_propose`** (wire type 111). The proposer sends its desired new
+   parameter values as a set of TLVs.
+3. **`dyn_ack`** (113) or **`dyn_reject`** (115). The responder validates the
+   proposal against BOLT 2 and local policy. It either acknowledges with a
+   domain-separated `dyn_ack` signature, or rejects with a bitfield identifying
+   the rejected parameters. A `dyn_reject` ends the current quiescence session;
+   a retry needs fresh quiescence.
+4. **`dyn_commit_sig`** (117). The proposer sends a single bundled message
+   carrying the proposer's commitment signature over the new (zero-HTLC)
+   commitment, the responder's `dyn_ack` signature, and the accepted proposal
+   TLVs. The commitment signature is computed over a domain-separated
+   double-SHA256 digest. This bundling removes a round trip and closes a race
+   compared to a separate `dyn_commit` followed by `commitment_signed`.
+5. **Commitment dance.** `dyn_commit_sig` is treated as the
+   `commitment_signed`-equivalent for the update. The two peers exchange
+   `revoke_and_ack` (and the responder's own `commitment_signed`) to lock the
+   new parameters into both commitment chains. Each chain adopts the new
+   parameters at its own lock-in height: the responder chain at the height
+   signed by `dyn_commit_sig`, the proposer chain at the height signed by the
+   responder's `commitment_signed`.
+6. **Quiescence exit.** Once the dance completes at the BOLT-defined termination
+   point, quiescence is released and the channel resumes normal operation with
+   the new parameters in effect.
+
+If the connection drops before a `dyn_commit_sig` has been sent or received, the
+in-progress negotiation is aborted and forgotten; a fresh negotiation (and fresh
+quiescence) is required. Once a `dyn_commit_sig` has been persisted, the update
+is retransmitted and completed on reconnect like any other commitment-dance
+step.
+
+## Recovery
+
+Some parameters affect on-chain script or output rendering — chiefly
+`to_self_delay` (the CSV embedded in `to_local` and second-level HTLC scripts)
+and `dust_limit` (which decides output presence). Breach and force-close
+recovery must reconstruct *historical* commitments using the parameter values
+that were in effect at that height, not the current ones. `lnd` keeps a
+per-side, on-disk **epoch history** of these values, keyed by commitment height,
+and every historical-reconstruction path looks up the epoch covering the target
+state. This history is deliberately *not* placed in static channel backups
+(SCBs); instead a fresh SCB is re-emitted after a successful update. See ADR
+0006 for the full rationale.
+
+## Design decisions
+
+The architecture is recorded as ADRs. Start with the process bootstrap, then the
+seven decisions specific to this feature:
+
+- [ADR 0001 — Record architecture decisions](./adr/0001-record-architecture-decisions.md):
+  establishes the ADR process itself.
+- [ADR 0002 — Params-only scope](./adr/0002-params-only-scope.md): what is in
+  and out, and why channel-type and funding-output changes are excluded.
+- [ADR 0003 — Modular `htlcswitch/dyn.Updater`](./adr/0003-modular-updater.md):
+  a scoped updater owns negotiation only, chosen over a `protofsm` negotiation
+  state machine.
+- [ADR 0004 — `dyn_commit` as an update-log entry](./adr/0004-dyn-commit-as-update-log-entry.md):
+  the agreed update rides the existing commitment dance, like `update_fee`.
+- [ADR 0005 — Bundled `dyn_commit_sig`](./adr/0005-bundled-dyn-commit-sig.md):
+  one message carries the proposer commit sig, the responder `dyn_ack` sig, and
+  the accepted TLVs, removing a round and a race.
+- [ADR 0006 — Breach recovery via epoch history](./adr/0006-breach-recovery-epoch-history.md):
+  per-side local epoch history for historical script reconstruction, not in
+  SCBs.
+- [ADR 0007 — Proposer-owned params](./adr/0007-proposer-owned-params.md): a
+  proposal updates the proposer's own declared parameters; `channel_flags` is
+  channel-wide.
+- [ADR 0008 — No HTLCs in flight](./adr/0008-no-htlcs-in-flight.md): no dynamic
+  update while any HTLC (including trimmed) exists in either commitment;
+  quiescence alone is insufficient.


### PR DESCRIPTION
Part of the Dynamic Commitments milestone: #60

Adds the `docs/adr/` process, the seed dynamic-commitments ADRs, and `docs/dynamic_commitments.md`.

**Stacked PR** — based on `master`; review after that branch (the base updates automatically as the parent merges).

Opened as a **draft**: this is part of the exploratory params-only stack (coarse commits, not final hygiene).