### PR TITLE
lnwire: dynamic commitments wire cleanup + feature bit

### DIFF
--- a/feature/deps.go
+++ b/feature/deps.go
@@ -94,6 +94,9 @@ var deps = depDesc{
 	lnwire.Bolt11BlindedPathsOptional: {
 		lnwire.RouteBlindingOptional: {},
 	},
+	lnwire.DynamicCommitmentsOptional: {
+		lnwire.QuiescenceOptional: {},
+	},
 }
 
 // ValidateDeps asserts that a feature vector sets all features and their

--- a/lnwire/dyn_ack.go
+++ b/lnwire/dyn_ack.go
@@ -3,35 +3,20 @@ package lnwire
 import (
 	"bytes"
 	"io"
-
-	"github.com/lightningnetwork/lnd/tlv"
-)
-
-const (
-	// DALocalMusig2Pubnonce is the TLV type number that identifies the
-	// musig2 public nonce that we need to verify the commitment transaction
-	// signature.
-	DALocalMusig2Pubnonce tlv.Type = 14
 )
 
 // DynAck is the message used to accept the parameters of a dynamic commitment
-// negotiation. Additional optional parameters will need to be present depending
-// on the details of the dynamic commitment upgrade.
+// negotiation. It carries the responder's acceptance signature over the
+// proposed parameters (see dyn_ack_sig.go).
 type DynAck struct {
 	// ChanID is the ChannelID of the channel that is currently undergoing
-	// a dynamic commitment negotiation
+	// a dynamic commitment negotiation.
 	ChanID ChannelID
 
 	// Sig is a signature that acknowledges and approves the parameters
-	// that were requested in the DynPropose
+	// that were requested in the DynPropose. See DynAckSigDigest for the
+	// exact signed payload.
 	Sig Sig
-
-	// LocalNonce is an optional field that is transmitted when accepting
-	// a dynamic commitment upgrade to Taproot Channels. This nonce will be
-	// used to verify the first commitment transaction signature. This will
-	// only be populated if the DynPropose we are responding to specifies
-	// taproot channels in the ChannelType field.
-	LocalNonce tlv.OptionalRecordT[tlv.TlvType14, Musig2Nonce]
 
 	// ExtraData is the set of data that was appended to this message to
 	// fill out the full maximum transport message size. These fields can
@@ -47,6 +32,10 @@ var _ Message = (*DynAck)(nil)
 // interface.
 var _ SizeableMessage = (*DynAck)(nil)
 
+// A compile time check to ensure DynAck implements the lnwire.LinkUpdater
+// interface.
+var _ LinkUpdater = (*DynAck)(nil)
+
 // Encode serializes the target DynAck into the passed io.Writer. Serialization
 // will observe the rules defined by the passed protocol version.
 //
@@ -60,27 +49,7 @@ func (da *DynAck) Encode(w *bytes.Buffer, _ uint32) error {
 		return err
 	}
 
-	// Create extra data records.
-	producers, err := da.ExtraData.RecordProducers()
-	if err != nil {
-		return err
-	}
-
-	// Append the known records.
-	da.LocalNonce.WhenSome(
-		func(rec tlv.RecordT[tlv.TlvType14, Musig2Nonce]) {
-			producers = append(producers, &rec)
-		},
-	)
-
-	// Encode all records.
-	var tlvData ExtraOpaqueData
-	err = tlvData.PackRecords(producers...)
-	if err != nil {
-		return err
-	}
-
-	return WriteBytes(w, tlvData)
+	return WriteBytes(w, da.ExtraData)
 }
 
 // Decode deserializes the serialized DynAck stored in the passed io.Reader into
@@ -90,32 +59,16 @@ func (da *DynAck) Encode(w *bytes.Buffer, _ uint32) error {
 // This is a part of the lnwire.Message interface.
 func (da *DynAck) Decode(r io.Reader, _ uint32) error {
 	// Parse out main message.
-	if err := ReadElements(r, &da.ChanID, &da.Sig); err != nil {
+	if err := ReadElements(
+		r, &da.ChanID, &da.Sig, &da.ExtraData,
+	); err != nil {
 		return err
 	}
 
-	// Parse out TLV records.
-	var tlvRecords ExtraOpaqueData
-	if err := ReadElement(r, &tlvRecords); err != nil {
-		return err
+	// This is required to pass the fuzz test round trip equality check.
+	if len(da.ExtraData) == 0 {
+		da.ExtraData = nil
 	}
-
-	// Parse all known records and extra data.
-	nonce := da.LocalNonce.Zero()
-	knownRecords, extraData, err := ParseAndExtractExtraData(
-		tlvRecords, &nonce,
-	)
-	if err != nil {
-		return err
-	}
-
-	// Check the results of the TLV Stream decoding and appropriately set
-	// message fields.
-	if _, ok := knownRecords[da.LocalNonce.TlvType()]; ok {
-		da.LocalNonce = tlv.SomeRecordT(nonce)
-	}
-
-	da.ExtraData = extraData
 
 	return nil
 }
@@ -133,4 +86,12 @@ func (da *DynAck) MsgType() MessageType {
 // This is part of the lnwire.SizeableMessage interface.
 func (da *DynAck) SerializedSize() (uint32, error) {
 	return MessageSerializedSize(da)
+}
+
+// TargetChanID returns the channel id of the link for which this message is
+// intended.
+//
+// NOTE: Part of peer.LinkUpdater interface.
+func (da *DynAck) TargetChanID() ChannelID {
+	return da.ChanID
 }

--- a/lnwire/dyn_ack_sig.go
+++ b/lnwire/dyn_ack_sig.go
@@ -1,0 +1,104 @@
+package lnwire
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+)
+
+// DynAckSigTag is the domain-separation tag that is prefixed to the payload
+// signed by a dyn_ack signature. It binds the signature to the dynamic
+// commitments protocol and this version of the signed message.
+const DynAckSigTag = "lightning-dynamic-commitments-dyn-ack-v1"
+
+var (
+	// ErrDynAckSigInvalid is returned when a dyn_ack signature does not
+	// verify against the expected payload and public key.
+	ErrDynAckSigInvalid = errors.New("dyn_ack signature invalid")
+
+	// ErrDynAckSigNotLowS is returned when a dyn_ack signature does not use
+	// a low-S value as required by the dynamic commitments extension BOLT.
+	ErrDynAckSigNotLowS = errors.New("dyn_ack signature is not low-S")
+)
+
+// DynAckSigDigest computes the digest that a dyn_ack signature covers. It is
+// the double-SHA256 of the domain-tagged payload:
+//
+//	DynAckSigTag ||
+//	chain_hash ||
+//	channel_id ||
+//	u64(next_commitment_number) ||
+//	dyn_propose_tlvs
+//
+// The nextCommitHeight is the next commitment number the responder expects to
+// receive from the proposer. The proposalTLVs is the exact encoded
+// dyn_propose_tlvs stream, i.e. the output of DynPropose.SerializeTlvData.
+func DynAckSigDigest(chainHash chainhash.Hash, chanID ChannelID,
+	nextCommitHeight uint64, proposalTLVs []byte) []byte {
+
+	var buf bytes.Buffer
+
+	// The tag is fixed length so no length prefix is required for domain
+	// separation.
+	buf.WriteString(DynAckSigTag)
+	buf.Write(chainHash[:])
+	buf.Write(chanID[:])
+
+	var height [8]byte
+	binary.BigEndian.PutUint64(height[:], nextCommitHeight)
+	buf.Write(height[:])
+
+	buf.Write(proposalTLVs)
+
+	return chainhash.DoubleHashB(buf.Bytes())
+}
+
+// SignDynAck produces the responder's dyn_ack signature over the accepted
+// proposal. The returned signature is a 64-byte low-S ECDSA signature (btcec's
+// ecdsa.Sign is deterministic and always produces a low-S value) that verifies
+// under the responder's node identity public key.
+func SignDynAck(priv *btcec.PrivateKey, chainHash chainhash.Hash,
+	chanID ChannelID, nextCommitHeight uint64,
+	proposalTLVs []byte) (Sig, error) {
+
+	digest := DynAckSigDigest(
+		chainHash, chanID, nextCommitHeight, proposalTLVs,
+	)
+
+	return NewSigFromSignature(ecdsa.Sign(priv, digest))
+}
+
+// VerifyDynAck verifies a dyn_ack signature against the accepted proposal under
+// the responder's node identity public key. It returns nil if the signature is
+// valid, ErrDynAckSigNotLowS if the signature is not low-S, or
+// ErrDynAckSigInvalid if the signature does not verify. Any decoding error is
+// returned directly.
+func VerifyDynAck(pub *btcec.PublicKey, sig Sig, chainHash chainhash.Hash,
+	chanID ChannelID, nextCommitHeight uint64, proposalTLVs []byte) error {
+
+	// The signature must use a low-S value. The S component occupies the
+	// second half of the fixed-size wire encoding.
+	var s btcec.ModNScalar
+	s.SetByteSlice(sig.bytes[32:64])
+	if s.IsOverHalfOrder() {
+		return ErrDynAckSigNotLowS
+	}
+
+	sigObj, err := sig.ToSignature()
+	if err != nil {
+		return err
+	}
+
+	digest := DynAckSigDigest(
+		chainHash, chanID, nextCommitHeight, proposalTLVs,
+	)
+	if !sigObj.Verify(digest, pub) {
+		return ErrDynAckSigInvalid
+	}
+
+	return nil
+}

--- a/lnwire/dyn_ack_sig_test.go
+++ b/lnwire/dyn_ack_sig_test.go
@@ -1,0 +1,107 @@
+package lnwire
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightningnetwork/lnd/tlv"
+	"github.com/stretchr/testify/require"
+)
+
+// dynAckTestProposal builds a DynPropose with a couple of parameters set and
+// returns the serialized dyn_propose_tlvs stream that a dyn_ack signature
+// covers.
+func dynAckTestProposal(t *testing.T, chanID ChannelID) []byte {
+	t.Helper()
+
+	dp := &DynPropose{ChanID: chanID}
+
+	var csvRec tlv.RecordT[tlv.TlvType4, uint16]
+	csvRec.Val = 144
+	dp.CsvDelay = tlv.SomeRecordT(csvRec)
+
+	var maxRec tlv.RecordT[tlv.TlvType5, uint16]
+	maxRec.Val = 30
+	dp.MaxAcceptedHTLCs = tlv.SomeRecordT(maxRec)
+
+	tlvData, err := dp.SerializeTlvData()
+	require.NoError(t, err)
+
+	return tlvData
+}
+
+// TestDynAckSignVerify checks the dyn_ack signature helper over both a freshly
+// signed signature and one that has round-tripped through the wire, plus the
+// relevant negative paths.
+func TestDynAckSignVerify(t *testing.T) {
+	t.Parallel()
+
+	priv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	pub := priv.PubKey()
+
+	var chainHash chainhash.Hash
+	copy(chainHash[:], bytes.Repeat([]byte{0xab}, 32))
+
+	var chanID ChannelID
+	copy(chanID[:], bytes.Repeat([]byte{0xcd}, 32))
+
+	const nextHeight uint64 = 42
+
+	tlvData := dynAckTestProposal(t, chanID)
+
+	// The digest must be deterministic for identical inputs.
+	require.Equal(t,
+		DynAckSigDigest(chainHash, chanID, nextHeight, tlvData),
+		DynAckSigDigest(chainHash, chanID, nextHeight, tlvData),
+	)
+
+	sig, err := SignDynAck(priv, chainHash, chanID, nextHeight, tlvData)
+	require.NoError(t, err)
+
+	// Positive: verifies under the signer's identity key.
+	require.NoError(t, VerifyDynAck(
+		pub, sig, chainHash, chanID, nextHeight, tlvData,
+	))
+
+	// The signature should still verify after a wire round trip through a
+	// DynAck message (which resets the sig type to ECDSA on decode).
+	ack := &DynAck{ChanID: chanID, Sig: sig}
+	w := new(bytes.Buffer)
+	require.NoError(t, ack.Encode(w, 0))
+
+	decoded := &DynAck{}
+	require.NoError(t, decoded.Decode(bytes.NewBuffer(w.Bytes()), 0))
+	require.NoError(t, VerifyDynAck(
+		pub, decoded.Sig, chainHash, chanID, nextHeight, tlvData,
+	))
+
+	// Negative: a different next commitment number must not verify.
+	require.ErrorIs(t, VerifyDynAck(
+		pub, sig, chainHash, chanID, nextHeight+1, tlvData,
+	), ErrDynAckSigInvalid)
+
+	// Negative: a different identity key must not verify.
+	otherPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	require.ErrorIs(t, VerifyDynAck(
+		otherPriv.PubKey(), sig, chainHash, chanID, nextHeight,
+		tlvData,
+	), ErrDynAckSigInvalid)
+
+	// Negative: tampered proposal TLVs must not verify.
+	tampered := append([]byte{}, tlvData...)
+	tampered[len(tampered)-1] ^= 0xff
+	require.ErrorIs(t, VerifyDynAck(
+		pub, sig, chainHash, chanID, nextHeight, tampered,
+	), ErrDynAckSigInvalid)
+
+	// Negative: a different chain hash must not verify.
+	var otherChain chainhash.Hash
+	copy(otherChain[:], bytes.Repeat([]byte{0x11}, 32))
+	require.ErrorIs(t, VerifyDynAck(
+		pub, sig, otherChain, chanID, nextHeight, tlvData,
+	), ErrDynAckSigInvalid)
+}

--- a/lnwire/dyn_ack_test.go
+++ b/lnwire/dyn_ack_test.go
@@ -9,7 +9,8 @@ import (
 )
 
 // TestDynAckEncodeDecode checks that the Encode and Decode methods for DynAck
-// work as expected.
+// work as expected. DynAck carries only a channel id and an acceptance
+// signature; any trailing bytes are opaque extra data.
 func TestDynAckEncodeDecode(t *testing.T) {
 	t.Parallel()
 
@@ -27,29 +28,8 @@ func TestDynAckEncodeDecode(t *testing.T) {
 	var sig Sig
 	copy(sig.bytes[:], sigBytes)
 
-	// Create test data for the TLVs. The actual value doesn't matter, as we
-	// only care about that the raw bytes can be decoded into a msg, and the
-	// msg can be encoded into the exact same raw bytes.
-	testTlvData := []byte{
-		// ExtraData - unknown tlv record.
-		//
-		// NOTE: This record is optional and occupies the type 1.
-		0x1,        // type.
-		0x2,        // length.
-		0x79, 0x79, // value.
-
-		// LocalNonce tlv.
-		0x14,                               // type.
-		0x42,                               // length.
-		0x2c, 0xd4, 0x53, 0x7d, 0xaa, 0x7b, // value.
-		0x7e, 0xae, 0x18, 0x32, 0xa6, 0xc4, 0x29, 0xe9, 0xe0, 0x91,
-		0x32, 0x7a, 0xaf, 0xd1, 0x1c, 0x2b, 0x04, 0xa0, 0x4d, 0xb5,
-		0x6a, 0x6f, 0x8b, 0x6c, 0xdc, 0xd1, 0x80, 0x2d, 0xff, 0x72,
-		0xd8, 0x3c, 0xfc, 0x01, 0x6e, 0x7c, 0x1a, 0xc8, 0x5e, 0x3a,
-		0x16, 0x98, 0xbc, 0x9b, 0x6e, 0x22, 0x58, 0x96, 0x96, 0xad,
-		0x88, 0xbf, 0xff, 0x59, 0x90, 0xbd, 0x36, 0x0b, 0x0b, 0x4d,
-
-		// ExtraData - unknown tlv.
+	// Trailing opaque extra data.
+	extraData := []byte{
 		0x6f,       // type.
 		0x2,        // length.
 		0x79, 0x79, // value.
@@ -57,20 +37,20 @@ func TestDynAckEncodeDecode(t *testing.T) {
 
 	msg := &DynAck{}
 
-	// Pre-allocate a new slice with enough capacity for all three parts for
-	// efficiency.
-	totalLen := len(chanIDBytes) + len(sigBytes) + len(testTlvData)
+	totalLen := len(chanIDBytes) + len(sigBytes) + len(extraData)
 	rawBytes := make([]byte, 0, totalLen)
 
-	// Append each slice to the new rawBytes slice.
 	rawBytes = append(rawBytes, chanIDBytes...)
 	rawBytes = append(rawBytes, sigBytes...)
-	rawBytes = append(rawBytes, testTlvData...)
+	rawBytes = append(rawBytes, extraData...)
 
 	// Decode the raw bytes.
 	r := bytes.NewBuffer(rawBytes)
 	err = msg.Decode(r, 0)
 	require.NoError(t, err)
+
+	require.Equal(t, chanID, msg.ChanID)
+	require.Equal(t, sig.bytes, msg.Sig.bytes)
 
 	t.Logf("Encoded msg is %v", lnutils.SpewLogClosure(msg))
 

--- a/lnwire/dyn_commit.go
+++ b/lnwire/dyn_commit.go
@@ -31,6 +31,18 @@ type DynCommit struct {
 	// across a reconnect.
 	AckSig Sig
 
+	// PartialSig is the musig2 extended partial signature (with the
+	// signer's public nonce) for the responder's next commitment. It is
+	// the partial_signature_with_nonce record (type 2) of the
+	// dyn_commit_sig_tlvs stream and is equivalent to the
+	// partial_signature_with_nonce TLV of commitment_signed.
+	//
+	// NOTE: This field is only populated for taproot (musig2) channels. In
+	// that case the CommitSig field above MUST be 64 zero bytes. For
+	// non-taproot channels this field MUST be absent and CommitSig carries
+	// the ECDSA commitment signature instead.
+	PartialSig OptPartialSigWithNonceTLV
+
 	// ExtraData is the set of data that was appended to this message to
 	// fill out the full maximum transport message size. These fields can
 	// be used to specify optional data such as custom TLV fields.
@@ -66,19 +78,47 @@ func (dc *DynCommit) Encode(w *bytes.Buffer, _ uint32) error {
 		return err
 	}
 
-	// Create extra data records.
+	// The accepted proposal parameters are serialized as a standalone,
+	// length-prefixed TLV stream (accepted_tlvs). This is the exact
+	// dyn_propose_tlvs byte stream the dyn_ack signature commits to, so it
+	// is kept separate from the dyn_commit_sig_tlvs stream below.
+	acceptedProducers, err := dc.DynPropose.ExtraData.RecordProducers()
+	if err != nil {
+		return err
+	}
+	acceptedProducers = append(
+		acceptedProducers, dynProposeRecords(&dc.DynPropose)...,
+	)
+
+	var acceptedTLVs ExtraOpaqueData
+	if err := acceptedTLVs.PackRecords(acceptedProducers...); err != nil {
+		return err
+	}
+
+	// Write the accepted_tlvs stream as a bigsize length prefix followed by
+	// the serialized records.
+	var buf [8]byte
+	err = tlv.WriteVarInt(w, uint64(len(acceptedTLVs)), &buf)
+	if err != nil {
+		return err
+	}
+	if err := WriteBytes(w, acceptedTLVs); err != nil {
+		return err
+	}
+
+	// Finally, encode the dyn_commit_sig_tlvs stream. For taproot channels
+	// this carries the partial_signature_with_nonce record (type 2). Any
+	// message-level extra data is appended here as well.
 	producers, err := dc.ExtraData.RecordProducers()
 	if err != nil {
 		return err
 	}
+	dc.PartialSig.WhenSome(func(sig PartialSigWithNonceTLV) {
+		producers = append(producers, &sig)
+	})
 
-	// Append the accepted proposal records.
-	producers = append(producers, dynProposeRecords(&dc.DynPropose)...)
-
-	// Encode all known records.
 	var tlvData ExtraOpaqueData
-	err = tlvData.PackRecords(producers...)
-	if err != nil {
+	if err := tlvData.PackRecords(producers...); err != nil {
 		return err
 	}
 
@@ -99,11 +139,19 @@ func (dc *DynCommit) Decode(r io.Reader, _ uint32) error {
 		return err
 	}
 
-	// Parse out TLV records.
-	var tlvRecords ExtraOpaqueData
-	if err := ReadElement(r, &tlvRecords); err != nil {
+	// Read the length-prefixed accepted proposal TLV stream
+	// (accepted_tlvs).
+	var buf [8]byte
+	acceptedLen, err := tlv.ReadVarInt(r, &buf)
+	if err != nil {
 		return err
 	}
+
+	acceptedBytes := make([]byte, acceptedLen)
+	if _, err := io.ReadFull(r, acceptedBytes); err != nil {
+		return err
+	}
+	acceptedTLVs := ExtraOpaqueData(acceptedBytes)
 
 	// Prepare receiving buffers to be filled by TLV extraction.
 	var dustLimit tlv.RecordT[tlv.TlvType0, tlv.BigSizeT[btcutil.Amount]]
@@ -114,9 +162,9 @@ func (dc *DynCommit) Decode(r io.Reader, _ uint32) error {
 	maxHtlcs := dc.MaxAcceptedHTLCs.Zero()
 	chanFlags := dc.ChannelFlags.Zero()
 
-	// Parse all known records and extra data.
-	knownRecords, extraData, err := ParseAndExtractExtraData(
-		tlvRecords, &dustLimit, &maxValue, &htlcMin, &reserve,
+	// Parse the accepted proposal records and any extra proposal data.
+	knownRecords, propExtra, err := ParseAndExtractExtraData(
+		acceptedTLVs, &dustLimit, &maxValue, &htlcMin, &reserve,
 		&csvDelay, &maxHtlcs, &chanFlags,
 	)
 	if err != nil {
@@ -145,6 +193,31 @@ func (dc *DynCommit) Decode(r io.Reader, _ uint32) error {
 	}
 	if _, ok := knownRecords[dc.ChannelFlags.TlvType()]; ok {
 		dc.ChannelFlags = tlv.SomeRecordT(chanFlags)
+	}
+
+	// Preserve any unknown records that were part of the accepted proposal
+	// so the accepted_tlvs stream round-trips faithfully.
+	if len(propExtra) > 0 {
+		dc.DynPropose.ExtraData = propExtra
+	}
+
+	// The remaining bytes form the dyn_commit_sig_tlvs stream, which may
+	// carry the partial_signature_with_nonce record (type 2) plus any
+	// message-level extra data.
+	var tlvRecords ExtraOpaqueData
+	if err := ReadElement(r, &tlvRecords); err != nil {
+		return err
+	}
+
+	partialSig := dc.PartialSig.Zero()
+	sigRecords, extraData, err := ParseAndExtractExtraData(
+		tlvRecords, &partialSig,
+	)
+	if err != nil {
+		return err
+	}
+	if _, ok := sigRecords[partialSig.TlvType()]; ok {
+		dc.PartialSig = tlv.SomeRecordT(partialSig)
 	}
 
 	dc.ExtraData = extraData

--- a/lnwire/dyn_commit.go
+++ b/lnwire/dyn_commit.go
@@ -8,16 +8,28 @@ import (
 	"github.com/lightningnetwork/lnd/tlv"
 )
 
-// DynCommit is a composite message that is used to irrefutably execute a
-// dynamic commitment update.
+// DynCommit is the message used to irrefutably execute a dynamic commitment
+// update. On the wire this is the dyn_commit_sig message. It bundles the
+// accepted proposal TLVs, the responder's dyn_ack acceptance signature, and the
+// proposer's commitment signature for the responder's next commitment. This
+// avoids a round trip and the race where a commitment signature is processed
+// before the dynamic update it commits.
 type DynCommit struct {
-	// DynPropose is an embedded version of the original DynPropose message
-	// that initiated this negotiation.
+	// DynPropose is an embedded version of the accepted DynPropose. It
+	// carries the channel id and the exact set of accepted proposal TLVs.
 	DynPropose
 
-	// DynAck is an embedded version of the original DynAck message that
-	// countersigned this negotiation.
-	DynAck
+	// CommitSig is the proposer's commitment signature for the responder's
+	// next commitment after applying the accepted proposal. It is
+	// equivalent to the signature field of commitment_signed. Since dynamic
+	// commitments require no HTLCs, there are no HTLC signatures.
+	CommitSig Sig
+
+	// AckSig is the responder's dyn_ack acceptance signature, echoed back
+	// so the responder can re-verify the accepted parameters and commitment
+	// number even if the pre-dyn_commit_sig negotiation state was forgotten
+	// across a reconnect.
+	AckSig Sig
 
 	// ExtraData is the set of data that was appended to this message to
 	// fill out the full maximum transport message size. These fields can
@@ -33,8 +45,12 @@ var _ Message = (*DynCommit)(nil)
 // lnwire.SizeableMessage interface.
 var _ SizeableMessage = (*DynCommit)(nil)
 
-// Encode serializes the target DynAck into the passed io.Writer. Serialization
-// will observe the rules defined by the passed protocol version.
+// A compile time check to ensure DynCommit implements the lnwire.LinkUpdater
+// interface. TargetChanID is promoted from the embedded DynPropose.
+var _ LinkUpdater = (*DynCommit)(nil)
+
+// Encode serializes the target DynCommit into the passed io.Writer.
+// Serialization will observe the rules defined by the passed protocol version.
 //
 // This is a part of the lnwire.Message interface.
 func (dc *DynCommit) Encode(w *bytes.Buffer, _ uint32) error {
@@ -42,7 +58,11 @@ func (dc *DynCommit) Encode(w *bytes.Buffer, _ uint32) error {
 		return err
 	}
 
-	if err := WriteSig(w, dc.Sig); err != nil {
+	if err := WriteSig(w, dc.CommitSig); err != nil {
+		return err
+	}
+
+	if err := WriteSig(w, dc.AckSig); err != nil {
 		return err
 	}
 
@@ -52,13 +72,8 @@ func (dc *DynCommit) Encode(w *bytes.Buffer, _ uint32) error {
 		return err
 	}
 
-	// Append the known records.
+	// Append the accepted proposal records.
 	producers = append(producers, dynProposeRecords(&dc.DynPropose)...)
-	dc.LocalNonce.WhenSome(
-		func(rec tlv.RecordT[tlv.TlvType14, Musig2Nonce]) {
-			producers = append(producers, &rec)
-		},
-	)
 
 	// Encode all known records.
 	var tlvData ExtraOpaqueData
@@ -71,16 +86,18 @@ func (dc *DynCommit) Encode(w *bytes.Buffer, _ uint32) error {
 }
 
 // Decode deserializes the serialized DynCommit stored in the passed io.Reader
-// into the target DynAck using the deserialization rules defined by the passed
-// protocol version.
+// into the target DynCommit using the deserialization rules defined by the
+// passed protocol version.
 //
 // This is a part of the lnwire.Message interface.
 func (dc *DynCommit) Decode(r io.Reader, _ uint32) error {
-	// Parse out main message.
-	if err := ReadElements(r, &dc.DynPropose.ChanID, &dc.Sig); err != nil {
+	// Parse out the required fields.
+	err := ReadElements(
+		r, &dc.DynPropose.ChanID, &dc.CommitSig, &dc.AckSig,
+	)
+	if err != nil {
 		return err
 	}
-	dc.DynAck.ChanID = dc.DynPropose.ChanID
 
 	// Parse out TLV records.
 	var tlvRecords ExtraOpaqueData
@@ -90,18 +107,17 @@ func (dc *DynCommit) Decode(r io.Reader, _ uint32) error {
 
 	// Prepare receiving buffers to be filled by TLV extraction.
 	var dustLimit tlv.RecordT[tlv.TlvType0, tlv.BigSizeT[btcutil.Amount]]
-	var maxValue tlv.RecordT[tlv.TlvType2, MilliSatoshi]
-	var htlcMin tlv.RecordT[tlv.TlvType4, MilliSatoshi]
-	var reserve tlv.RecordT[tlv.TlvType6, tlv.BigSizeT[btcutil.Amount]]
+	var maxValue tlv.RecordT[tlv.TlvType1, MilliSatoshi]
+	var htlcMin tlv.RecordT[tlv.TlvType2, MilliSatoshi]
+	var reserve tlv.RecordT[tlv.TlvType3, tlv.BigSizeT[btcutil.Amount]]
 	csvDelay := dc.CsvDelay.Zero()
 	maxHtlcs := dc.MaxAcceptedHTLCs.Zero()
-	chanType := dc.ChannelType.Zero()
-	nonce := dc.LocalNonce.Zero()
+	chanFlags := dc.ChannelFlags.Zero()
 
 	// Parse all known records and extra data.
 	knownRecords, extraData, err := ParseAndExtractExtraData(
 		tlvRecords, &dustLimit, &maxValue, &htlcMin, &reserve,
-		&csvDelay, &maxHtlcs, &chanType, &nonce,
+		&csvDelay, &maxHtlcs, &chanFlags,
 	)
 	if err != nil {
 		return err
@@ -127,11 +143,8 @@ func (dc *DynCommit) Decode(r io.Reader, _ uint32) error {
 	if _, ok := knownRecords[dc.MaxAcceptedHTLCs.TlvType()]; ok {
 		dc.MaxAcceptedHTLCs = tlv.SomeRecordT(maxHtlcs)
 	}
-	if _, ok := knownRecords[dc.ChannelType.TlvType()]; ok {
-		dc.ChannelType = tlv.SomeRecordT(chanType)
-	}
-	if _, ok := knownRecords[dc.LocalNonce.TlvType()]; ok {
-		dc.LocalNonce = tlv.SomeRecordT(nonce)
+	if _, ok := knownRecords[dc.ChannelFlags.TlvType()]; ok {
+		dc.ChannelFlags = tlv.SomeRecordT(chanFlags)
 	}
 
 	dc.ExtraData = extraData

--- a/lnwire/dyn_commit_test.go
+++ b/lnwire/dyn_commit_test.go
@@ -9,7 +9,8 @@ import (
 )
 
 // TestDynCommitEncodeDecode checks that the Encode and Decode methods for
-// DynCommit work as expected.
+// DynCommit (the wire dyn_commit_sig) work as expected. It bundles a commitment
+// signature, the responder's dyn_ack signature, and the accepted proposal TLVs.
 func TestDynCommitEncodeDecode(t *testing.T) {
 	t.Parallel()
 
@@ -20,68 +21,52 @@ func TestDynCommitEncodeDecode(t *testing.T) {
 	var chanID ChannelID
 	copy(chanID[:], chanIDBytes)
 
-	// Generate random sig.
-	sigBytes, err := generateRandomBytes(64)
+	// Generate two random sigs: the proposer's commitment sig and the
+	// responder's dyn_ack sig.
+	commitSigBytes, err := generateRandomBytes(64)
 	require.NoError(t, err)
 
-	var sig Sig
-	copy(sig.bytes[:], sigBytes)
+	ackSigBytes, err := generateRandomBytes(64)
+	require.NoError(t, err)
 
-	// Create test data for the TLVs. The actual value doesn't matter, as we
-	// only care about that the raw bytes can be decoded into a msg, and the
-	// msg can be encoded into the exact same raw bytes.
+	// Create test data for the accepted proposal TLVs.
 	testTlvData := []byte{
-		// DustLimit tlv.
+		// DustLimit tlv (type 0).
 		0x0,                        // type.
 		0x5,                        // length.
 		0xfe, 0x0, 0xf, 0x42, 0x40, // value (BigSize: 1_000_000).
 
-		// ExtraData - unknown tlv record.
-		//
-		// NOTE: This record is optional and occupies the type 1.
-		0x1,        // type.
-		0x2,        // length.
-		0x79, 0x79, // value.
+		// MaxValueInFlight tlv (type 1).
+		0x1,                        // type.
+		0x5,                        // length.
+		0xfe, 0x0, 0xf, 0x42, 0x40, // value (BigSize: 1_000_000).
 
-		// MaxValueInFlight tlv.
+		// HtlcMinimum tlv (type 2).
 		0x2,                        // type.
 		0x5,                        // length.
 		0xfe, 0x0, 0xf, 0x42, 0x40, // value (BigSize: 1_000_000).
 
-		// HtlcMinimum tlv.
-		0x4,                        // type.
-		0x5,                        // length.
-		0xfe, 0x0, 0xf, 0x42, 0x40, // value (BigSize: 1_000_000).
-		//
-		// ChannelReserve tlv.
-		0x6,                        // type.
+		// ChannelReserve tlv (type 3).
+		0x3,                        // type.
 		0x5,                        // length.
 		0xfe, 0x0, 0xf, 0x42, 0x40, // value (BigSize: 1_000_000).
 
-		// CsvDelay tlv.
-		0x8,      // type.
+		// CsvDelay tlv (type 4).
+		0x4,      // type.
 		0x2,      // length.
 		0x0, 0x8, // value.
 
-		// MaxAcceptedHTLCs tlv.
-		0xa,      // type.
+		// MaxAcceptedHTLCs tlv (type 5).
+		0x5,      // type.
 		0x2,      // length.
 		0x0, 0x8, // value.
 
-		// ChannelType tlv is empty.
-		//
-		// LocalNonce tlv.
-		0x14,                               // type.
-		0x42,                               // length.
-		0x2c, 0xd4, 0x53, 0x7d, 0xaa, 0x7b, // value.
-		0x7e, 0xae, 0x18, 0x32, 0xa6, 0xc4, 0x29, 0xe9, 0xe0, 0x91,
-		0x32, 0x7a, 0xaf, 0xd1, 0x1c, 0x2b, 0x04, 0xa0, 0x4d, 0xb5,
-		0x6a, 0x6f, 0x8b, 0x6c, 0xdc, 0xd1, 0x80, 0x2d, 0xff, 0x72,
-		0xd8, 0x3c, 0xfc, 0x01, 0x6e, 0x7c, 0x1a, 0xc8, 0x5e, 0x3a,
-		0x16, 0x98, 0xbc, 0x9b, 0x6e, 0x22, 0x58, 0x96, 0x96, 0xad,
-		0x88, 0xbf, 0xff, 0x59, 0x90, 0xbd, 0x36, 0x0b, 0x0b, 0x4d,
+		// ChannelFlags tlv (type 6).
+		0x6, // type.
+		0x1, // length.
+		0x1, // value (FFAnnounceChannel).
 
-		// ExtraData - unknown tlv record.
+		// ExtraData - unknown odd tlv record.
 		0x6f,       // type.
 		0x2,        // length.
 		0x79, 0x79, // value.
@@ -89,20 +74,26 @@ func TestDynCommitEncodeDecode(t *testing.T) {
 
 	msg := &DynCommit{}
 
-	// Pre-allocate a new slice with enough capacity for all three parts for
-	// efficiency.
-	totalLen := len(chanIDBytes) + len(sigBytes) + len(testTlvData)
+	totalLen := len(chanIDBytes) + len(commitSigBytes) +
+		len(ackSigBytes) + len(testTlvData)
 	rawBytes := make([]byte, 0, totalLen)
 
-	// Append each slice to the new rawBytes slice.
 	rawBytes = append(rawBytes, chanIDBytes...)
-	rawBytes = append(rawBytes, sigBytes...)
+	rawBytes = append(rawBytes, commitSigBytes...)
+	rawBytes = append(rawBytes, ackSigBytes...)
 	rawBytes = append(rawBytes, testTlvData...)
 
 	// Decode the raw bytes.
 	r := bytes.NewBuffer(rawBytes)
 	err = msg.Decode(r, 0)
 	require.NoError(t, err)
+
+	// The channel id, both sigs and the parameters should be populated.
+	require.Equal(t, chanID, msg.ChanID)
+	require.Equal(t, commitSigBytes, msg.CommitSig.bytes[:])
+	require.Equal(t, ackSigBytes, msg.AckSig.bytes[:])
+	require.True(t, msg.DustLimit.IsSome())
+	require.True(t, msg.ChannelFlags.IsSome())
 
 	t.Logf("Encoded msg is %v", lnutils.SpewLogClosure(msg))
 

--- a/lnwire/dyn_commit_test.go
+++ b/lnwire/dyn_commit_test.go
@@ -4,33 +4,16 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/lightningnetwork/lnd/lnutils"
+	"github.com/lightningnetwork/lnd/tlv"
 	"github.com/stretchr/testify/require"
 )
 
-// TestDynCommitEncodeDecode checks that the Encode and Decode methods for
-// DynCommit (the wire dyn_commit_sig) work as expected. It bundles a commitment
-// signature, the responder's dyn_ack signature, and the accepted proposal TLVs.
-func TestDynCommitEncodeDecode(t *testing.T) {
-	t.Parallel()
-
-	// Generate random channel ID.
-	chanIDBytes, err := generateRandomBytes(32)
-	require.NoError(t, err)
-
-	var chanID ChannelID
-	copy(chanID[:], chanIDBytes)
-
-	// Generate two random sigs: the proposer's commitment sig and the
-	// responder's dyn_ack sig.
-	commitSigBytes, err := generateRandomBytes(64)
-	require.NoError(t, err)
-
-	ackSigBytes, err := generateRandomBytes(64)
-	require.NoError(t, err)
-
-	// Create test data for the accepted proposal TLVs.
-	testTlvData := []byte{
+// acceptedProposalTlvs returns the serialized accepted_tlvs stream (the
+// dyn_propose_tlvs records for types 0 through 6) used by the DynCommit tests.
+func acceptedProposalTlvs() []byte {
+	return []byte{
 		// DustLimit tlv (type 0).
 		0x0,                        // type.
 		0x5,                        // length.
@@ -65,43 +48,147 @@ func TestDynCommitEncodeDecode(t *testing.T) {
 		0x6, // type.
 		0x1, // length.
 		0x1, // value (FFAnnounceChannel).
-
-		// ExtraData - unknown odd tlv record.
-		0x6f,       // type.
-		0x2,        // length.
-		0x79, 0x79, // value.
 	}
+}
 
-	msg := &DynCommit{}
+// TestDynCommitEncodeDecode checks that the Encode and Decode methods for
+// DynCommit (the wire dyn_commit_sig) round-trip correctly. It exercises both
+// the non-taproot form (an ECDSA commit_signature with no partial signature)
+// and the taproot form (a zeroed commit_signature plus a
+// partial_signature_with_nonce record in the dyn_commit_sig_tlvs stream).
+func TestDynCommitEncodeDecode(t *testing.T) {
+	t.Parallel()
 
-	totalLen := len(chanIDBytes) + len(commitSigBytes) +
-		len(ackSigBytes) + len(testTlvData)
-	rawBytes := make([]byte, 0, totalLen)
-
-	rawBytes = append(rawBytes, chanIDBytes...)
-	rawBytes = append(rawBytes, commitSigBytes...)
-	rawBytes = append(rawBytes, ackSigBytes...)
-	rawBytes = append(rawBytes, testTlvData...)
-
-	// Decode the raw bytes.
-	r := bytes.NewBuffer(rawBytes)
-	err = msg.Decode(r, 0)
+	// Generate a random channel ID.
+	chanIDBytes, err := generateRandomBytes(32)
 	require.NoError(t, err)
 
-	// The channel id, both sigs and the parameters should be populated.
-	require.Equal(t, chanID, msg.ChanID)
-	require.Equal(t, commitSigBytes, msg.CommitSig.bytes[:])
-	require.Equal(t, ackSigBytes, msg.AckSig.bytes[:])
-	require.True(t, msg.DustLimit.IsSome())
-	require.True(t, msg.ChannelFlags.IsSome())
+	var chanID ChannelID
+	copy(chanID[:], chanIDBytes)
 
-	t.Logf("Encoded msg is %v", lnutils.SpewLogClosure(msg))
-
-	// Encode the msg into raw bytes and assert the encoded bytes equal to
-	// the rawBytes.
-	w := new(bytes.Buffer)
-	err = msg.Encode(w, 0)
+	// Generate two random sigs: the proposer's commitment sig and the
+	// responder's dyn_ack sig.
+	commitSigBytes, err := generateRandomBytes(64)
 	require.NoError(t, err)
 
-	require.Equal(t, rawBytes, w.Bytes())
+	ackSigBytes, err := generateRandomBytes(64)
+	require.NoError(t, err)
+
+	// The non-taproot form omits the partial signature and carries an
+	// unknown odd record in the trailing dyn_commit_sig_tlvs stream to
+	// verify that message-level extra data round-trips.
+	t.Run("non-taproot", func(t *testing.T) {
+		t.Parallel()
+
+		acceptedTlvData := acceptedProposalTlvs()
+		require.Less(t, len(acceptedTlvData), 0xfd)
+
+		// The trailing dyn_commit_sig_tlvs stream, carrying just an
+		// unknown odd extra record (no partial signature).
+		trailingTlvData := []byte{
+			0x6f,       // type.
+			0x2,        // length.
+			0x79, 0x79, // value.
+		}
+
+		// Assemble the wire bytes: channel_id || commit_signature ||
+		// dyn_ack_signature || bigsize(accepted_tlvs_len) ||
+		// accepted_tlvs || dyn_commit_sig_tlvs.
+		rawBytes := make([]byte, 0)
+		rawBytes = append(rawBytes, chanIDBytes...)
+		rawBytes = append(rawBytes, commitSigBytes...)
+		rawBytes = append(rawBytes, ackSigBytes...)
+		rawBytes = append(rawBytes, byte(len(acceptedTlvData)))
+		rawBytes = append(rawBytes, acceptedTlvData...)
+		rawBytes = append(rawBytes, trailingTlvData...)
+
+		// Decode the raw bytes.
+		msg := &DynCommit{}
+		r := bytes.NewBuffer(rawBytes)
+		require.NoError(t, msg.Decode(r, 0))
+
+		// The channel id, both sigs and the proposal parameters should
+		// be populated, while the partial signature is absent.
+		require.Equal(t, chanID, msg.ChanID)
+		require.Equal(t, commitSigBytes, msg.CommitSig.bytes[:])
+		require.Equal(t, ackSigBytes, msg.AckSig.bytes[:])
+		require.True(t, msg.DustLimit.IsSome())
+		require.True(t, msg.ChannelFlags.IsSome())
+		require.True(t, msg.PartialSig.IsNone())
+
+		t.Logf("Encoded msg is %v", lnutils.SpewLogClosure(msg))
+
+		// Encoding the message again must reproduce the raw bytes.
+		w := new(bytes.Buffer)
+		require.NoError(t, msg.Encode(w, 0))
+		require.Equal(t, rawBytes, w.Bytes())
+	})
+
+	// The taproot form sets commit_signature to 64 zero bytes and includes
+	// the partial_signature_with_nonce record. We build the message from a
+	// struct and assert a full struct round-trip.
+	t.Run("taproot", func(t *testing.T) {
+		t.Parallel()
+
+		// Build a valid MuSig2 partial signature with nonce.
+		sig, err := NewSigFromSchnorrRawSignature(commitSigBytes)
+		require.NoError(t, err)
+
+		sigScalar := new(btcec.ModNScalar)
+		sigScalar.SetByteSlice(sig.RawBytes())
+
+		// Generate a valid MuSig2 nonce (two compressed public keys).
+		_, pub1 := btcec.PrivKeyFromBytes(chanIDBytes)
+		_, pub2 := btcec.PrivKeyFromBytes(commitSigBytes[:32])
+
+		var nonce Musig2Nonce
+		copy(nonce[:33], pub1.SerializeCompressed())
+		copy(nonce[33:], pub2.SerializeCompressed())
+
+		sigWithNonce := NewPartialSigWithNonce(nonce, *sigScalar)
+
+		// Assemble a taproot DynCommit: a zeroed commit_signature, the
+		// dyn_ack signature, an accepted proposal parameter, the
+		// partial signature, and an unknown extra record.
+		dp := DynPropose{ChanID: chanID}
+
+		csvDelay := dp.CsvDelay.Zero()
+		csvDelay.Val = 144
+		dp.CsvDelay = tlv.SomeRecordT(csvDelay)
+
+		var ackSig Sig
+		copy(ackSig.bytes[:], ackSigBytes)
+
+		msg := &DynCommit{
+			DynPropose: dp,
+			AckSig:     ackSig,
+			PartialSig: MaybePartialSigWithNonce(sigWithNonce),
+			ExtraData:  ExtraOpaqueData{0x6f, 0x2, 0x79, 0x79},
+		}
+
+		// The commit_signature MUST be all-zero for taproot channels.
+		require.Equal(t, Sig{}, msg.CommitSig)
+
+		// Encode, then decode into a fresh message.
+		w := new(bytes.Buffer)
+		require.NoError(t, msg.Encode(w, 0))
+
+		t.Logf("Encoded msg is %v", lnutils.SpewLogClosure(msg))
+
+		decoded := &DynCommit{}
+		require.NoError(
+			t, decoded.Decode(bytes.NewBuffer(w.Bytes()), 0),
+		)
+
+		// The decoded message must match the original, including the
+		// preserved partial signature.
+		require.Equal(t, msg, decoded)
+		require.True(t, decoded.PartialSig.IsSome())
+		require.Equal(t, Sig{}, decoded.CommitSig)
+		require.True(t, decoded.CsvDelay.IsSome())
+
+		decoded.PartialSig.WhenSomeV(func(p PartialSigWithNonce) {
+			require.Equal(t, nonce, p.Nonce)
+		})
+	})
 }

--- a/lnwire/dyn_propose.go
+++ b/lnwire/dyn_propose.go
@@ -9,7 +9,9 @@ import (
 )
 
 // DynPropose is a message that is sent during a dynamic commitments negotiation
-// process. It is sent by both parties to propose new channel parameters.
+// process. It is sent by the proposer to propose a new set of channel
+// parameters. The TLV type numbers follow the dyn_propose_tlvs stream defined
+// in the dynamic commitments extension BOLT.
 type DynPropose struct {
 	// ChanID identifies the channel whose parameters we are trying to
 	// re-negotiate.
@@ -23,29 +25,30 @@ type DynPropose struct {
 
 	// MaxValueInFlight, if not nil, proposes a change to the
 	// max_htlc_value_in_flight_msat limit of the sender.
-	MaxValueInFlight tlv.OptionalRecordT[tlv.TlvType2, MilliSatoshi]
+	MaxValueInFlight tlv.OptionalRecordT[tlv.TlvType1, MilliSatoshi]
 
 	// HtlcMinimum, if not nil, proposes a change to the htlc_minimum_msat
 	// floor of the sender.
-	HtlcMinimum tlv.OptionalRecordT[tlv.TlvType4, MilliSatoshi]
+	HtlcMinimum tlv.OptionalRecordT[tlv.TlvType2, MilliSatoshi]
 
 	// ChannelReserve, if not nil, proposes a change to the
 	// channel_reserve_satoshis requirement of the recipient.
 	ChannelReserve tlv.OptionalRecordT[
-		tlv.TlvType6, tlv.BigSizeT[btcutil.Amount],
+		tlv.TlvType3, tlv.BigSizeT[btcutil.Amount],
 	]
 
 	// CsvDelay, if not nil, proposes a change to the to_self_delay
 	// requirement of the recipient.
-	CsvDelay tlv.OptionalRecordT[tlv.TlvType8, uint16]
+	CsvDelay tlv.OptionalRecordT[tlv.TlvType4, uint16]
 
 	// MaxAcceptedHTLCs, if not nil, proposes a change to the
 	// max_accepted_htlcs limit of the sender.
-	MaxAcceptedHTLCs tlv.OptionalRecordT[tlv.TlvType10, uint16]
+	MaxAcceptedHTLCs tlv.OptionalRecordT[tlv.TlvType5, uint16]
 
-	// ChannelType, if not nil, proposes a change to the channel_type
-	// parameter.
-	ChannelType tlv.OptionalRecordT[tlv.TlvType12, ChannelType]
+	// ChannelFlags, if not nil, proposes a change to the channel_flags
+	// announcement intent for the channel. It uses the same bits as the
+	// channel_flags field of open_channel.
+	ChannelFlags tlv.OptionalRecordT[tlv.TlvType6, FundingFlag]
 
 	// ExtraData is the set of data that was appended to this message to
 	// fill out the full maximum transport message size. These fields can
@@ -64,6 +67,10 @@ var _ Message = (*DynPropose)(nil)
 // A compile time check to ensure DynPropose implements the
 // lnwire.SizeableMessage interface.
 var _ SizeableMessage = (*DynPropose)(nil)
+
+// A compile time check to ensure DynPropose implements the lnwire.LinkUpdater
+// interface.
+var _ LinkUpdater = (*DynPropose)(nil)
 
 // Encode serializes the target DynPropose into the passed io.Writer.
 // Serialization will observe the rules defined by the passed protocol version.
@@ -112,16 +119,16 @@ func (dp *DynPropose) Decode(r io.Reader, _ uint32) error {
 
 	// Prepare receiving buffers to be filled by TLV extraction.
 	var dustLimit tlv.RecordT[tlv.TlvType0, tlv.BigSizeT[btcutil.Amount]]
-	var maxValue tlv.RecordT[tlv.TlvType2, MilliSatoshi]
-	var htlcMin tlv.RecordT[tlv.TlvType4, MilliSatoshi]
-	var reserve tlv.RecordT[tlv.TlvType6, tlv.BigSizeT[btcutil.Amount]]
+	var maxValue tlv.RecordT[tlv.TlvType1, MilliSatoshi]
+	var htlcMin tlv.RecordT[tlv.TlvType2, MilliSatoshi]
+	var reserve tlv.RecordT[tlv.TlvType3, tlv.BigSizeT[btcutil.Amount]]
 	csvDelay := dp.CsvDelay.Zero()
 	maxHtlcs := dp.MaxAcceptedHTLCs.Zero()
-	chanType := dp.ChannelType.Zero()
+	chanFlags := dp.ChannelFlags.Zero()
 
 	knownRecords, extraData, err := ParseAndExtractExtraData(
 		tlvRecords, &dustLimit, &maxValue, &htlcMin, &reserve,
-		&csvDelay, &maxHtlcs, &chanType,
+		&csvDelay, &maxHtlcs, &chanFlags,
 	)
 	if err != nil {
 		return err
@@ -153,8 +160,8 @@ func (dp *DynPropose) Decode(r io.Reader, _ uint32) error {
 		dp.MaxAcceptedHTLCs = tlv.SomeRecordT(maxHtlcs)
 	}
 
-	if _, ok := knownRecords[dp.ChannelType.TlvType()]; ok {
-		dp.ChannelType = tlv.SomeRecordT(chanType)
+	if _, ok := knownRecords[dp.ChannelFlags.TlvType()]; ok {
+		dp.ChannelFlags = tlv.SomeRecordT(chanFlags)
 	}
 
 	dp.ExtraData = extraData
@@ -175,6 +182,14 @@ func (dp *DynPropose) MsgType() MessageType {
 // This is part of the lnwire.SizeableMessage interface.
 func (dp *DynPropose) SerializedSize() (uint32, error) {
 	return MessageSerializedSize(dp)
+}
+
+// TargetChanID returns the channel id of the link for which this message is
+// intended.
+//
+// NOTE: Part of peer.LinkUpdater interface.
+func (dp *DynPropose) TargetChanID() ChannelID {
+	return dp.ChanID
 }
 
 // SerializeTlvData takes just the TLV data of DynPropose (which covers all of
@@ -203,35 +218,35 @@ func dynProposeRecords(dp *DynPropose) []tlv.RecordProducer {
 		},
 	)
 	dp.MaxValueInFlight.WhenSome(
-		func(mvif tlv.RecordT[tlv.TlvType2, MilliSatoshi]) {
+		func(mvif tlv.RecordT[tlv.TlvType1, MilliSatoshi]) {
 			recordProducers = append(recordProducers, &mvif)
 		},
 	)
 	dp.HtlcMinimum.WhenSome(
-		func(hm tlv.RecordT[tlv.TlvType4, MilliSatoshi]) {
+		func(hm tlv.RecordT[tlv.TlvType2, MilliSatoshi]) {
 			recordProducers = append(recordProducers, &hm)
 		},
 	)
 	dp.ChannelReserve.WhenSome(
-		func(reserve tlv.RecordT[tlv.TlvType6,
+		func(reserve tlv.RecordT[tlv.TlvType3,
 			tlv.BigSizeT[btcutil.Amount]]) {
 
 			recordProducers = append(recordProducers, &reserve)
 		},
 	)
 	dp.CsvDelay.WhenSome(
-		func(wait tlv.RecordT[tlv.TlvType8, uint16]) {
+		func(wait tlv.RecordT[tlv.TlvType4, uint16]) {
 			recordProducers = append(recordProducers, &wait)
 		},
 	)
 	dp.MaxAcceptedHTLCs.WhenSome(
-		func(mah tlv.RecordT[tlv.TlvType10, uint16]) {
+		func(mah tlv.RecordT[tlv.TlvType5, uint16]) {
 			recordProducers = append(recordProducers, &mah)
 		},
 	)
-	dp.ChannelType.WhenSome(
-		func(ty tlv.RecordT[tlv.TlvType12, ChannelType]) {
-			recordProducers = append(recordProducers, &ty)
+	dp.ChannelFlags.WhenSome(
+		func(cf tlv.RecordT[tlv.TlvType6, FundingFlag]) {
+			recordProducers = append(recordProducers, &cf)
 		},
 	)
 

--- a/lnwire/dyn_propose_test.go
+++ b/lnwire/dyn_propose_test.go
@@ -8,7 +8,8 @@ import (
 )
 
 // TestDynProposeEncodeDecode checks that the Encode and Decode methods work as
-// expected.
+// expected. The raw bytes exercise the dyn_propose_tlvs numbering defined by
+// the dynamic commitments extension BOLT.
 func TestDynProposeEncodeDecode(t *testing.T) {
 	t.Parallel()
 
@@ -23,46 +24,42 @@ func TestDynProposeEncodeDecode(t *testing.T) {
 	// only care about that the raw bytes can be decoded into a msg, and the
 	// msg can be encoded into the exact same raw bytes.
 	testTlvData := []byte{
-		// DustLimit tlv.
+		// DustLimit tlv (type 0).
 		0x0,                        // type.
 		0x5,                        // length.
 		0xfe, 0x0, 0xf, 0x42, 0x40, // value (BigSize:  1_000_000).
 
-		// ExtraData - unknown tlv record.
-		//
-		// NOTE: This record is optional and occupies the type 1.
-		0x1,        // type.
-		0x2,        // length.
-		0x79, 0x79, // value.
+		// MaxValueInFlight tlv (type 1).
+		0x1,                        // type.
+		0x5,                        // length.
+		0xfe, 0x0, 0xf, 0x42, 0x40, // value (BigSize: 1_000_000).
 
-		// MaxValueInFlight tlv.
+		// HtlcMinimum tlv (type 2).
 		0x2,                        // type.
 		0x5,                        // length.
 		0xfe, 0x0, 0xf, 0x42, 0x40, // value (BigSize: 1_000_000).
 
-		// HtlcMinimum tlv.
-		0x4,                        // type.
-		0x5,                        // length.
-		0xfe, 0x0, 0xf, 0x42, 0x40, // value (BigSize: 1_000_000).
-		//
-		// ChannelReserve tlv.
-		0x6,                        // type.
+		// ChannelReserve tlv (type 3).
+		0x3,                        // type.
 		0x5,                        // length.
 		0xfe, 0x0, 0xf, 0x42, 0x40, // value (BigSize: 1_000_000).
 
-		// CsvDelay tlv.
-		0x8,      // type.
+		// CsvDelay tlv (type 4).
+		0x4,      // type.
 		0x2,      // length.
 		0x0, 0x8, // value.
 
-		// MaxAcceptedHTLCs tlv.
-		0xa,      // type.
+		// MaxAcceptedHTLCs tlv (type 5).
+		0x5,      // type.
 		0x2,      // length.
 		0x0, 0x8, // value.
 
-		// ChannelType tlv is empty.
-		//
-		// ExtraData - unknown tlv record.
+		// ChannelFlags tlv (type 6).
+		0x6, // type.
+		0x1, // length.
+		0x1, // value (FFAnnounceChannel).
+
+		// ExtraData - unknown odd tlv record.
 		0x6f,       // type.
 		0x2,        // length.
 		0x79, 0x79, // value.
@@ -77,6 +74,19 @@ func TestDynProposeEncodeDecode(t *testing.T) {
 	r := bytes.NewBuffer(rawBytes)
 	err = msg.Decode(r, 0)
 	require.NoError(t, err)
+
+	// Every known parameter should have been mapped to its field.
+	require.True(t, msg.DustLimit.IsSome())
+	require.True(t, msg.MaxValueInFlight.IsSome())
+	require.True(t, msg.HtlcMinimum.IsSome())
+	require.True(t, msg.ChannelReserve.IsSome())
+	require.True(t, msg.CsvDelay.IsSome())
+	require.True(t, msg.MaxAcceptedHTLCs.IsSome())
+	require.True(t, msg.ChannelFlags.IsSome())
+
+	// The channel flags should round trip to the announce bit.
+	flags := msg.ChannelFlags.UnwrapOrFailV(t)
+	require.Equal(t, FFAnnounceChannel, flags)
 
 	w := new(bytes.Buffer)
 	err = msg.Encode(w, 0)

--- a/lnwire/dyn_reject.go
+++ b/lnwire/dyn_reject.go
@@ -5,15 +5,59 @@ import (
 	"io"
 )
 
-// DynReject is a message that is sent during a dynamic commitments negotiation
-// process. It is sent by both parties to propose new channel parameters.
+// DynRejectBit is a bit position in the dyn_reject parameter_rejections
+// bitfield. It is a fixed enumeration that uses the same bit ordering as
+// feature vectors; it is NOT a feature bit and is NOT indexed by TLV type.
+//
+// Bit 0 is permanently reserved for unknown_or_unsupported_tlv. Bits 1-7 map to
+// the parameters defined by the dynamic commitments extension BOLT. Future
+// parameter rejection bits MUST be appended starting at bit 8, regardless of
+// the proposed parameter's TLV type.
+type DynRejectBit uint16
+
+const (
+	// DynRejectUnknownOrUnsupportedTLV is set to signal that the proposal
+	// contained an unknown or unsupported (odd) TLV type. This bit is
+	// permanently reserved.
+	DynRejectUnknownOrUnsupportedTLV DynRejectBit = 0
+
+	// DynRejectDustLimit rejects the proposed dust_limit_satoshis.
+	DynRejectDustLimit DynRejectBit = 1
+
+	// DynRejectMaxValueInFlight rejects the proposed
+	// max_htlc_value_in_flight_msat.
+	DynRejectMaxValueInFlight DynRejectBit = 2
+
+	// DynRejectHtlcMinimum rejects the proposed htlc_minimum_msat.
+	DynRejectHtlcMinimum DynRejectBit = 3
+
+	// DynRejectChannelReserve rejects the proposed
+	// channel_reserve_satoshis.
+	DynRejectChannelReserve DynRejectBit = 4
+
+	// DynRejectCsvDelay rejects the proposed to_self_delay.
+	DynRejectCsvDelay DynRejectBit = 5
+
+	// DynRejectMaxAcceptedHTLCs rejects the proposed max_accepted_htlcs.
+	DynRejectMaxAcceptedHTLCs DynRejectBit = 6
+
+	// DynRejectChannelFlags rejects the proposed channel_flags.
+	DynRejectChannelFlags DynRejectBit = 7
+)
+
+// DynReject is the message sent by the responder to reject a dyn_propose. It
+// carries a fixed-enumeration bitfield calling out which of the proposed
+// parameters are unacceptable. A zero-valued bitfield rejects the negotiation
+// without identifying specific parameters.
 type DynReject struct {
-	// ChanID identifies the channel whose parameters we are trying to
-	// re-negotiate.
+	// ChanID identifies the channel whose parameter re-negotiation is being
+	// rejected.
 	ChanID ChannelID
 
-	// UpdateRejections is a bit vector that specifies which of the
-	// DynPropose parameters we wish to call out as being unacceptable.
+	// UpdateRejections is the parameter_rejections bitfield. It uses the
+	// same bit ordering as feature vectors but is a fixed enumeration (see
+	// DynRejectBit), not a feature vector. Use SetRejection/IsRejected to
+	// manipulate the individual bits.
 	UpdateRejections RawFeatureVector
 
 	// ExtraData is the set of data that was appended to this message to
@@ -33,6 +77,40 @@ var _ Message = (*DynReject)(nil)
 // A compile time check to ensure DynReject implements the
 // lnwire.SizeableMessage interface.
 var _ SizeableMessage = (*DynReject)(nil)
+
+// A compile time check to ensure DynReject implements the lnwire.LinkUpdater
+// interface.
+var _ LinkUpdater = (*DynReject)(nil)
+
+// NewDynReject constructs a DynReject for the given channel with the provided
+// rejection bits set.
+func NewDynReject(chanID ChannelID, bits ...DynRejectBit) *DynReject {
+	dr := &DynReject{
+		ChanID:           chanID,
+		UpdateRejections: *NewRawFeatureVector(),
+	}
+	for _, bit := range bits {
+		dr.SetRejection(bit)
+	}
+
+	return dr
+}
+
+// SetRejection sets the given rejection bit in the parameter_rejections
+// bitfield.
+func (dr *DynReject) SetRejection(bit DynRejectBit) {
+	if dr.UpdateRejections.features == nil {
+		dr.UpdateRejections = *NewRawFeatureVector()
+	}
+
+	dr.UpdateRejections.Set(FeatureBit(bit))
+}
+
+// IsRejected returns true if the given rejection bit is set in the
+// parameter_rejections bitfield.
+func (dr *DynReject) IsRejected(bit DynRejectBit) bool {
+	return dr.UpdateRejections.IsSet(FeatureBit(bit))
+}
 
 // Encode serializes the target DynReject into the passed io.Writer.
 // Serialization will observe the rules defined by the passed protocol version.
@@ -84,4 +162,12 @@ func (dr *DynReject) MsgType() MessageType {
 // This is part of the lnwire.SizeableMessage interface.
 func (dr *DynReject) SerializedSize() (uint32, error) {
 	return MessageSerializedSize(dr)
+}
+
+// TargetChanID returns the channel id of the link for which this message is
+// intended.
+//
+// NOTE: Part of peer.LinkUpdater interface.
+func (dr *DynReject) TargetChanID() ChannelID {
+	return dr.ChanID
 }

--- a/lnwire/dyn_reject_test.go
+++ b/lnwire/dyn_reject_test.go
@@ -1,0 +1,77 @@
+package lnwire
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestDynRejectBitfield checks the parameter_rejections bitfield helpers and
+// that the encoding matches the bit ordering defined by the dynamic commitments
+// extension BOLT.
+func TestDynRejectBitfield(t *testing.T) {
+	t.Parallel()
+
+	chanIDBytes, err := generateRandomBytes(32)
+	require.NoError(t, err)
+
+	var chanID ChannelID
+	copy(chanID[:], chanIDBytes)
+
+	// Reject both dust_limit_satoshis (bit 1) and
+	// max_htlc_value_in_flight_msat (bit 2).
+	dr := NewDynReject(
+		chanID, DynRejectDustLimit, DynRejectMaxValueInFlight,
+	)
+
+	require.True(t, dr.IsRejected(DynRejectDustLimit))
+	require.True(t, dr.IsRejected(DynRejectMaxValueInFlight))
+	require.False(t, dr.IsRejected(DynRejectUnknownOrUnsupportedTLV))
+	require.False(t, dr.IsRejected(DynRejectChannelFlags))
+
+	// SetRejection should be additive.
+	dr.SetRejection(DynRejectChannelFlags)
+	require.True(t, dr.IsRejected(DynRejectChannelFlags))
+
+	// A freshly zero-valued DynReject must not panic on IsRejected and
+	// should report no rejections.
+	var zero DynReject
+	require.False(t, zero.IsRejected(DynRejectDustLimit))
+}
+
+// TestDynRejectEncodeDecode checks that the Encode and Decode methods for
+// DynReject round trip, and that the bitfield encoding matches the BOLT example
+// (rejecting dust_limit and max_htlc_value_in_flight is 0b00000110).
+func TestDynRejectEncodeDecode(t *testing.T) {
+	t.Parallel()
+
+	chanIDBytes, err := generateRandomBytes(32)
+	require.NoError(t, err)
+
+	var chanID ChannelID
+	copy(chanID[:], chanIDBytes)
+
+	dr := NewDynReject(
+		chanID, DynRejectDustLimit, DynRejectMaxValueInFlight,
+	)
+
+	w := new(bytes.Buffer)
+	require.NoError(t, dr.Encode(w, 0))
+
+	// The channel id is followed by the length-prefixed feature vector. The
+	// vector fits in a single byte equal to 0b00000110 = 0x06.
+	encoded := w.Bytes()
+	require.Equal(t, chanIDBytes, encoded[:32])
+	require.Equal(t, []byte{0x00, 0x01, 0x06}, encoded[32:35])
+
+	// Decode into a fresh message and assert the rejection bits survive the
+	// round trip.
+	decoded := &DynReject{}
+	require.NoError(t, decoded.Decode(bytes.NewBuffer(encoded), 0))
+
+	require.Equal(t, chanID, decoded.ChanID)
+	require.True(t, decoded.IsRejected(DynRejectDustLimit))
+	require.True(t, decoded.IsRejected(DynRejectMaxValueInFlight))
+	require.False(t, decoded.IsRejected(DynRejectChannelReserve))
+}

--- a/lnwire/features.go
+++ b/lnwire/features.go
@@ -325,6 +325,18 @@ const (
 	// that the node can forward onion messages.
 	OnionMessagesOptional = 39
 
+	// DynamicCommitmentsRequired is a required feature bit that signals
+	// that the node supports the dynamic commitments protocol, which allows
+	// re-negotiating channel parameters without a new funding transaction.
+	// It depends on option_quiesce.
+	DynamicCommitmentsRequired = 64
+
+	// DynamicCommitmentsOptional is an optional feature bit that signals
+	// that the node supports the dynamic commitments protocol, which allows
+	// re-negotiating channel parameters without a new funding transaction.
+	// It depends on option_quiesce.
+	DynamicCommitmentsOptional = 65
+
 	// MaxBolt11Feature is the maximum feature bit value allowed in bolt 11
 	// invoices.
 	//
@@ -405,6 +417,8 @@ var Features = map[FeatureBit]string{
 	RbfCoopCloseRequiredStaging:          "rbf-coop-close-x",
 	OnionMessagesOptional:                "onion-messages",
 	OnionMessagesRequired:                "onion-messages",
+	DynamicCommitmentsOptional:           "dynamic-commitments",
+	DynamicCommitmentsRequired:           "dynamic-commitments",
 }
 
 // RawFeatureVector represents a set of feature bits as defined in BOLT-09.  A

--- a/lnwire/open_channel.go
+++ b/lnwire/open_channel.go
@@ -21,6 +21,44 @@ const (
 	FFAnnounceChannel FundingFlag = 1 << iota
 )
 
+// Record returns a TLV record that can be used to encode/decode a FundingFlag
+// to/from a TLV stream. The flag is serialized as a single byte, matching the
+// channel_flags field of open_channel.
+func (f *FundingFlag) Record() tlv.Record {
+	return tlv.MakeStaticRecord(
+		0, f, 1, fundingFlagEncoder, fundingFlagDecoder,
+	)
+}
+
+// fundingFlagEncoder is a custom TLV encoder for the FundingFlag record.
+func fundingFlagEncoder(w io.Writer, val interface{}, buf *[8]byte) error {
+	if v, ok := val.(*FundingFlag); ok {
+		flag := uint8(*v)
+
+		return tlv.EUint8(w, &flag, buf)
+	}
+
+	return tlv.NewTypeForEncodingErr(val, "lnwire.FundingFlag")
+}
+
+// fundingFlagDecoder is a custom TLV decoder for the FundingFlag record.
+func fundingFlagDecoder(r io.Reader, val interface{}, buf *[8]byte,
+	l uint64) error {
+
+	if v, ok := val.(*FundingFlag); ok {
+		var flag uint8
+		if err := tlv.DUint8(r, &flag, buf, l); err != nil {
+			return err
+		}
+
+		*v = FundingFlag(flag)
+
+		return nil
+	}
+
+	return tlv.NewTypeForDecodingErr(val, "lnwire.FundingFlag", l, 1)
+}
+
 // OpenChannel is the message Alice sends to Bob if we should like to create a
 // channel with Bob where she's the sole provider of funds to the channel.
 // Single funder channels simplify the initial funding workflow, are supported

--- a/lnwire/test_message.go
+++ b/lnwire/test_message.go
@@ -960,26 +960,15 @@ var _ TestMessage = (*DynAck)(nil)
 func (da *DynAck) RandTestMessage(t *rapid.T) Message {
 	msg := &DynAck{
 		ChanID: RandChannelID(t),
+		Sig:    RandSignature(t),
 	}
 
-	includeLocalNonce := rapid.Bool().Draw(t, "includeLocalNonce")
-	if includeLocalNonce {
-		nonce := RandMusig2Nonce(t)
-		rec := tlv.NewRecordT[tlv.TlvType14](nonce)
-		msg.LocalNonce = tlv.SomeRecordT(rec)
+	// DynAck has no known TLV records; any trailing bytes are opaque extra
+	// data.
+	randData := RandExtraOpaqueData(t, nil)
+	if len(randData) > 0 {
+		msg.ExtraData = randData
 	}
-
-	// Create a tlv type lists to hold all known records which will be
-	// ignored when creating ExtraData records.
-	ignoreRecords := fn.NewSet[uint64]()
-	for i := range uint64(15) {
-		// Ignore known records.
-		if i%2 == 0 {
-			ignoreRecords.Add(i)
-		}
-	}
-
-	msg.ExtraData = RandExtraOpaqueData(t, ignoreRecords)
 
 	return msg
 }
@@ -1002,12 +991,13 @@ func (dp *DynPropose) RandTestMessage(t *rapid.T) Message {
 	includeMaxValueInFlight := rapid.Bool().Draw(
 		t, "includeMaxValueInFlight",
 	)
+	includeHtlcMinimum := rapid.Bool().Draw(t, "includeHtlcMinimum")
 	includeChannelReserve := rapid.Bool().Draw(t, "includeChannelReserve")
 	includeCsvDelay := rapid.Bool().Draw(t, "includeCsvDelay")
 	includeMaxAcceptedHTLCs := rapid.Bool().Draw(
 		t, "includeMaxAcceptedHTLCs",
 	)
-	includeChannelType := rapid.Bool().Draw(t, "includeChannelType")
+	includeChannelFlags := rapid.Bool().Draw(t, "includeChannelFlags")
 
 	// Generate random values for each included field
 	if includeDustLimit {
@@ -1018,14 +1008,21 @@ func (dp *DynPropose) RandTestMessage(t *rapid.T) Message {
 	}
 
 	if includeMaxValueInFlight {
-		var rec tlv.RecordT[tlv.TlvType2, MilliSatoshi]
+		var rec tlv.RecordT[tlv.TlvType1, MilliSatoshi]
 		val := MilliSatoshi(rapid.Uint64().Draw(t, "maxValueInFlight"))
 		rec.Val = val
 		msg.MaxValueInFlight = tlv.SomeRecordT(rec)
 	}
 
+	if includeHtlcMinimum {
+		var rec tlv.RecordT[tlv.TlvType2, MilliSatoshi]
+		val := MilliSatoshi(rapid.Uint64().Draw(t, "htlcMinimum"))
+		rec.Val = val
+		msg.HtlcMinimum = tlv.SomeRecordT(rec)
+	}
+
 	if includeChannelReserve {
-		var rec tlv.RecordT[tlv.TlvType6, tlv.BigSizeT[btcutil.Amount]]
+		var rec tlv.RecordT[tlv.TlvType3, tlv.BigSizeT[btcutil.Amount]]
 		val := btcutil.Amount(rapid.Uint32().Draw(t, "channelReserve"))
 		rec.Val = tlv.NewBigSizeT(val)
 		msg.ChannelReserve = tlv.SomeRecordT(rec)
@@ -1044,20 +1041,18 @@ func (dp *DynPropose) RandTestMessage(t *rapid.T) Message {
 		msg.MaxAcceptedHTLCs = tlv.SomeRecordT(maxHtlcs)
 	}
 
-	if includeChannelType {
-		chanType := msg.ChannelType.Zero()
-		chanType.Val = *RandChannelType(t)
-		msg.ChannelType = tlv.SomeRecordT(chanType)
+	if includeChannelFlags {
+		chanFlags := msg.ChannelFlags.Zero()
+		chanFlags.Val = FundingFlag(rapid.Byte().Draw(t, "channelFlags"))
+		msg.ChannelFlags = tlv.SomeRecordT(chanFlags)
 	}
 
-	// Create a tlv type lists to hold all known records which will be
-	// ignored when creating ExtraData records.
+	// Create a tlv type list to hold all known records, which will be
+	// ignored when creating ExtraData records. The known records occupy
+	// TLV types 0 through 6.
 	ignoreRecords := fn.NewSet[uint64]()
-	for i := range uint64(13) {
-		// Ignore known records.
-		if i%2 == 0 {
-			ignoreRecords.Add(i)
-		}
+	for i := range uint64(7) {
+		ignoreRecords.Add(i)
 	}
 
 	msg.ExtraData = RandExtraOpaqueData(t, ignoreRecords)
@@ -1110,10 +1105,6 @@ var _ TestMessage = (*DynCommit)(nil)
 func (dc *DynCommit) RandTestMessage(t *rapid.T) Message {
 	chanID := RandChannelID(t)
 
-	da := &DynAck{
-		ChanID: chanID,
-	}
-
 	dp := &DynPropose{
 		ChanID: chanID,
 	}
@@ -1123,12 +1114,13 @@ func (dc *DynCommit) RandTestMessage(t *rapid.T) Message {
 	includeMaxValueInFlight := rapid.Bool().Draw(
 		t, "includeMaxValueInFlight",
 	)
+	includeHtlcMinimum := rapid.Bool().Draw(t, "includeHtlcMinimum")
 	includeChannelReserve := rapid.Bool().Draw(t, "includeChannelReserve")
 	includeCsvDelay := rapid.Bool().Draw(t, "includeCsvDelay")
 	includeMaxAcceptedHTLCs := rapid.Bool().Draw(
 		t, "includeMaxAcceptedHTLCs",
 	)
-	includeChannelType := rapid.Bool().Draw(t, "includeChannelType")
+	includeChannelFlags := rapid.Bool().Draw(t, "includeChannelFlags")
 
 	// Generate random values for each included field
 	if includeDustLimit {
@@ -1139,14 +1131,21 @@ func (dc *DynCommit) RandTestMessage(t *rapid.T) Message {
 	}
 
 	if includeMaxValueInFlight {
-		var rec tlv.RecordT[tlv.TlvType2, MilliSatoshi]
+		var rec tlv.RecordT[tlv.TlvType1, MilliSatoshi]
 		val := MilliSatoshi(rapid.Uint64().Draw(t, "maxValueInFlight"))
 		rec.Val = val
 		dp.MaxValueInFlight = tlv.SomeRecordT(rec)
 	}
 
+	if includeHtlcMinimum {
+		var rec tlv.RecordT[tlv.TlvType2, MilliSatoshi]
+		val := MilliSatoshi(rapid.Uint64().Draw(t, "htlcMinimum"))
+		rec.Val = val
+		dp.HtlcMinimum = tlv.SomeRecordT(rec)
+	}
+
 	if includeChannelReserve {
-		var rec tlv.RecordT[tlv.TlvType6, tlv.BigSizeT[btcutil.Amount]]
+		var rec tlv.RecordT[tlv.TlvType3, tlv.BigSizeT[btcutil.Amount]]
 		val := btcutil.Amount(rapid.Uint32().Draw(t, "channelReserve"))
 		rec.Val = tlv.NewBigSizeT(val)
 		dp.ChannelReserve = tlv.SomeRecordT(rec)
@@ -1165,31 +1164,24 @@ func (dc *DynCommit) RandTestMessage(t *rapid.T) Message {
 		dp.MaxAcceptedHTLCs = tlv.SomeRecordT(maxHtlcs)
 	}
 
-	if includeChannelType {
-		chanType := dp.ChannelType.Zero()
-		chanType.Val = *RandChannelType(t)
-		dp.ChannelType = tlv.SomeRecordT(chanType)
+	if includeChannelFlags {
+		chanFlags := dp.ChannelFlags.Zero()
+		chanFlags.Val = FundingFlag(rapid.Byte().Draw(t, "channelFlags"))
+		dp.ChannelFlags = tlv.SomeRecordT(chanFlags)
 	}
 
-	includeLocalNonce := rapid.Bool().Draw(t, "includeLocalNonce")
-	if includeLocalNonce {
-		nonce := RandMusig2Nonce(t)
-		rec := tlv.NewRecordT[tlv.TlvType14](nonce)
-		da.LocalNonce = tlv.SomeRecordT(rec)
-	}
-
-	// Create a tlv type lists to hold all known records which will be
-	// ignored when creating ExtraData records.
+	// Create a tlv type list to hold all known records, which will be
+	// ignored when creating ExtraData records. The known records occupy
+	// TLV types 0 through 6.
 	ignoreRecords := fn.NewSet[uint64]()
-	for i := range uint64(15) {
-		// Ignore known records.
-		if i%2 == 0 {
-			ignoreRecords.Add(i)
-		}
+	for i := range uint64(7) {
+		ignoreRecords.Add(i)
 	}
+
 	msg := &DynCommit{
 		DynPropose: *dp,
-		DynAck:     *da,
+		CommitSig:  RandSignature(t),
+		AckSig:     RandSignature(t),
 	}
 
 	msg.ExtraData = RandExtraOpaqueData(t, ignoreRecords)

--- a/lnwire/test_message.go
+++ b/lnwire/test_message.go
@@ -1180,8 +1180,19 @@ func (dc *DynCommit) RandTestMessage(t *rapid.T) Message {
 
 	msg := &DynCommit{
 		DynPropose: *dp,
-		CommitSig:  RandSignature(t),
 		AckSig:     RandSignature(t),
+	}
+
+	// Randomly include the taproot partial signature. Per the spec, taproot
+	// channels set commit_signature to 64 zero bytes and include the
+	// partial_signature_with_nonce record; non-taproot channels carry the
+	// ECDSA commit_signature and omit the partial signature.
+	includePartialSig := rapid.Bool().Draw(t, "includePartialSig")
+	if includePartialSig {
+		sigWithNonce := RandPartialSigWithNonce(t)
+		msg.PartialSig = MaybePartialSigWithNonce(sigWithNonce)
+	} else {
+		msg.CommitSig = RandSignature(t)
 	}
 
 	msg.ExtraData = RandExtraOpaqueData(t, ignoreRecords)


### PR DESCRIPTION
Part of the Dynamic Commitments milestone: #60

`lnwire` cleanup + `option_dynamic_commitments` feature bit, incl. the taproot `partial_signature_with_nonce` TLV on `dyn_commit_sig`.

**Stacked PR** — based on `yy-dyn-0-adr`; review after that branch (the base updates automatically as the parent merges).

Opened as a **draft**: this is part of the exploratory params-only stack (coarse commits, not final hygiene).