### PR TITLE
channeldb: add commit-chain epoch history

### DIFF
--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -272,6 +272,13 @@ type openChannelTlvData struct {
 	// Note: if not set, it means either the channel has not been
 	// closed yet, or it was closed before this field was introduced.
 	closeConfirmationHeight tlv.OptionalRecordT[tlv.TlvType9, uint32]
+
+	// commitChainEpochHistory records the per-side history of the
+	// script/output-rendering commitment parameters (CSV and dust). It is
+	// only present once the channel has recorded at least one parameter
+	// change; when absent the history is defaulted at read time from the
+	// channel configs (see OpenChannel.amendTlvData).
+	commitChainEpochHistory tlv.OptionalRecordT[tlv.TlvType10, CommitChainEpochHistory] //nolint:ll
 }
 
 // encode serializes the openChannelTlvData to the given io.Writer.
@@ -299,6 +306,11 @@ func (c *openChannelTlvData) encode(w io.Writer) error {
 			tlvRecords = append(tlvRecords, h.Record())
 		},
 	)
+	c.commitChainEpochHistory.WhenSome(
+		func(h tlv.RecordT[tlv.TlvType10, CommitChainEpochHistory]) {
+			tlvRecords = append(tlvRecords, h.Record())
+		},
+	)
 
 	tlv.SortRecords(tlvRecords)
 
@@ -317,6 +329,7 @@ func (c *openChannelTlvData) decode(r io.Reader) error {
 	tapscriptRoot := c.tapscriptRoot.Zero()
 	blob := c.customBlob.Zero()
 	closeConfHeight := c.closeConfirmationHeight.Zero()
+	epochHistory := c.commitChainEpochHistory.Zero()
 
 	// Create the tlv stream.
 	tlvStream, err := tlv.NewStream(
@@ -329,6 +342,7 @@ func (c *openChannelTlvData) decode(r io.Reader) error {
 		blob.Record(),
 		c.confirmationHeight.Record(),
 		closeConfHeight.Record(),
+		epochHistory.Record(),
 	)
 	if err != nil {
 		return err
@@ -350,6 +364,9 @@ func (c *openChannelTlvData) decode(r io.Reader) error {
 	}
 	if _, ok := tlvs[closeConfHeight.TlvType()]; ok {
 		c.closeConfirmationHeight = tlv.SomeRecordT(closeConfHeight)
+	}
+	if _, ok := tlvs[epochHistory.TlvType()]; ok {
+		c.commitChainEpochHistory = tlv.SomeRecordT(epochHistory)
 	}
 
 	return nil
@@ -1051,6 +1068,16 @@ type OpenChannel struct {
 	// RemoteChanCfg is the channel configuration for the remote node.
 	RemoteChanCfg ChannelConfig
 
+	// CommitChainEpochHistory tracks, per side, the history of the
+	// script/output-rendering commitment parameters (CSV and dust) so that
+	// historical commitment and HTLC scripts can be reconstructed by their
+	// commitment height once dynamic commitments allow these parameters to
+	// change mid-channel. For channels that never renegotiate (and all
+	// channels persisted before this field existed) it is defaulted at read
+	// time to a single "epoch 0" per side derived from LocalChanCfg and
+	// RemoteChanCfg, and is only persisted once a change is recorded.
+	CommitChainEpochHistory CommitChainEpochHistory
+
 	// LocalCommitment is the current local commitment state for the local
 	// party. This is stored distinct from the state of the remote party
 	// as there are certain asymmetric parameters which affect the
@@ -1327,6 +1354,26 @@ func (c *OpenChannel) amendTlvData(auxData openChannelTlvData) {
 	auxData.closeConfirmationHeight.WhenSomeV(func(h uint32) {
 		c.CloseConfirmationHeight = fn.Some(h)
 	})
+
+	// The commit-chain epoch history is only persisted once a parameter
+	// change has been recorded. When absent (all channels persisted before
+	// this field existed, and freshly funded channels that have never
+	// renegotiated), synthesize a single "epoch 0" per side from the current
+	// channel configs, which covers all heights. This is a read-time default
+	// that avoids a destructive migration; the config reads are valid here
+	// because fetchChanInfo populates the channel configs before decoding the
+	// aux TLV data.
+	c.CommitChainEpochHistory = NewCommitChainEpochHistory(
+		lntypes.Dual[CommitmentParams]{
+			Local:  c.LocalChanCfg.CommitmentParams,
+			Remote: c.RemoteChanCfg.CommitmentParams,
+		},
+	)
+	auxData.commitChainEpochHistory.WhenSomeV(
+		func(h CommitChainEpochHistory) {
+			c.CommitChainEpochHistory = h
+		},
+	)
 }
 
 // extractTlvData creates a new openChannelTlvData from the given channel.
@@ -1370,7 +1417,68 @@ func (c *OpenChannel) extractTlvData() openChannelTlvData {
 		)
 	})
 
+	// Only persist the epoch history once it carries at least one closed
+	// epoch on either side. Until then the read-time default in amendTlvData
+	// reconstructs it from the channel configs, which keeps existing channels
+	// migration-free.
+	if len(c.CommitChainEpochHistory.Historical.Local) > 0 ||
+		len(c.CommitChainEpochHistory.Historical.Remote) > 0 {
+
+		auxData.commitChainEpochHistory = tlv.SomeRecordT(
+			tlv.NewRecordT[tlv.TlvType10](c.CommitChainEpochHistory),
+		)
+	}
+
 	return auxData
+}
+
+// CommitParamsForHeight returns the script/output-rendering commitment
+// parameters (CSV and dust) that were in effect for the given party's
+// commitment chain at the given commit height. It consults the channel's
+// per-side epoch history, falling back to the current parameters for heights
+// beyond all recorded epochs.
+func (c *OpenChannel) CommitParamsForHeight(party lntypes.ChannelParty,
+	height uint64) CommitmentParams {
+
+	c.RLock()
+	defer c.RUnlock()
+
+	return c.CommitChainEpochHistory.ParamsAt(party, height)
+}
+
+// PutCommitChainEpochHistory persists the given per-side commit-chain epoch
+// history for the channel, replacing any previously stored history. It is used
+// by the dynamic-commitments machinery to record a parameter change once it
+// locks in on each commitment chain.
+func (c *OpenChannel) PutCommitChainEpochHistory(
+	hist CommitChainEpochHistory) error {
+
+	c.Lock()
+	defer c.Unlock()
+
+	if err := kvdb.Update(c.Db.backend, func(tx kvdb.RwTx) error {
+		chanBucket, err := fetchChanBucketRw(
+			tx, c.IdentityPub, &c.FundingOutpoint, c.ChainHash,
+		)
+		if err != nil {
+			return err
+		}
+
+		channel, err := fetchOpenChannel(chanBucket, &c.FundingOutpoint)
+		if err != nil {
+			return err
+		}
+
+		channel.CommitChainEpochHistory = hist
+
+		return putOpenChannel(chanBucket, channel)
+	}, func() {}); err != nil {
+		return err
+	}
+
+	c.CommitChainEpochHistory = hist
+
+	return nil
 }
 
 // Refresh updates the in-memory channel state using the latest state observed

--- a/channeldb/channel_epochs.go
+++ b/channeldb/channel_epochs.go
@@ -1,0 +1,288 @@
+package channeldb
+
+import (
+	"io"
+
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+// Byte sizes of the fixed-width fields that make up a serialized
+// CommitChainEpochHistory. They are used by the TLV size function, which MUST
+// return the exact encoded length, and double as documentation of the wire
+// layout.
+const (
+	// commitmentParamsSize is the encoded size of a CommitmentParams: an
+	// 8-byte dust limit (btcutil.Amount serialized as a uint64) followed by
+	// a 2-byte CSV delay (uint16).
+	commitmentParamsSize = 8 + 2
+
+	// commitChainEpochSize is the encoded size of a CommitChainEpoch: an
+	// 8-byte last height (uint64) followed by the epoch's CommitmentParams.
+	commitChainEpochSize = 8 + commitmentParamsSize
+
+	// epochListLenSize is the size of the uint16 length prefix that
+	// precedes each per-side epoch list.
+	epochListLenSize = 2
+)
+
+// CommitChainEpoch refers to a single period of time during which a particular
+// set of commitment parameters were in effect on one commitment chain.
+type CommitChainEpoch struct {
+	// LastHeight is the last commit height, inclusive, that this epoch's
+	// parameters applied to on the commitment chain it belongs to.
+	LastHeight uint64
+
+	// Params are the script/output-rendering commitment parameters (CSV and
+	// dust) that were in effect for this epoch. They are "normalized" in the
+	// sense that they are the parameters that actually apply to the party's
+	// commitment transaction, irrespective of which party specified them.
+	Params CommitmentParams
+}
+
+// encode serializes a CommitChainEpoch to the given writer.
+func (c *CommitChainEpoch) encode(w io.Writer) error {
+	return WriteElements(
+		w, c.LastHeight, c.Params.DustLimit, c.Params.CsvDelay,
+	)
+}
+
+// decode deserializes a CommitChainEpoch from the given reader.
+func (c *CommitChainEpoch) decode(r io.Reader) error {
+	return ReadElements(
+		r, &c.LastHeight, &c.Params.DustLimit, &c.Params.CsvDelay,
+	)
+}
+
+// CommitChainEpochHistory maintains, per side, the history of the commitment
+// parameters that govern how each commitment chain's transactions and scripts
+// are rendered. The two commitment chains lock in new parameters at different
+// heights, so the history is tracked independently for each side via
+// lntypes.Dual.
+//
+// This is needed so that historical (revoked/old-height) commitment and HTLC
+// scripts can be reconstructed with the parameters that were actually in effect
+// at that height, rather than the current parameters, once dynamic commitments
+// allow those parameters to change mid-channel.
+type CommitChainEpochHistory struct {
+	// Current holds the commitment parameters presently in effect for each
+	// side. They are kept separate from Historical because the height that
+	// will eventually close them out is not yet known.
+	Current lntypes.Dual[CommitmentParams]
+
+	// Historical holds, for each side, the list of closed epochs sorted in
+	// ascending order by LastHeight.
+	Historical lntypes.Dual[[]CommitChainEpoch]
+}
+
+// NewCommitChainEpochHistory constructs a CommitChainEpochHistory whose current
+// parameters are the given per-side values and whose history is empty. This is
+// the state of every channel prior to its first parameter change, and is also
+// the read-time default synthesized for channels persisted before this field
+// existed (using their current channel configs).
+func NewCommitChainEpochHistory(
+	current lntypes.Dual[CommitmentParams]) CommitChainEpochHistory {
+
+	return CommitChainEpochHistory{
+		Current: current,
+	}
+}
+
+// ParamsAt returns the commitment parameters in effect for the given party's
+// commitment chain at the given commit height. It walks that side's historical
+// epochs for the first one that still covers the height, falling back to the
+// current parameters when the height is beyond all recorded epochs.
+func (c *CommitChainEpochHistory) ParamsAt(party lntypes.ChannelParty,
+	height uint64) CommitmentParams {
+
+	// Epochs are stored in ascending order by LastHeight, and are
+	// contiguous. The first epoch whose LastHeight is greater than or equal
+	// to the query height is therefore the one that encloses it, since the
+	// previous epoch's LastHeight is strictly less than the query height.
+	epochs := c.Historical.GetForParty(party)
+	for i := range epochs {
+		if height <= epochs[i].LastHeight {
+			return epochs[i].Params
+		}
+	}
+
+	// The height is newer than any closed epoch, so the current parameters
+	// apply.
+	return c.Current.GetForParty(party)
+}
+
+// RecordParamChange closes out the current epoch on both commitment chains and
+// installs a new set of current parameters reflecting a change made by the
+// whoSpecified party. The lockInHeights give the last height that the outgoing
+// parameters applied to on each chain (the local and remote chains lock in at
+// different heights).
+//
+// The change is normalized per BOLT semantics: a party's declared dust limit
+// governs its own commitment outputs, whereas the to_self_delay (CSV) it
+// declares is imposed on its counterparty's commitment. Concretely, the
+// specifying party's own dust limit is updated to params.DustLimit while its
+// CSV is carried over unchanged, and the counterparty's CSV is updated to
+// params.CsvDelay while its dust limit is carried over unchanged. Callers that
+// only intend to change one field must therefore pass the unchanged value for
+// the other.
+func (c *CommitChainEpochHistory) RecordParamChange(
+	whoSpecified lntypes.ChannelParty, params CommitmentParams,
+	lockInHeights lntypes.Dual[uint64]) {
+
+	// Close the outgoing epoch on both chains at their respective lock-in
+	// heights and append them to the per-side history.
+	c.Historical.Local = append(c.Historical.Local, CommitChainEpoch{
+		LastHeight: lockInHeights.Local,
+		Params:     c.Current.Local,
+	})
+	c.Historical.Remote = append(c.Historical.Remote, CommitChainEpoch{
+		LastHeight: lockInHeights.Remote,
+		Params:     c.Current.Remote,
+	})
+
+	// The specifying party keeps its old CSV (a CSV change it declares
+	// applies to its counterparty, not itself) but adopts the new dust
+	// limit.
+	counterParty := whoSpecified.CounterParty()
+	oldMain := c.Current.GetForParty(whoSpecified)
+	oldCounter := c.Current.GetForParty(counterParty)
+
+	c.Current.SetForParty(whoSpecified, CommitmentParams{
+		DustLimit: params.DustLimit,
+		CsvDelay:  oldMain.CsvDelay,
+	})
+
+	// The counterparty keeps its old dust limit but adopts the CSV imposed
+	// on it by the specifying party.
+	c.Current.SetForParty(counterParty, CommitmentParams{
+		DustLimit: oldCounter.DustLimit,
+		CsvDelay:  params.CsvDelay,
+	})
+}
+
+// Size returns the exact number of bytes that encode produces for this
+// CommitChainEpochHistory. It is used as the TLV size function, which must
+// match the encoded length exactly.
+//
+// NOTE: This is a part of the RecordProducer size contract.
+func (c *CommitChainEpochHistory) Size() uint64 {
+	numEpochs := uint64(
+		len(c.Historical.Local) + len(c.Historical.Remote),
+	)
+
+	// Two sets of current params, two per-side length prefixes, and one
+	// fixed-width entry per epoch.
+	return 2*commitmentParamsSize + 2*epochListLenSize +
+		numEpochs*commitChainEpochSize
+}
+
+// encode serializes a CommitChainEpochHistory to the given writer. The layout
+// is: the local then remote current params, followed by a
+// uint16-length-prefixed list of local epochs, then a uint16-length-prefixed
+// list of remote epochs.
+func (c *CommitChainEpochHistory) encode(w io.Writer) error {
+	err := WriteElements(
+		w, c.Current.Local.DustLimit, c.Current.Local.CsvDelay,
+		c.Current.Remote.DustLimit, c.Current.Remote.CsvDelay,
+	)
+	if err != nil {
+		return err
+	}
+
+	if err := encodeEpochList(w, c.Historical.Local); err != nil {
+		return err
+	}
+
+	return encodeEpochList(w, c.Historical.Remote)
+}
+
+// encodeEpochList writes a uint16 length prefix followed by each epoch in the
+// list.
+func encodeEpochList(w io.Writer, epochs []CommitChainEpoch) error {
+	if err := WriteElement(w, uint16(len(epochs))); err != nil {
+		return err
+	}
+
+	for i := range epochs {
+		if err := epochs[i].encode(w); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// decode deserializes a CommitChainEpochHistory from the given reader.
+func (c *CommitChainEpochHistory) decode(r io.Reader) error {
+	err := ReadElements(
+		r, &c.Current.Local.DustLimit, &c.Current.Local.CsvDelay,
+		&c.Current.Remote.DustLimit, &c.Current.Remote.CsvDelay,
+	)
+	if err != nil {
+		return err
+	}
+
+	c.Historical.Local, err = decodeEpochList(r)
+	if err != nil {
+		return err
+	}
+
+	c.Historical.Remote, err = decodeEpochList(r)
+
+	return err
+}
+
+// decodeEpochList reads a uint16 length prefix and then that many epochs.
+func decodeEpochList(r io.Reader) ([]CommitChainEpoch, error) {
+	var numEpochs uint16
+	if err := ReadElement(r, &numEpochs); err != nil {
+		return nil, err
+	}
+
+	if numEpochs == 0 {
+		return nil, nil
+	}
+
+	epochs := make([]CommitChainEpoch, numEpochs)
+	for i := range epochs {
+		if err := epochs[i].decode(r); err != nil {
+			return nil, err
+		}
+	}
+
+	return epochs, nil
+}
+
+// Record returns a TLV record that can be used to encode/decode a
+// CommitChainEpochHistory to/from a TLV stream.
+//
+// NOTE: This is a part of the RecordProducer interface.
+func (c *CommitChainEpochHistory) Record() tlv.Record {
+	return tlv.MakeDynamicRecord(
+		0, c, c.Size, eCommitChainEpochHistory,
+		dCommitChainEpochHistory,
+	)
+}
+
+// eCommitChainEpochHistory is a tlv.Encoder for CommitChainEpochHistory.
+func eCommitChainEpochHistory(w io.Writer, val interface{}, _ *[8]byte) error {
+	if hist, ok := val.(*CommitChainEpochHistory); ok {
+		return hist.encode(w)
+	}
+
+	return tlv.NewTypeForEncodingErr(val, "*CommitChainEpochHistory")
+}
+
+// dCommitChainEpochHistory is a tlv.Decoder for CommitChainEpochHistory.
+func dCommitChainEpochHistory(r io.Reader, val interface{}, _ *[8]byte,
+	l uint64) error {
+
+	if hist, ok := val.(*CommitChainEpochHistory); ok {
+		return hist.decode(r)
+	}
+
+	return tlv.NewTypeForDecodingErr(val, "*CommitChainEpochHistory", l, l)
+}
+
+// Assert that CommitChainEpochHistory implements the RecordProducer interface.
+var _ tlv.RecordProducer = (*CommitChainEpochHistory)(nil)

--- a/channeldb/channel_epochs_test.go
+++ b/channeldb/channel_epochs_test.go
@@ -1,0 +1,386 @@
+package channeldb
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/tlv"
+	"github.com/stretchr/testify/require"
+)
+
+// encodeDecodeEpochHistory round-trips a CommitChainEpochHistory through a TLV
+// stream using its Record() producer and returns the decoded value. It also
+// asserts that Size() exactly matches the number of encoded bytes, which is
+// required for the TLV length prefix to be correct.
+func encodeDecodeEpochHistory(t *testing.T,
+	hist CommitChainEpochHistory) CommitChainEpochHistory {
+
+	t.Helper()
+
+	// First, assert that the raw body encoding matches the advertised size.
+	var body bytes.Buffer
+	require.NoError(t, hist.encode(&body))
+	require.EqualValues(t, hist.Size(), body.Len(),
+		"Size() must match encoded body length")
+
+	// Now round-trip through a full TLV stream via the RecordProducer.
+	var buf bytes.Buffer
+	encStream, err := tlv.NewStream(hist.Record())
+	require.NoError(t, err)
+	require.NoError(t, encStream.Encode(&buf))
+
+	var decoded CommitChainEpochHistory
+	decStream, err := tlv.NewStream(decoded.Record())
+	require.NoError(t, err)
+	require.NoError(t, decStream.Decode(bytes.NewReader(buf.Bytes())))
+
+	return decoded
+}
+
+// TestCommitChainEpochHistoryEncodeDecode verifies that a
+// CommitChainEpochHistory survives a TLV encode/decode round-trip for the
+// empty, single-epoch, and multi-epoch cases across both sides.
+func TestCommitChainEpochHistoryEncodeDecode(t *testing.T) {
+	t.Parallel()
+
+	current := lntypes.Dual[CommitmentParams]{
+		Local:  CommitmentParams{DustLimit: 354, CsvDelay: 144},
+		Remote: CommitmentParams{DustLimit: 546, CsvDelay: 288},
+	}
+
+	testCases := []struct {
+		name string
+		hist CommitChainEpochHistory
+	}{
+		{
+			name: "empty history",
+			hist: NewCommitChainEpochHistory(current),
+		},
+		{
+			name: "local epochs only",
+			hist: CommitChainEpochHistory{
+				Current: current,
+				Historical: lntypes.Dual[[]CommitChainEpoch]{
+					Local: []CommitChainEpoch{
+						{
+							LastHeight: 10,
+							Params: CommitmentParams{
+								DustLimit: 330,
+								CsvDelay:  100,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multi-epoch both sides",
+			hist: CommitChainEpochHistory{
+				Current: current,
+				Historical: lntypes.Dual[[]CommitChainEpoch]{
+					Local: []CommitChainEpoch{
+						{
+							LastHeight: 5,
+							Params: CommitmentParams{
+								DustLimit: 300,
+								CsvDelay:  50,
+							},
+						},
+						{
+							LastHeight: 12,
+							Params: CommitmentParams{
+								DustLimit: 320,
+								CsvDelay:  75,
+							},
+						},
+					},
+					Remote: []CommitChainEpoch{
+						{
+							LastHeight: 7,
+							Params: CommitmentParams{
+								DustLimit: 400,
+								CsvDelay:  60,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			decoded := encodeDecodeEpochHistory(t, tc.hist)
+			require.Equal(t, tc.hist, decoded)
+		})
+	}
+}
+
+// TestCommitChainEpochHistoryParamsAt verifies that ParamsAt returns the
+// parameters in effect at a given height, treating epoch boundaries as
+// inclusive of the LastHeight and resolving each side independently.
+func TestCommitChainEpochHistoryParamsAt(t *testing.T) {
+	t.Parallel()
+
+	var (
+		localEpoch0 = CommitmentParams{DustLimit: 300, CsvDelay: 50}
+		localEpoch1 = CommitmentParams{DustLimit: 320, CsvDelay: 75}
+		localCurr   = CommitmentParams{DustLimit: 340, CsvDelay: 100}
+
+		remoteEpoch0 = CommitmentParams{DustLimit: 400, CsvDelay: 60}
+		remoteCurr   = CommitmentParams{DustLimit: 420, CsvDelay: 90}
+	)
+
+	hist := CommitChainEpochHistory{
+		Current: lntypes.Dual[CommitmentParams]{
+			Local:  localCurr,
+			Remote: remoteCurr,
+		},
+		Historical: lntypes.Dual[[]CommitChainEpoch]{
+			Local: []CommitChainEpoch{
+				{LastHeight: 5, Params: localEpoch0},
+				{LastHeight: 10, Params: localEpoch1},
+			},
+			Remote: []CommitChainEpoch{
+				{LastHeight: 7, Params: remoteEpoch0},
+			},
+		},
+	}
+
+	tests := []struct {
+		name   string
+		party  lntypes.ChannelParty
+		height uint64
+		want   CommitmentParams
+	}{
+		{
+			name:   "local at first epoch boundary",
+			party:  lntypes.Local,
+			height: 5,
+			want:   localEpoch0,
+		},
+		{
+			name:   "local within first epoch",
+			party:  lntypes.Local,
+			height: 3,
+			want:   localEpoch0,
+		},
+		{
+			name:   "local just past first boundary",
+			party:  lntypes.Local,
+			height: 6,
+			want:   localEpoch1,
+		},
+		{
+			name:   "local at second epoch boundary",
+			party:  lntypes.Local,
+			height: 10,
+			want:   localEpoch1,
+		},
+		{
+			name:   "local past all epochs uses current",
+			party:  lntypes.Local,
+			height: 11,
+			want:   localCurr,
+		},
+		{
+			name:   "remote within only epoch",
+			party:  lntypes.Remote,
+			height: 7,
+			want:   remoteEpoch0,
+		},
+		{
+			name:   "remote past epoch uses current",
+			party:  lntypes.Remote,
+			height: 8,
+			want:   remoteCurr,
+		},
+		{
+			name:   "remote independent of local boundary",
+			party:  lntypes.Remote,
+			height: 6,
+			want:   remoteEpoch0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := hist.ParamsAt(tc.party, tc.height)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestCommitChainEpochHistoryParamsAtEmpty verifies that when there is no
+// history, ParamsAt always resolves to the current parameters for the queried
+// side.
+func TestCommitChainEpochHistoryParamsAtEmpty(t *testing.T) {
+	t.Parallel()
+
+	current := lntypes.Dual[CommitmentParams]{
+		Local:  CommitmentParams{DustLimit: 354, CsvDelay: 144},
+		Remote: CommitmentParams{DustLimit: 546, CsvDelay: 288},
+	}
+	hist := NewCommitChainEpochHistory(current)
+
+	require.Equal(t, current.Local, hist.ParamsAt(lntypes.Local, 0))
+	require.Equal(t, current.Local, hist.ParamsAt(lntypes.Local, 9999))
+	require.Equal(t, current.Remote, hist.ParamsAt(lntypes.Remote, 42))
+}
+
+// TestCommitChainEpochHistoryRecordParamChange verifies that recording a
+// parameter change closes out the current epoch on both chains at the given
+// lock-in heights and normalizes the new current parameters correctly: the
+// specifying party's dust changes while its CSV carries over, and the
+// counterparty's CSV changes while its dust carries over.
+func TestCommitChainEpochHistoryRecordParamChange(t *testing.T) {
+	t.Parallel()
+
+	origLocal := CommitmentParams{DustLimit: 300, CsvDelay: 50}
+	origRemote := CommitmentParams{DustLimit: 400, CsvDelay: 60}
+
+	hist := NewCommitChainEpochHistory(lntypes.Dual[CommitmentParams]{
+		Local:  origLocal,
+		Remote: origRemote,
+	})
+
+	// The local party declares a change: a new dust limit for itself and a
+	// new to_self_delay that it imposes on the remote party.
+	newParams := CommitmentParams{DustLimit: 333, CsvDelay: 144}
+	lockIn := lntypes.Dual[uint64]{Local: 10, Remote: 12}
+	hist.RecordParamChange(lntypes.Local, newParams, lockIn)
+
+	// The outgoing epochs should be closed at their respective heights with
+	// the original parameters.
+	require.Equal(t, []CommitChainEpoch{
+		{LastHeight: 10, Params: origLocal},
+	}, hist.Historical.Local)
+	require.Equal(t, []CommitChainEpoch{
+		{LastHeight: 12, Params: origRemote},
+	}, hist.Historical.Remote)
+
+	// The specifying party (local) keeps its old CSV but takes the new dust.
+	require.Equal(t, CommitmentParams{
+		DustLimit: 333,
+		CsvDelay:  50,
+	}, hist.Current.Local)
+
+	// The counterparty (remote) keeps its old dust but takes the new CSV.
+	require.Equal(t, CommitmentParams{
+		DustLimit: 400,
+		CsvDelay:  144,
+	}, hist.Current.Remote)
+
+	// Lookups before and after the boundary should now differ per side.
+	require.Equal(t, origLocal, hist.ParamsAt(lntypes.Local, 10))
+	require.Equal(t, hist.Current.Local, hist.ParamsAt(lntypes.Local, 11))
+	require.Equal(t, origRemote, hist.ParamsAt(lntypes.Remote, 12))
+	require.Equal(t, hist.Current.Remote, hist.ParamsAt(lntypes.Remote, 13))
+
+	// A second change should stack onto the history and remain
+	// round-trippable through TLV.
+	hist.RecordParamChange(
+		lntypes.Remote,
+		CommitmentParams{DustLimit: 555, CsvDelay: 200},
+		lntypes.Dual[uint64]{Local: 20, Remote: 22},
+	)
+	require.Len(t, hist.Historical.Local, 2)
+	require.Len(t, hist.Historical.Remote, 2)
+
+	decoded := encodeDecodeEpochHistory(t, hist)
+	require.Equal(t, hist, decoded)
+}
+
+// TestOpenChannelCommitEpochHistoryDefault verifies that a channel persisted
+// without an epoch history (the read-time default path) is read back with a
+// single implicit "epoch 0" per side derived from its channel configs.
+func TestOpenChannelCommitEpochHistoryDefault(t *testing.T) {
+	t.Parallel()
+
+	fullDB, err := MakeTestDB(t)
+	require.NoError(t, err)
+
+	cdb := fullDB.ChannelStateDB()
+
+	state := createTestChannel(t, cdb)
+
+	openChannels, err := cdb.FetchOpenChannels(state.IdentityPub)
+	require.NoError(t, err)
+	fetched := openChannels[0]
+
+	// No epoch was ever recorded, so nothing is persisted; the history must
+	// be defaulted from the channel configs.
+	require.Empty(t, fetched.CommitChainEpochHistory.Historical.Local)
+	require.Empty(t, fetched.CommitChainEpochHistory.Historical.Remote)
+
+	require.Equal(
+		t, fetched.LocalChanCfg.CommitmentParams,
+		fetched.CommitParamsForHeight(lntypes.Local, 0),
+	)
+	require.Equal(
+		t, fetched.LocalChanCfg.CommitmentParams,
+		fetched.CommitParamsForHeight(lntypes.Local, 123456),
+	)
+	require.Equal(
+		t, fetched.RemoteChanCfg.CommitmentParams,
+		fetched.CommitParamsForHeight(lntypes.Remote, 999),
+	)
+}
+
+// TestOpenChannelCommitEpochHistoryPersistence verifies that a recorded
+// parameter change is persisted as an optional TLV and survives a fetch, with
+// historical lookups returning the pre-change parameters.
+func TestOpenChannelCommitEpochHistoryPersistence(t *testing.T) {
+	t.Parallel()
+
+	fullDB, err := MakeTestDB(t)
+	require.NoError(t, err)
+
+	cdb := fullDB.ChannelStateDB()
+
+	state := createTestChannel(t, cdb)
+
+	// Capture the original per-side params so we can assert on them after
+	// the change is recorded.
+	origLocal := state.LocalChanCfg.CommitmentParams
+	origRemote := state.RemoteChanCfg.CommitmentParams
+
+	// Record a change on the local side and persist it.
+	hist := state.CommitChainEpochHistory
+	newParams := CommitmentParams{
+		DustLimit: origLocal.DustLimit + btcutil.Amount(11),
+		CsvDelay:  origRemote.CsvDelay + 7,
+	}
+	hist.RecordParamChange(
+		lntypes.Local, newParams,
+		lntypes.Dual[uint64]{Local: 100, Remote: 200},
+	)
+	require.NoError(t, state.PutCommitChainEpochHistory(hist))
+
+	// Re-fetch from disk and confirm the history was persisted verbatim.
+	openChannels, err := cdb.FetchOpenChannels(state.IdentityPub)
+	require.NoError(t, err)
+	fetched := openChannels[0]
+
+	require.Equal(t, hist, fetched.CommitChainEpochHistory)
+
+	// Historical lookups by height should now return the pre-change params
+	// before the boundary and the new params after it, per side.
+	require.Equal(
+		t, origLocal, fetched.CommitParamsForHeight(lntypes.Local, 100),
+	)
+	require.Equal(
+		t, hist.Current.Local,
+		fetched.CommitParamsForHeight(lntypes.Local, 101),
+	)
+	require.Equal(
+		t, origRemote,
+		fetched.CommitParamsForHeight(lntypes.Remote, 200),
+	)
+	require.Equal(
+		t, hist.Current.Remote,
+		fetched.CommitParamsForHeight(lntypes.Remote, 201),
+	)
+}

--- a/channeldb/channel_test.go
+++ b/channeldb/channel_test.go
@@ -376,16 +376,22 @@ func createTestChannelState(t *testing.T, cdb *ChannelStateDB) *OpenChannel {
 	copy(tapscriptRoot[:], bytes.Repeat([]byte{1}, 32))
 
 	return &OpenChannel{
-		ChanType:          SingleFunderBit | FrozenBit,
-		ChainHash:         key,
-		FundingOutpoint:   op,
-		ShortChannelID:    chanID,
-		IsInitiator:       true,
-		IsPending:         true,
-		IdentityPub:       pubKey,
-		Capacity:          btcutil.Amount(10000),
-		LocalChanCfg:      localCfg,
-		RemoteChanCfg:     remoteCfg,
+		ChanType:        SingleFunderBit | FrozenBit,
+		ChainHash:       key,
+		FundingOutpoint: op,
+		ShortChannelID:  chanID,
+		IsInitiator:     true,
+		IsPending:       true,
+		IdentityPub:     pubKey,
+		Capacity:        btcutil.Amount(10000),
+		LocalChanCfg:    localCfg,
+		RemoteChanCfg:   remoteCfg,
+		CommitChainEpochHistory: NewCommitChainEpochHistory(
+			lntypes.Dual[CommitmentParams]{
+				Local:  localRenderingParams,
+				Remote: remoteRenderingParams,
+			},
+		),
 		TotalMSatSent:     8,
 		TotalMSatReceived: 2,
 		LocalCommitment: ChannelCommitment{


### PR DESCRIPTION
Part of the Dynamic Commitments milestone: #60

Per-side commit-chain epoch history in `channeldb` (CSV/dust).

**Stacked PR** — based on `yy-dyn-1-wire`; review after that branch (the base updates automatically as the parent merges).

Opened as a **draft**: this is part of the exploratory params-only stack (coarse commits, not final hygiene).