### PR TITLE
lnwallet: historical params for breach recovery

### DIFF
--- a/contractcourt/breach_arbitrator_test.go
+++ b/contractcourt/breach_arbitrator_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/lightningnetwork/lnd/lntest/channels"
 	"github.com/lightningnetwork/lnd/lntest/mock"
 	"github.com/lightningnetwork/lnd/lntest/wait"
+	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -2322,6 +2323,15 @@ func createInitChannels(t *testing.T) (
 		Db:                      dbAlice.ChannelStateDB(),
 		Packager:                channeldb.NewChannelPackager(shortChanID),
 		FundingTxn:              channels.TestFundingTx,
+		// Mirror the read-time default synthesized by fetchOpenChannel
+		// so historical-parameter lookups behave as on a disk-loaded
+		// channel (see lnwallet breach recovery).
+		CommitChainEpochHistory: channeldb.NewCommitChainEpochHistory(
+			lntypes.Dual[channeldb.CommitmentParams]{
+				Local:  aliceCfg.CommitmentParams,
+				Remote: bobCfg.CommitmentParams,
+			},
+		),
 	}
 	bobChannelState := &channeldb.OpenChannel{
 		LocalChanCfg:            bobCfg,
@@ -2339,6 +2349,12 @@ func createInitChannels(t *testing.T) (
 		RemoteCommitment:        bobCommit,
 		Db:                      dbBob.ChannelStateDB(),
 		Packager:                channeldb.NewChannelPackager(shortChanID),
+		CommitChainEpochHistory: channeldb.NewCommitChainEpochHistory(
+			lntypes.Dual[channeldb.CommitmentParams]{
+				Local:  bobCfg.CommitmentParams,
+				Remote: aliceCfg.CommitmentParams,
+			},
+		),
 	}
 
 	aliceSigner := input.NewMockSigner(

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -2086,6 +2086,42 @@ type BreachRetribution struct {
 	ChanType channeldb.ChannelType
 }
 
+// Dynamic-commitments historical-parameter audit (PR 1.3)
+// ------------------------------------------------------
+// Once dynamic commitments allow CSV/dust to change mid-channel, any path
+// that reconstructs a *historical* (revoked/old-height) commitment or HTLC
+// script must use the parameters that were in effect at that height, not the
+// live config, or it will build the wrong witness script. The classification
+// of every CSV/dust read in lnwallet (commitment.go + channel.go) is:
+//
+//   HISTORICAL (fixed to look up the per-side epoch history by height):
+//     - NewBreachRetribution: CSV for the revoked remote to_local, plus
+//       dust to gate the output sweep descriptors.
+//     - createHtlcRetribution: CSV for the revoked remote 2nd-level script.
+//     - createBreachRetributionLegacy: dust to re-trim the revoked HTLC set.
+//     - findOutputIndexesFromRemote: CSV for the remote commitment being
+//       moved into the revocation log.
+//   These reconstruct the *remote* commitment chain at an arbitrary past
+//   height, so they query CommitParamsForHeight(lntypes.Remote, height).
+//
+//   CURRENT/latest state (live config is correct; audited, left as-is):
+//     - CreateCommitTx / genRemoteHtlcSigJobs / genHtlcSigValidationJobs
+//       build or validate the *new* commitment in an active state
+//       transition.
+//     - NewLocalForceCloseSummary / extractHtlcResolutions resolve the
+//       *latest* broadcastable commitment (a force close only ever spends
+//       the current tip; an old state would be a self-breach), so current
+//       config == the params of the state being resolved.
+//
+// ChanType reads are left untouched: channel-type transitions are out of
+// scope for the params-only milestone, so the type never changes. CSV is the
+// hard requirement (it is embedded directly in the reconstructed witness
+// scripts); the historical dust limit is additionally consulted where a dust
+// comparison gates output *presence* on the revoked commitment, so a later
+// dust-limit increase can't strand an output that legitimately existed at
+// the revoked height. Both CSV and dust already live in the epoch history, so
+// the revocation-log on-disk format is unchanged.
+
 // NewBreachRetribution creates a new fully populated BreachRetribution for the
 // passed channel, at a particular revoked state number. If the spend
 // transaction that the breach retribution should target is known, then it can
@@ -2170,7 +2206,21 @@ func NewBreachRetribution(chanState *channeldb.OpenChannel, stateNum uint64,
 			return l.LocalAuxLeaf
 		},
 	)(auxResult.AuxLeaves)
-	theirDelay := uint32(chanState.RemoteChanCfg.CsvDelay)
+	// A breach is the remote party broadcasting one of their own revoked
+	// commitment transactions, so the to_local (and HTLC second-level)
+	// delay we must reconstruct is the CSV imposed on the *remote*
+	// commitment chain at the revoked state's height. Consult the per-side
+	// epoch history rather than the live config: with dynamic commitments
+	// the live CSV may have changed since this revoked state, and rebuilding
+	// with it would yield an unspendable justice tx. The historical dust
+	// limit is looked up alongside it (used below to gate the sweep
+	// descriptors) so that an output that was above dust at the revoked
+	// height is still swept even if the current dust limit was later raised
+	// above it. For channels without epoch history (pre-dyn, or never
+	// updated) this returns the current RemoteChanCfg params, matching
+	// legacy behavior exactly.
+	remoteParams := chanState.CommitParamsForHeight(lntypes.Remote, stateNum)
+	theirDelay := uint32(remoteParams.CsvDelay)
 	theirScript, err := CommitScriptToSelf(
 		chanState.ChanType, isRemoteInitiator, keyRing.ToLocalKey,
 		keyRing.RevocationKey, theirDelay, leaseExpiry, localAuxLeaf,
@@ -2191,7 +2241,8 @@ func NewBreachRetribution(chanState *channeldb.OpenChannel, stateNum uint64,
 	if revokedLog != nil {
 		br, ourAmt, theirAmt, err = createBreachRetribution(
 			revokedLog, spendTx, chanState, keyRing,
-			commitmentSecret, leaseExpiry, auxResult.AuxLeaves,
+			commitmentSecret, leaseExpiry, theirDelay,
+			auxResult.AuxLeaves,
 		)
 		if err != nil {
 			return nil, err
@@ -2206,7 +2257,8 @@ func NewBreachRetribution(chanState *channeldb.OpenChannel, stateNum uint64,
 		// are confident that no legacy format is in use.
 		br, ourAmt, theirAmt, err = createBreachRetributionLegacy(
 			revokedLogLegacy, chanState, keyRing, commitmentSecret,
-			ourScript, theirScript, leaseExpiry,
+			ourScript, theirScript, leaseExpiry, theirDelay,
+			remoteParams.DustLimit,
 		)
 		if err != nil {
 			return nil, err
@@ -2218,8 +2270,12 @@ func NewBreachRetribution(chanState *channeldb.OpenChannel, stateNum uint64,
 	// party's dust limit, the respective sign descriptor will be nil.
 	//
 	// If our balance exceeds the remote party's dust limit, instantiate
-	// the sign descriptor for our output.
-	if ourAmt >= int64(chanState.RemoteChanCfg.DustLimit) {
+	// the sign descriptor for our output. We use the dust limit that was in
+	// effect for the remote commitment at the revoked height (see
+	// remoteParams above) rather than the live one, so a later dust-limit
+	// increase can't cause us to skip sweeping an output that legitimately
+	// exists on this revoked commitment.
+	if ourAmt >= int64(remoteParams.DustLimit) {
 		// As we're about to sweep our own output w/o a delay, we'll
 		// obtain the witness script for the success/delay path.
 		witnessScript, err := ourScript.WitnessScriptForPath(
@@ -2299,8 +2355,10 @@ func NewBreachRetribution(chanState *channeldb.OpenChannel, stateNum uint64,
 	}
 
 	// Similarly, if their balance exceeds the remote party's dust limit,
-	// assemble the sign descriptor for their output, which we can sweep.
-	if theirAmt >= int64(chanState.RemoteChanCfg.DustLimit) {
+	// assemble the sign descriptor for their output, which we can sweep. As
+	// above, we compare against the historical dust limit for this revoked
+	// height rather than the live one.
+	if theirAmt >= int64(remoteParams.DustLimit) {
 		// As we're trying to defend the channel against a breach
 		// attempt from the remote party, we want to obain the
 		// revocation witness script here.
@@ -2392,16 +2450,19 @@ func NewBreachRetribution(chanState *channeldb.OpenChannel, stateNum uint64,
 }
 
 // createHtlcRetribution is a helper function to construct an HtlcRetribution
-// based on the passed params.
+// based on the passed params. The theirDelay argument is the CSV delay that
+// governed the remote commitment chain at the revoked state's height (looked
+// up from the epoch history by the caller). It is used for the second-level
+// HTLC script rather than the live config, so historical breach scripts stay
+// correct once dynamic commitments can change CSV.
 func createHtlcRetribution(chanState *channeldb.OpenChannel,
 	keyRing *CommitmentKeyRing, commitHash chainhash.Hash,
 	commitmentSecret *btcec.PrivateKey, leaseExpiry uint32,
-	htlc *channeldb.HTLCEntry,
+	theirDelay uint32, htlc *channeldb.HTLCEntry,
 	auxLeaves fn.Option[CommitAuxLeaves]) (HtlcRetribution, error) {
 
 	var emptyRetribution HtlcRetribution
 
-	theirDelay := uint32(chanState.RemoteChanCfg.CsvDelay)
 	isRemoteInitiator := !chanState.IsInitiator
 
 	// We'll generate the original second level witness script now, as
@@ -2522,7 +2583,7 @@ func createHtlcRetribution(chanState *channeldb.OpenChannel,
 func createBreachRetribution(revokedLog *channeldb.RevocationLog,
 	spendTx *wire.MsgTx, chanState *channeldb.OpenChannel,
 	keyRing *CommitmentKeyRing, commitmentSecret *btcec.PrivateKey,
-	leaseExpiry uint32,
+	leaseExpiry uint32, theirDelay uint32,
 	auxLeaves fn.Option[CommitAuxLeaves]) (*BreachRetribution, int64, int64,
 	error) {
 
@@ -2533,7 +2594,8 @@ func createBreachRetribution(revokedLog *channeldb.RevocationLog,
 	for i, htlc := range revokedLog.HTLCEntries {
 		hr, err := createHtlcRetribution(
 			chanState, keyRing, commitHash.Val,
-			commitmentSecret, leaseExpiry, htlc, auxLeaves,
+			commitmentSecret, leaseExpiry, theirDelay, htlc,
+			auxLeaves,
 		)
 		if err != nil {
 			return nil, 0, 0, err
@@ -2640,7 +2702,8 @@ func createBreachRetributionLegacy(revokedLog *channeldb.ChannelCommitment,
 	chanState *channeldb.OpenChannel, keyRing *CommitmentKeyRing,
 	commitmentSecret *btcec.PrivateKey,
 	ourScript, theirScript input.ScriptDescriptor,
-	leaseExpiry uint32) (*BreachRetribution, int64, int64, error) {
+	leaseExpiry uint32, theirDelay uint32,
+	dustLimit btcutil.Amount) (*BreachRetribution, int64, int64, error) {
 
 	commitHash := revokedLog.CommitTx.TxHash()
 	ourOutpoint := wire.OutPoint{
@@ -2668,11 +2731,16 @@ func createBreachRetributionLegacy(revokedLog *channeldb.ChannelCommitment,
 	for i, htlc := range revokedLog.Htlcs {
 		// If the HTLC is dust, then we'll skip it as it doesn't have
 		// an output on the commitment transaction.
+		// Trim with the dust limit that was in effect for the remote
+		// commitment at this revoked height (passed in by the caller
+		// from the epoch history), not the live one, so the set of
+		// non-dust HTLCs we rebuild matches the outputs that were
+		// actually present on the revoked commitment.
 		if HtlcIsDust(
 			chanState.ChanType, htlc.Incoming, lntypes.Remote,
 			chainfee.SatPerKWeight(revokedLog.FeePerKw),
 			htlc.Amt.ToSatoshis(),
-			chanState.RemoteChanCfg.DustLimit,
+			dustLimit,
 		) {
 
 			continue
@@ -2685,7 +2753,7 @@ func createBreachRetributionLegacy(revokedLog *channeldb.ChannelCommitment,
 
 		hr, err := createHtlcRetribution(
 			chanState, keyRing, commitHash,
-			commitmentSecret, leaseExpiry, entry,
+			commitmentSecret, leaseExpiry, theirDelay, entry,
 			fn.None[CommitAuxLeaves](),
 		)
 		if err != nil {
@@ -3340,6 +3408,10 @@ func genRemoteHtlcSigJobs(keyRing *CommitmentKeyRing,
 	leafStore fn.Option[AuxLeafStore]) ([]SignJob, []AuxSigJob,
 	chan struct{}, error) {
 
+	// PR 1.3 audit (dyncomms historical params): current-state site. The
+	// remote CSV/dust read below feeds sig jobs for the new remote
+	// commitment in the in-progress state transition, so the live config is
+	// the correct value and no epoch lookup is needed.
 	var (
 		isRemoteInitiator = !chanState.IsInitiator
 		localChanCfg      = chanState.LocalChanCfg
@@ -4971,6 +5043,10 @@ func genHtlcSigValidationJobs(chanState *channeldb.OpenChannel,
 	leafStore fn.Option[AuxLeafStore], auxSigner fn.Option[AuxSigner],
 	sigBlob fn.Option[tlv.Blob]) ([]VerifyJob, []AuxVerifyJob, error) {
 
+	// PR 1.3 audit (dyncomms historical params): current-state site. The
+	// local CSV read below validates sigs for the new local commitment in
+	// the in-progress state transition, so the live config is correct and no
+	// epoch lookup is needed.
 	var (
 		isLocalInitiator = chanState.IsInitiator
 		localChanCfg     = chanState.LocalChanCfg
@@ -8173,6 +8249,12 @@ func extractHtlcResolutions(feePerKw chainfee.SatPerKWeight,
 	auxLeaves fn.Option[CommitAuxLeaves],
 	auxResolver fn.Option[AuxContractResolver]) (*HtlcResolutions, error) {
 
+	// PR 1.3 audit (dyncomms historical params): current-state site. Force
+	// close / unilateral close only ever resolves the latest broadcastable
+	// commitment (an old state would be a self-breach handled by the breach
+	// path), so the live config CSV/dust for whoseCommit is the correct
+	// value and no epoch lookup is needed.
+	//
 	// TODO(roasbeef): don't need to swap csv delay?
 	dustLimit := remoteChanCfg.DustLimit
 	csvDelay := remoteChanCfg.CsvDelay
@@ -8393,6 +8475,11 @@ func NewLocalForceCloseSummary(chanState *channeldb.OpenChannel,
 	// commitment transaction. We'll need this to find the corresponding
 	// output in the commitment transaction and potentially for creating
 	// the sign descriptor.
+	//
+	// PR 1.3 audit (dyncomms historical params): current-state site. A local
+	// force close broadcasts our latest local commitment (never a revoked
+	// one), so the live LocalChanCfg CSV matches the state being resolved
+	// and no epoch lookup is needed.
 	csvTimeout := uint32(chanState.LocalChanCfg.CsvDelay)
 
 	// We use the passed state num to derive our scripts, since in case

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -10104,9 +10104,11 @@ func TestCreateHtlcRetribution(t *testing.T) {
 	}
 
 	// Create the htlc retribution.
+	theirDelay := uint32(aliceChannel.channelState.RemoteChanCfg.CsvDelay)
 	hr, err := createHtlcRetribution(
 		aliceChannel.channelState, keyRing, commitHash,
-		dummyPrivate, leaseExpiry, htlc, fn.None[CommitAuxLeaves](),
+		dummyPrivate, leaseExpiry, theirDelay, htlc,
+		fn.None[CommitAuxLeaves](),
 	)
 	// Expect no error.
 	require.NoError(t, err)
@@ -10307,10 +10309,13 @@ func TestCreateBreachRetribution(t *testing.T) {
 				tx = nil
 			}
 
+			theirDelay := uint32(
+				aliceChannel.channelState.RemoteChanCfg.CsvDelay,
+			)
 			br, our, their, err := createBreachRetribution(
 				tc.revocationLog, tx,
 				aliceChannel.channelState, keyRing,
-				dummyPrivate, leaseExpiry,
+				dummyPrivate, leaseExpiry, theirDelay,
 				fn.None[CommitAuxLeaves](),
 			)
 
@@ -10367,9 +10372,12 @@ func TestCreateBreachRetributionLegacy(t *testing.T) {
 	}
 
 	// Create the breach retribution using the legacy format.
+	theirDelay := uint32(aliceChannel.channelState.RemoteChanCfg.CsvDelay)
+	dustLimit := aliceChannel.channelState.RemoteChanCfg.DustLimit
 	br, ourAmt, theirAmt, err := createBreachRetributionLegacy(
 		&revokedLog, aliceChannel.channelState, keyRing,
 		dummyPrivate, ourScript, theirScript, leaseExpiry,
+		theirDelay, dustLimit,
 	)
 	require.NoError(t, err)
 
@@ -10522,6 +10530,176 @@ func testNewBreachRetribution(t *testing.T, chanType channeldb.ChannelType) {
 		fn.Some[AuxContractResolver](&MockAuxContractResolver{}),
 	)
 	require.ErrorIs(t, err, channeldb.ErrLogEntryNotFound)
+}
+
+// TestNewBreachRetributionHistoricalCSV verifies that, once the commit-chain
+// epoch history records a mid-channel CSV change, NewBreachRetribution
+// reconstructs a revoked remote commitment with the CSV that was in effect
+// at that revoked height rather than the current one. This is the
+// funds-safety crux of dynamic commitments: a justice transaction built
+// with the wrong CSV would produce an unspendable witness script.
+func TestNewBreachRetributionHistoricalCSV(t *testing.T) {
+	t.Parallel()
+
+	aliceChannel, bobChannel, err := CreateTestChannels(
+		t, channeldb.ZeroHtlcTxFeeBit,
+	)
+	require.NoError(t, err)
+
+	chanState := aliceChannel.channelState
+	breachHeight := uint32(101)
+
+	// The CSV imposed on the revoked remote commitment's to_local branch is
+	// the remote party's configured CSV (the epoch-0 default). Pick a
+	// distinct new value to stand in for a dyncomms CSV change.
+	oldCSV := chanState.RemoteChanCfg.CsvDelay
+	newCSV := oldCSV + 140
+
+	// Advance the channel through two state transitions so that we have
+	// revocation logs (and revocation-store preimages) for remote heights 0
+	// and 1.
+	require.NoError(t, ForceStateTransition(aliceChannel, bobChannel))
+	require.NoError(t, ForceStateTransition(aliceChannel, bobChannel))
+
+	// Record a CSV change specified by the local party. A to_self_delay a
+	// party declares is imposed on its counterparty's commitment, so this
+	// updates the remote commitment chain's CSV. We lock the outgoing epoch
+	// in at remote height 0, so height 0 keeps the old CSV while height 1
+	// (and beyond) uses the new one.
+	hist := chanState.CommitChainEpochHistory
+	hist.RecordParamChange(
+		lntypes.Local,
+		channeldb.CommitmentParams{
+			DustLimit: chanState.LocalChanCfg.DustLimit,
+			CsvDelay:  newCSV,
+		},
+		lntypes.Dual[uint64]{Local: 0, Remote: 0},
+	)
+	chanState.CommitChainEpochHistory = hist
+
+	// Sanity check the epoch lookup itself before exercising the breach
+	// path.
+	require.EqualValues(
+		t, oldCSV,
+		chanState.CommitParamsForHeight(lntypes.Remote, 0).CsvDelay,
+	)
+	require.EqualValues(
+		t, newCSV,
+		chanState.CommitParamsForHeight(lntypes.Remote, 1).CsvDelay,
+	)
+
+	// assertBreachCSV builds a breach retribution for the given revoked
+	// state and asserts the reconstructed remote (revoked) to_local output
+	// carries the expected CSV, both in the RemoteDelay field and embedded
+	// in the actual witness script.
+	assertBreachCSV := func(stateNum uint64, wantCSV uint16) {
+		t.Helper()
+
+		br, err := NewBreachRetribution(
+			chanState, stateNum, breachHeight, nil,
+			fn.Some[AuxLeafStore](&MockAuxLeafStore{}),
+			fn.Some[AuxContractResolver](&MockAuxContractResolver{}),
+		)
+		require.NoError(t, err)
+
+		// The delay recorded on the retribution must be the historical
+		// CSV.
+		require.EqualValues(t, wantCSV, br.RemoteDelay)
+
+		// The remote (revoked) output must have a sign descriptor whose
+		// witness script embeds the historical CSV. We independently
+		// rebuild the expected to_local script with the wanted CSV and
+		// compare the raw witness scripts byte-for-byte.
+		require.NotNil(t, br.RemoteOutputSignDesc)
+
+		expectedScript, err := CommitScriptToSelf(
+			chanState.ChanType, !chanState.IsInitiator,
+			br.KeyRing.ToLocalKey, br.KeyRing.RevocationKey,
+			uint32(wantCSV), 0, input.NoneTapLeaf(),
+		)
+		require.NoError(t, err)
+
+		expectedWitness, err := expectedScript.WitnessScriptForPath(
+			input.ScriptPathRevocation,
+		)
+		require.NoError(t, err)
+
+		require.Equal(
+			t, expectedWitness,
+			br.RemoteOutputSignDesc.WitnessScript,
+		)
+	}
+
+	// A breach of the pre-change revoked state must reconstruct with the OLD
+	// CSV...
+	assertBreachCSV(0, oldCSV)
+
+	// ...while a breach of the post-change revoked state must use the NEW
+	// CSV.
+	assertBreachCSV(1, newCSV)
+}
+
+// TestNewBreachRetributionHistoricalDust verifies that NewBreachRetribution
+// gates the revoked output sweep on the dust limit that was in effect at
+// the revoked height, so a later dyncomms dust-limit increase cannot strand
+// an output that legitimately existed on the revoked commitment.
+func TestNewBreachRetributionHistoricalDust(t *testing.T) {
+	t.Parallel()
+
+	aliceChannel, bobChannel, err := CreateTestChannels(
+		t, channeldb.ZeroHtlcTxFeeBit,
+	)
+	require.NoError(t, err)
+
+	chanState := aliceChannel.channelState
+	breachHeight := uint32(101)
+
+	// Advance once so that we have a revocation log at remote height 0.
+	require.NoError(t, ForceStateTransition(aliceChannel, bobChannel))
+
+	oldDust := chanState.RemoteChanCfg.DustLimit
+
+	// Simulate a dyncomms change in which the remote raised its own dust
+	// limit above its balance on the commitment (~5 BTC in a balanced test
+	// channel), while the revoked height 0 keeps the original low dust
+	// limit. A party's declared dust limit governs its own commitment, so
+	// the remote is the specifier here.
+	hugeDust := btcutil.Amount(9 * btcutil.SatoshiPerBitcoin)
+	hist := chanState.CommitChainEpochHistory
+	hist.RecordParamChange(
+		lntypes.Remote,
+		channeldb.CommitmentParams{
+			DustLimit: hugeDust,
+			CsvDelay:  chanState.LocalChanCfg.CsvDelay,
+		},
+		lntypes.Dual[uint64]{Local: 0, Remote: 0},
+	)
+	chanState.CommitChainEpochHistory = hist
+
+	// The revoked height must retain the original (low) dust limit, while
+	// the current parameters carry the raised one that would otherwise
+	// strand the output.
+	require.Equal(
+		t, oldDust,
+		chanState.CommitParamsForHeight(lntypes.Remote, 0).DustLimit,
+	)
+	require.Equal(
+		t, hugeDust,
+		chanState.CommitParamsForHeight(lntypes.Remote, 1).DustLimit,
+	)
+
+	// Breaching the revoked height-0 state must still build the sweep
+	// descriptor for the remote's output, because at that height the output
+	// was well above the (low) dust limit. Using the live raised dust limit
+	// would incorrectly skip it and strand the funds.
+	br, err := NewBreachRetribution(
+		chanState, 0, breachHeight, nil,
+		fn.Some[AuxLeafStore](&MockAuxLeafStore{}),
+		fn.Some[AuxContractResolver](&MockAuxContractResolver{}),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, br.RemoteOutputSignDesc)
+	require.NotNil(t, br.LocalOutputSignDesc)
 }
 
 // TestExtractPayDescs asserts that `extractPayDescs` can correctly turn a

--- a/lnwallet/commitment.go
+++ b/lnwallet/commitment.go
@@ -974,6 +974,9 @@ func CreateCommitTx(chanType channeldb.ChannelType,
 	localAuxLeaf := fn.MapOption(func(l CommitAuxLeaves) input.AuxTapLeaf {
 		return l.LocalAuxLeaf
 	})(auxLeaves)
+	// PR 1.3 audit (dyncomms historical params): current-state site. This
+	// builds the commitment being signed now, so the live config CSV is the
+	// correct value; no epoch lookup needed.
 	toLocalScript, err := CommitScriptToSelf(
 		chanType, initiator, keyRing.ToLocalKey, keyRing.RevocationKey,
 		uint32(localChanCfg.CsvDelay), leaseExpiry,
@@ -1339,8 +1342,17 @@ func findOutputIndexesFromRemote(revocationPreimage *chainhash.Hash,
 
 	// Since it's remote commitment chain, we'd used the mirrored values.
 	//
-	// We use the remote's channel config for the csv delay.
-	theirDelay := uint32(chanState.RemoteChanCfg.CsvDelay)
+	// We use the CSV delay that governed the remote commitment chain at the
+	// height of the commitment we are locating outputs for, looked up from
+	// the per-side epoch history, rather than the live config. Once dynamic
+	// commitments can change CSV mid-channel, the live value may differ from
+	// the one this (about-to-be-revoked) commitment was built with, which
+	// would make the reconstructed to_local script fail to match and persist
+	// a wrong output index into the revocation log. For channels without
+	// epoch history this returns the current RemoteChanCfg CSV unchanged.
+	theirDelay := uint32(chanState.CommitParamsForHeight(
+		lntypes.Remote, chanCommit.CommitHeight,
+	).CsvDelay)
 
 	// If we are the initiator of this channel, then it's be false from the
 	// remote's PoV.

--- a/lnwallet/test_utils.go
+++ b/lnwallet/test_utils.go
@@ -325,6 +325,16 @@ func CreateTestChannels(t *testing.T, chanType channeldb.ChannelType,
 		Db:                      dbAlice.ChannelStateDB(),
 		Packager:                channeldb.NewChannelPackager(shortChanID),
 		FundingTxn:              testTx,
+		// Mirror the read-time default synthesized by fetchOpenChannel:
+		// a single epoch 0 per side seeded from the current configs, so
+		// historical-parameter lookups behave as on a disk-loaded
+		// channel.
+		CommitChainEpochHistory: channeldb.NewCommitChainEpochHistory(
+			lntypes.Dual[channeldb.CommitmentParams]{
+				Local:  aliceCfg.CommitmentParams,
+				Remote: bobCfg.CommitmentParams,
+			},
+		),
 	}
 	bobChannelState := &channeldb.OpenChannel{
 		LocalChanCfg:            bobCfg,
@@ -342,6 +352,12 @@ func CreateTestChannels(t *testing.T, chanType channeldb.ChannelType,
 		RemoteCommitment:        bobRemoteCommit,
 		Db:                      dbBob.ChannelStateDB(),
 		Packager:                channeldb.NewChannelPackager(shortChanID),
+		CommitChainEpochHistory: channeldb.NewCommitChainEpochHistory(
+			lntypes.Dual[channeldb.CommitmentParams]{
+				Local:  bobCfg.CommitmentParams,
+				Remote: aliceCfg.CommitmentParams,
+			},
+		),
 	}
 
 	// If the channel type has a tapscript root, then we'll also specify


### PR DESCRIPTION
Part of the Dynamic Commitments milestone: #60

Historical-param audit + breach recovery using historical CSV/dust.

**Stacked PR** — based on `yy-dyn-2-epoch`; review after that branch (the base updates automatically as the parent merges).

Opened as a **draft**: this is part of the exploratory params-only stack (coarse commits, not final hygiene).