### PR TITLE
lnwallet: mutable channel params API + validation

### DIFF
--- a/channeldb/channel_apply_test.go
+++ b/channeldb/channel_apply_test.go
@@ -1,0 +1,178 @@
+package channeldb
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/stretchr/testify/require"
+)
+
+// TestApplyChannelParamsPolicyOnly asserts that a policy-only parameter change
+// (one with no EpochParamChange) is persisted, changes the per-side bounds and
+// channel flags, and crucially does NOT record any commit-chain epoch or alter
+// the script/output-rendering (CSV/dust) parameters.
+func TestApplyChannelParamsPolicyOnly(t *testing.T) {
+	t.Parallel()
+
+	fullDB, err := MakeTestDB(t)
+	require.NoError(t, err, "unable to make test database")
+	cdb := fullDB.ChannelStateDB()
+
+	channel := createTestChannel(t, cdb)
+
+	// Capture the initial rendering params so we can assert they are
+	// untouched by a policy-only change.
+	initLocalCP := channel.LocalChanCfg.CommitmentParams
+	initRemoteCP := channel.RemoteChanCfg.CommitmentParams
+	require.Empty(t, channel.CommitChainEpochHistory.Historical.Local)
+	require.Empty(t, channel.CommitChainEpochHistory.Historical.Remote)
+
+	// Change a policy-only parameter (max accepted htlcs) on the remote
+	// side, and flip the announcement intent.
+	newLocalBounds := channel.LocalChanCfg.ChannelStateBounds
+	newRemoteBounds := channel.RemoteChanCfg.ChannelStateBounds
+	newRemoteBounds.MaxAcceptedHtlcs = 42
+	newRemoteBounds.ChanReserve = btcutil.Amount(7777)
+	newFlags := channel.ChannelFlags ^ lnwire.FFAnnounceChannel
+
+	err = channel.ApplyChannelParams(
+		newLocalBounds, newRemoteBounds, newFlags,
+		fn.None[EpochParamChange](),
+	)
+	require.NoError(t, err)
+
+	assertPolicyOnly := func(t *testing.T, c *OpenChannel) {
+		t.Helper()
+
+		// Policy bounds and flags reflect the change.
+		require.EqualValues(t, 42, c.RemoteChanCfg.MaxAcceptedHtlcs)
+		require.EqualValues(
+			t, 7777, c.RemoteChanCfg.ChanReserve,
+		)
+		require.Equal(t, newFlags, c.ChannelFlags)
+
+		// No epoch was recorded, and the rendering params are unchanged.
+		require.Empty(t, c.CommitChainEpochHistory.Historical.Local)
+		require.Empty(t, c.CommitChainEpochHistory.Historical.Remote)
+		require.Equal(t, initLocalCP, c.LocalChanCfg.CommitmentParams)
+		require.Equal(t, initRemoteCP, c.RemoteChanCfg.CommitmentParams)
+	}
+
+	// The in-memory channel reflects the change...
+	assertPolicyOnly(t, channel)
+
+	// ... and so does a fresh copy loaded from disk.
+	fetched, err := cdb.FetchChannel(channel.FundingOutpoint)
+	require.NoError(t, err)
+	assertPolicyOnly(t, fetched)
+}
+
+// TestApplyChannelParamsEpoch asserts that a script/output-rendering parameter
+// change (CSV/dust) closes the outgoing epoch on both commitment chains at the
+// per-side lock-in heights, installs the new normalized params, keeps the
+// configs' CommitmentParams in sync with the epoch history, and persists all of
+// it.
+func TestApplyChannelParamsEpoch(t *testing.T) {
+	t.Parallel()
+
+	fullDB, err := MakeTestDB(t)
+	require.NoError(t, err, "unable to make test database")
+	cdb := fullDB.ChannelStateDB()
+
+	channel := createTestChannel(t, cdb)
+
+	// Record the outgoing (current) rendering params; these are what the
+	// closed epochs must capture.
+	oldLocalCP := channel.LocalChanCfg.CommitmentParams
+	oldRemoteCP := channel.RemoteChanCfg.CommitmentParams
+
+	// The Local party proposes both a new dust limit (for itself) and a new
+	// CSV (imposed on the Remote counterparty).
+	const (
+		newDust      = btcutil.Amount(500)
+		newCsv       = uint16(720)
+		localLockIn  = uint64(11)
+		remoteLockIn = uint64(9)
+	)
+
+	epoch := EpochParamChange{
+		WhoSpecified: lntypes.Local,
+		Params: CommitmentParams{
+			DustLimit: newDust,
+			CsvDelay:  newCsv,
+		},
+		LockInHeights: lntypes.Dual[uint64]{
+			Local:  localLockIn,
+			Remote: remoteLockIn,
+		},
+	}
+
+	err = channel.ApplyChannelParams(
+		channel.LocalChanCfg.ChannelStateBounds,
+		channel.RemoteChanCfg.ChannelStateBounds,
+		channel.ChannelFlags, fn.Some(epoch),
+	)
+	require.NoError(t, err)
+
+	assertEpoch := func(t *testing.T, c *OpenChannel) {
+		t.Helper()
+
+		hist := c.CommitChainEpochHistory
+
+		// One closed epoch per side, capturing the outgoing params at
+		// the per-side lock-in heights.
+		require.Len(t, hist.Historical.Local, 1)
+		require.Len(t, hist.Historical.Remote, 1)
+		require.Equal(t, CommitChainEpoch{
+			LastHeight: localLockIn,
+			Params:     oldLocalCP,
+		}, hist.Historical.Local[0])
+		require.Equal(t, CommitChainEpoch{
+			LastHeight: remoteLockIn,
+			Params:     oldRemoteCP,
+		}, hist.Historical.Remote[0])
+
+		// The proposer (Local) adopts the new dust but keeps its CSV;
+		// the counterparty (Remote) adopts the new CSV but keeps its
+		// dust.
+		require.Equal(t, CommitmentParams{
+			DustLimit: newDust,
+			CsvDelay:  oldLocalCP.CsvDelay,
+		}, hist.Current.Local)
+		require.Equal(t, CommitmentParams{
+			DustLimit: oldRemoteCP.DustLimit,
+			CsvDelay:  newCsv,
+		}, hist.Current.Remote)
+
+		// The configs' rendering params must track the epoch history.
+		require.Equal(
+			t, hist.Current.Local, c.LocalChanCfg.CommitmentParams,
+		)
+		require.Equal(
+			t, hist.Current.Remote,
+			c.RemoteChanCfg.CommitmentParams,
+		)
+
+		// The historical params for the outgoing heights resolve back to
+		// the old values, while heights past lock-in resolve to current.
+		require.Equal(
+			t, oldLocalCP,
+			c.CommitParamsForHeight(lntypes.Local, localLockIn),
+		)
+		require.Equal(
+			t, hist.Current.Local,
+			c.CommitParamsForHeight(lntypes.Local, localLockIn+1),
+		)
+	}
+
+	// The in-memory channel reflects the change...
+	assertEpoch(t, channel)
+
+	// ... and so does a fresh copy loaded from disk.
+	fetched, err := cdb.FetchChannel(channel.FundingOutpoint)
+	require.NoError(t, err)
+	assertEpoch(t, fetched)
+}

--- a/channeldb/channel_epochs.go
+++ b/channeldb/channel_epochs.go
@@ -3,7 +3,10 @@ package channeldb
 import (
 	"io"
 
+	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/tlv"
 )
 
@@ -286,3 +289,113 @@ func dCommitChainEpochHistory(r io.Reader, val interface{}, _ *[8]byte,
 
 // Assert that CommitChainEpochHistory implements the RecordProducer interface.
 var _ tlv.RecordProducer = (*CommitChainEpochHistory)(nil)
+
+// EpochParamChange describes a change to the script/output-rendering commitment
+// parameters (CSV and dust) that must be recorded in the commit-chain epoch
+// history. It is the epoch-affecting portion of a dynamic-commitments parameter
+// change; policy-only changes (reserve, in-flight limits, and the like) do not
+// produce one.
+type EpochParamChange struct {
+	// WhoSpecified is the party that proposed the parameter change. Its own
+	// dust limit and its counterparty's CSV are updated, per BOLT
+	// normalization (see RecordParamChange).
+	WhoSpecified lntypes.ChannelParty
+
+	// Params are the new normalized parameters. Params.DustLimit is the
+	// proposer's new dust limit and Params.CsvDelay is the counterparty's
+	// new CSV; callers must pass the current value for a field that is not
+	// changing.
+	Params CommitmentParams
+
+	// LockInHeights give the last height, inclusive, that the outgoing
+	// parameters applied to on each commitment chain (the local and remote
+	// chains lock in at different heights).
+	LockInHeights lntypes.Dual[uint64]
+}
+
+// ApplyChannelParams atomically persists a validated dynamic-commitments
+// parameter change. The per-side ChannelStateBounds (the policy parameters:
+// channel reserve, max value in flight, htlc minimum, and max accepted htlcs)
+// are replaced wholesale with localBounds and remoteBounds, and the
+// channel-wide announcement intent is set to flags.
+//
+// When paramChange is Some, the script/output-rendering parameters (CSV and
+// dust) are changed: the current epoch is closed on both commitment chains at
+// the given per-side lock-in heights and the new parameters are installed via
+// the commit-chain epoch history. The local and remote CommitmentParams are
+// then re-derived from the resulting epoch history so that they can never drift
+// from it. When paramChange is None, the epoch history and the CommitmentParams
+// are left untouched, which guarantees that policy-only changes never pollute
+// the epoch history.
+//
+// It is used by the dynamic-commitments machinery once a parameter change has
+// been agreed and locked in on each commitment chain.
+func (c *OpenChannel) ApplyChannelParams(localBounds,
+	remoteBounds ChannelStateBounds, flags lnwire.FundingFlag,
+	paramChange fn.Option[EpochParamChange]) error {
+
+	c.Lock()
+	defer c.Unlock()
+
+	// updated captures the mutated channel so the applied state can be
+	// copied back into the in-memory OpenChannel after the write succeeds.
+	var updated *OpenChannel
+	err := kvdb.Update(c.Db.backend, func(tx kvdb.RwTx) error {
+		chanBucket, err := fetchChanBucketRw(
+			tx, c.IdentityPub, &c.FundingOutpoint, c.ChainHash,
+		)
+		if err != nil {
+			return err
+		}
+
+		channel, err := fetchOpenChannel(chanBucket, &c.FundingOutpoint)
+		if err != nil {
+			return err
+		}
+
+		// Apply the policy-only parameters and the channel-wide flags.
+		channel.LocalChanCfg.ChannelStateBounds = localBounds
+		channel.RemoteChanCfg.ChannelStateBounds = remoteBounds
+		channel.ChannelFlags = flags
+
+		// The script/output-rendering parameters may only change through
+		// the epoch history so that historical states remain
+		// reconstructable. Record the change and re-derive the configs'
+		// CommitmentParams from the resulting current epoch, which makes
+		// the epoch history the single source of truth for them.
+		paramChange.WhenSome(func(pc EpochParamChange) {
+			channel.CommitChainEpochHistory.RecordParamChange(
+				pc.WhoSpecified, pc.Params, pc.LockInHeights,
+			)
+
+			hist := channel.CommitChainEpochHistory
+			channel.LocalChanCfg.CommitmentParams = hist.Current.Local
+			channel.RemoteChanCfg.CommitmentParams =
+				hist.Current.Remote
+		})
+
+		if err := putOpenChannel(chanBucket, channel); err != nil {
+			return err
+		}
+
+		updated = channel
+
+		return nil
+	}, func() {
+		updated = nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// Mirror the persisted state into the in-memory channel.
+	c.LocalChanCfg.ChannelStateBounds = updated.LocalChanCfg.ChannelStateBounds
+	c.RemoteChanCfg.ChannelStateBounds =
+		updated.RemoteChanCfg.ChannelStateBounds
+	c.LocalChanCfg.CommitmentParams = updated.LocalChanCfg.CommitmentParams
+	c.RemoteChanCfg.CommitmentParams = updated.RemoteChanCfg.CommitmentParams
+	c.ChannelFlags = updated.ChannelFlags
+	c.CommitChainEpochHistory = updated.CommitChainEpochHistory
+
+	return nil
+}

--- a/lnwallet/chan_params.go
+++ b/lnwallet/chan_params.go
@@ -1,0 +1,445 @@
+package lnwallet
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+// Sentinel errors returned by ChannelParams validation. They are wrapped with
+// concrete values for logging, so callers must use errors.Is to match them.
+var (
+	// ErrDynParamsNoChange is returned when a dynamic-commitments parameter
+	// proposal does not change any parameter.
+	ErrDynParamsNoChange = errors.New("dynamic params proposal is empty")
+
+	// ErrDynDustLimitTooSmall is returned when a proposed dust limit is
+	// below the protocol minimum.
+	ErrDynDustLimitTooSmall = errors.New("dust limit below minimum")
+
+	// ErrDynDustLimitTooLarge is returned when a proposed dust limit is
+	// above the maximum we consider safe.
+	ErrDynDustLimitTooLarge = errors.New("dust limit above maximum")
+
+	// ErrDynReserveBelowDust is returned when either peer's channel reserve
+	// would end up below either peer's dust limit.
+	ErrDynReserveBelowDust = errors.New(
+		"channel reserve below dust limit",
+	)
+
+	// ErrDynReserveTooLarge is returned when a proposed channel reserve
+	// exceeds the maximum fraction of the channel capacity we allow.
+	ErrDynReserveTooLarge = errors.New(
+		"channel reserve exceeds maximum",
+	)
+
+	// ErrDynCsvDelayTooLarge is returned when a proposed CSV delay
+	// (to_self_delay) exceeds our configured maximum.
+	ErrDynCsvDelayTooLarge = errors.New("csv delay exceeds maximum")
+
+	// ErrDynMaxAcceptedTooLarge is returned when a proposed max_accepted_
+	// htlcs value exceeds the protocol maximum.
+	ErrDynMaxAcceptedTooLarge = errors.New(
+		"max accepted htlcs exceeds protocol maximum",
+	)
+
+	// ErrDynHtlcMinTooLarge is returned when a proposed htlc_minimum_msat
+	// exceeds the corresponding max_htlc_value_in_flight_msat.
+	ErrDynHtlcMinTooLarge = errors.New(
+		"htlc minimum exceeds max value in flight",
+	)
+)
+
+// ChannelParams is the canonical, internal representation of a proposed change
+// to the mutable ("dynamic") channel parameters. It is shared by the RPC, wire,
+// wallet, and updater layers so they all speak the same param vocabulary, and
+// it mirrors the lnwire.DynPropose message one-to-one.
+//
+// Each field is optional: an unset field means the corresponding parameter is
+// left unchanged by the proposal. The fields carry the values the proposer
+// advertised at channel open, with the same meaning as the like-named fields of
+// open_channel/accept_channel.
+//
+// NOTE: Only DustLimit and CsvDelay are script/output-rendering parameters and
+// therefore feed the commit-chain epoch history (so historical commitment and
+// HTLC scripts stay reconstructable). All the other fields are pure policy
+// parameters and MUST NOT create epoch entries.
+type ChannelParams struct {
+	// DustLimit is the sender's dust_limit_satoshis for its own commitment
+	// transaction. It is an epoch-affecting (script-rendering) parameter.
+	DustLimit fn.Option[btcutil.Amount]
+
+	// MaxValueInFlight is the sender's max_htlc_value_in_flight_msat limit.
+	// It is a policy parameter.
+	MaxValueInFlight fn.Option[lnwire.MilliSatoshi]
+
+	// HtlcMinimum is the sender's htlc_minimum_msat floor. It is a policy
+	// parameter.
+	HtlcMinimum fn.Option[lnwire.MilliSatoshi]
+
+	// ChannelReserve is the channel_reserve_satoshis the sender requires of
+	// the recipient. It is a policy parameter.
+	ChannelReserve fn.Option[btcutil.Amount]
+
+	// CsvDelay is the to_self_delay the sender requires of the recipient. It
+	// is an epoch-affecting (script-rendering) parameter.
+	CsvDelay fn.Option[uint16]
+
+	// MaxAcceptedHtlcs is the sender's max_accepted_htlcs limit. It is a
+	// policy parameter.
+	MaxAcceptedHtlcs fn.Option[uint16]
+
+	// ChannelFlags is the channel-wide announcement intent. It is neither an
+	// epoch nor a per-side policy parameter; it applies to the whole
+	// channel.
+	ChannelFlags fn.Option[lnwire.FundingFlag]
+}
+
+// IsEmpty returns true if the proposal changes no parameter.
+func (p ChannelParams) IsEmpty() bool {
+	return p.DustLimit.IsNone() && p.MaxValueInFlight.IsNone() &&
+		p.HtlcMinimum.IsNone() && p.ChannelReserve.IsNone() &&
+		p.CsvDelay.IsNone() && p.MaxAcceptedHtlcs.IsNone() &&
+		p.ChannelFlags.IsNone()
+}
+
+// AffectsEpoch returns true if the proposal changes a script/output-rendering
+// parameter (CSV or dust) and therefore requires a commit-chain epoch entry.
+func (p ChannelParams) AffectsEpoch() bool {
+	return p.DustLimit.IsSome() || p.CsvDelay.IsSome()
+}
+
+// ChannelParamsFromDynPropose converts a wire lnwire.DynPropose message into
+// the canonical ChannelParams representation.
+func ChannelParamsFromDynPropose(dp *lnwire.DynPropose) ChannelParams {
+	amt := func(b tlv.BigSizeT[btcutil.Amount]) btcutil.Amount {
+		return b.Int()
+	}
+
+	return ChannelParams{
+		DustLimit:        fn.MapOption(amt)(dp.DustLimit.ValOpt()),
+		MaxValueInFlight: dp.MaxValueInFlight.ValOpt(),
+		HtlcMinimum:      dp.HtlcMinimum.ValOpt(),
+		ChannelReserve:   fn.MapOption(amt)(dp.ChannelReserve.ValOpt()),
+		CsvDelay:         dp.CsvDelay.ValOpt(),
+		MaxAcceptedHtlcs: dp.MaxAcceptedHTLCs.ValOpt(),
+		ChannelFlags:     dp.ChannelFlags.ValOpt(),
+	}
+}
+
+// ToDynPropose converts the canonical ChannelParams into a wire
+// lnwire.DynPropose message for the given channel. Only the set fields are
+// included in the message.
+func (p ChannelParams) ToDynPropose(
+	chanID lnwire.ChannelID) *lnwire.DynPropose {
+
+	dp := &lnwire.DynPropose{ChanID: chanID}
+
+	p.DustLimit.WhenSome(func(a btcutil.Amount) {
+		var rec tlv.RecordT[tlv.TlvType0, tlv.BigSizeT[btcutil.Amount]]
+		rec.Val = tlv.NewBigSizeT(a)
+		dp.DustLimit = tlv.SomeRecordT(rec)
+	})
+	p.MaxValueInFlight.WhenSome(func(m lnwire.MilliSatoshi) {
+		var rec tlv.RecordT[tlv.TlvType1, lnwire.MilliSatoshi]
+		rec.Val = m
+		dp.MaxValueInFlight = tlv.SomeRecordT(rec)
+	})
+	p.HtlcMinimum.WhenSome(func(m lnwire.MilliSatoshi) {
+		var rec tlv.RecordT[tlv.TlvType2, lnwire.MilliSatoshi]
+		rec.Val = m
+		dp.HtlcMinimum = tlv.SomeRecordT(rec)
+	})
+	p.ChannelReserve.WhenSome(func(a btcutil.Amount) {
+		var rec tlv.RecordT[tlv.TlvType3, tlv.BigSizeT[btcutil.Amount]]
+		rec.Val = tlv.NewBigSizeT(a)
+		dp.ChannelReserve = tlv.SomeRecordT(rec)
+	})
+	p.CsvDelay.WhenSome(func(c uint16) {
+		var rec tlv.RecordT[tlv.TlvType4, uint16]
+		rec.Val = c
+		dp.CsvDelay = tlv.SomeRecordT(rec)
+	})
+	p.MaxAcceptedHtlcs.WhenSome(func(n uint16) {
+		var rec tlv.RecordT[tlv.TlvType5, uint16]
+		rec.Val = n
+		dp.MaxAcceptedHTLCs = tlv.SomeRecordT(rec)
+	})
+	p.ChannelFlags.WhenSome(func(f lnwire.FundingFlag) {
+		var rec tlv.RecordT[tlv.TlvType6, lnwire.FundingFlag]
+		rec.Val = f
+		dp.ChannelFlags = tlv.SomeRecordT(rec)
+	})
+
+	return dp
+}
+
+// ChannelParamsFromConfigs extracts the full set of dynamic parameters the
+// given party currently advertises from the channel's local and remote configs
+// plus the channel-wide flags. It is the inverse of ApplyToConfigs for a full
+// param set, and is useful for reporting or seeding a proposal with the current
+// values.
+//
+// The party's own dust limit governs its own commitment outputs and so is read
+// from its own config. The remaining parameters are requirements the party
+// imposes on its counterparty, and are therefore read from the counterparty's
+// config (matching how open_channel/accept_channel are mapped to configs).
+func ChannelParamsFromConfigs(proposer lntypes.ChannelParty, local,
+	remote channeldb.ChannelConfig,
+	flags lnwire.FundingFlag) ChannelParams {
+
+	cfgs := lntypes.Dual[channeldb.ChannelConfig]{
+		Local:  local,
+		Remote: remote,
+	}
+	own := cfgs.GetForParty(proposer)
+	counter := cfgs.GetForParty(proposer.CounterParty())
+
+	return ChannelParams{
+		DustLimit:        fn.Some(own.DustLimit),
+		MaxValueInFlight: fn.Some(counter.MaxPendingAmount),
+		HtlcMinimum:      fn.Some(counter.MinHTLC),
+		ChannelReserve:   fn.Some(counter.ChanReserve),
+		CsvDelay:         fn.Some(counter.CsvDelay),
+		MaxAcceptedHtlcs: fn.Some(counter.MaxAcceptedHtlcs),
+		ChannelFlags:     fn.Some(flags),
+	}
+}
+
+// ApplyToConfigs applies the proposal on top of the given local and remote
+// channel configs and returns the resulting configs. The inputs are not
+// mutated.
+//
+// The proposer's own dust limit is written to the proposer's own config, while
+// the remaining (non-flags) parameters are requirements the proposer imposes on
+// its counterparty and are therefore written to the counterparty's config. This
+// keeps the resulting configs consistent with how LND stores parameters from
+// open_channel/accept_channel, and with the commit-chain epoch normalization.
+//
+// ChannelFlags is channel-wide and is not carried in a ChannelConfig, so it is
+// not reflected here; callers apply it separately.
+func (p ChannelParams) ApplyToConfigs(proposer lntypes.ChannelParty, local,
+	remote channeldb.ChannelConfig) (channeldb.ChannelConfig,
+	channeldb.ChannelConfig) {
+
+	cfgs := lntypes.Dual[channeldb.ChannelConfig]{
+		Local:  local,
+		Remote: remote,
+	}
+
+	// The proposer's own dust limit lives in the proposer's own config.
+	proposerCfg := cfgs.GetForParty(proposer)
+	p.DustLimit.WhenSome(func(a btcutil.Amount) {
+		proposerCfg.DustLimit = a
+	})
+	cfgs.SetForParty(proposer, proposerCfg)
+
+	// The remaining parameters are requirements imposed on the counterparty
+	// and so live in the counterparty's config.
+	counterCfg := cfgs.GetForParty(proposer.CounterParty())
+	p.CsvDelay.WhenSome(func(c uint16) {
+		counterCfg.CsvDelay = c
+	})
+	p.ChannelReserve.WhenSome(func(a btcutil.Amount) {
+		counterCfg.ChanReserve = a
+	})
+	p.MaxValueInFlight.WhenSome(func(m lnwire.MilliSatoshi) {
+		counterCfg.MaxPendingAmount = m
+	})
+	p.HtlcMinimum.WhenSome(func(m lnwire.MilliSatoshi) {
+		counterCfg.MinHTLC = m
+	})
+	p.MaxAcceptedHtlcs.WhenSome(func(n uint16) {
+		counterCfg.MaxAcceptedHtlcs = n
+	})
+	cfgs.SetForParty(proposer.CounterParty(), counterCfg)
+
+	return cfgs.Local, cfgs.Remote
+}
+
+// ValidateChannelParams checks that the resulting local and remote channel
+// configs (i.e. the configs after a proposal has been applied) satisfy BOLT #2
+// and LND policy. It validates the whole resulting channel, as mandated by the
+// dynamic-commitments extension, rather than only the changed fields. All
+// errors wrap one of the package sentinels so callers can match them with
+// errors.Is.
+func ValidateChannelParams(local, remote channeldb.ChannelConfig,
+	capacity btcutil.Amount, maxLocalCSVDelay uint16) error {
+
+	// The BOLT-mandated minimum dust limit (354 sat) coincides with LND's
+	// minimum for an unknown-witness output; we reuse the maximum allowed
+	// there as our upper bound too, matching open_channel validation.
+	minDust := DustLimitForSize(input.UnknownWitnessSize)
+	maxDust := 3 * minDust
+	maxReserve := capacity / 5
+	maxAccepted := uint16(input.MaxHTLCNumber / 2)
+
+	// Per-side sanity checks. Each config holds the parameters that
+	// constrain that party.
+	sides := []struct {
+		name string
+		cfg  channeldb.ChannelConfig
+	}{
+		{"local", local},
+		{"remote", remote},
+	}
+	for _, s := range sides {
+		cfg := s.cfg
+
+		switch {
+		case cfg.DustLimit < minDust:
+			return fmt.Errorf("%s dust limit %v: %w", s.name,
+				cfg.DustLimit, ErrDynDustLimitTooSmall)
+
+		case cfg.DustLimit > maxDust:
+			return fmt.Errorf("%s dust limit %v (max %v): %w",
+				s.name, cfg.DustLimit, maxDust,
+				ErrDynDustLimitTooLarge)
+		}
+
+		if cfg.CsvDelay > maxLocalCSVDelay {
+			return fmt.Errorf("%s csv delay %v (max %v): %w",
+				s.name, cfg.CsvDelay, maxLocalCSVDelay,
+				ErrDynCsvDelayTooLarge)
+		}
+
+		if cfg.ChanReserve > maxReserve {
+			return fmt.Errorf("%s reserve %v (max %v): %w", s.name,
+				cfg.ChanReserve, maxReserve,
+				ErrDynReserveTooLarge)
+		}
+
+		if cfg.MaxAcceptedHtlcs > maxAccepted {
+			return fmt.Errorf("%s max accepted htlcs %v (max %v): "+
+				"%w", s.name, cfg.MaxAcceptedHtlcs, maxAccepted,
+				ErrDynMaxAcceptedTooLarge)
+		}
+
+		if cfg.MinHTLC > cfg.MaxPendingAmount {
+			return fmt.Errorf("%s htlc minimum %v exceeds max in "+
+				"flight %v: %w", s.name, cfg.MinHTLC,
+				cfg.MaxPendingAmount, ErrDynHtlcMinTooLarge)
+		}
+	}
+
+	// Cross-peer check: the smaller of the two reserves must be at least the
+	// larger of the two dust limits, so neither party can be pushed below
+	// its own dust limit while still being above its reserve.
+	minReserve := local.ChanReserve
+	if remote.ChanReserve < minReserve {
+		minReserve = remote.ChanReserve
+	}
+	maxDustLimit := local.DustLimit
+	if remote.DustLimit > maxDustLimit {
+		maxDustLimit = remote.DustLimit
+	}
+	if minReserve < maxDustLimit {
+		return fmt.Errorf("min reserve %v below max dust limit %v: %w",
+			minReserve, maxDustLimit, ErrDynReserveBelowDust)
+	}
+
+	return nil
+}
+
+// Validate computes the resulting channel configs for a proposal by the given
+// party and validates them against BOLT #2 and LND policy. It is a convenience
+// wrapper that combines ApplyToConfigs and ValidateChannelParams, and also
+// rejects an empty proposal.
+func (p ChannelParams) Validate(proposer lntypes.ChannelParty, local,
+	remote channeldb.ChannelConfig, capacity btcutil.Amount,
+	maxLocalCSVDelay uint16) error {
+
+	if p.IsEmpty() {
+		return ErrDynParamsNoChange
+	}
+
+	newLocal, newRemote := p.ApplyToConfigs(proposer, local, remote)
+
+	return ValidateChannelParams(
+		newLocal, newRemote, capacity, maxLocalCSVDelay,
+	)
+}
+
+// ApplyChannelParams validates and atomically applies a dynamic-commitments
+// parameter change proposed by the given party, persisting the result to disk
+// and updating the in-memory channel state.
+//
+// The change is applied with proposer-owned semantics: it updates the values
+// the proposer advertised at channel open (its own dust limit, and the
+// requirements it imposes on its counterparty), plus the channel-wide
+// ChannelFlags.
+//
+// When the proposal changes a script/output-rendering parameter (CSV or dust) a
+// new commit-chain epoch is recorded at the given per-side lock-in heights, so
+// historical commitment and HTLC scripts remain reconstructable. Policy-only
+// proposals leave the epoch history untouched. lockInHeights gives the last
+// height the outgoing parameters applied to on each commitment chain; it is
+// only consulted for epoch-affecting changes.
+//
+// This is an API-level primitive: it performs the safe mutation and validation.
+// It does not drive quiescence, negotiation, or the commitment dance; callers
+// are responsible for invoking it at the point each chain locks in.
+func (lc *LightningChannel) ApplyChannelParams(proposer lntypes.ChannelParty,
+	params ChannelParams, maxLocalCSVDelay uint16,
+	lockInHeights lntypes.Dual[uint64]) error {
+
+	lc.Lock()
+	defer lc.Unlock()
+
+	if params.IsEmpty() {
+		return ErrDynParamsNoChange
+	}
+
+	local := lc.channelState.LocalChanCfg
+	remote := lc.channelState.RemoteChanCfg
+
+	// Compute the resulting configs and validate the whole resulting set.
+	newLocal, newRemote := params.ApplyToConfigs(proposer, local, remote)
+	err := ValidateChannelParams(
+		newLocal, newRemote, lc.channelState.Capacity, maxLocalCSVDelay,
+	)
+	if err != nil {
+		return err
+	}
+
+	// Only script/output-rendering parameters (CSV/dust) produce an epoch
+	// entry. Build one that carries the proposer's new dust limit and the
+	// counterparty's new CSV, each defaulting to the current value so an
+	// unchanged field is preserved.
+	var epochChange fn.Option[channeldb.EpochParamChange]
+	if params.AffectsEpoch() {
+		cfgs := lntypes.Dual[channeldb.ChannelConfig]{
+			Local:  local,
+			Remote: remote,
+		}
+		proposerDust := params.DustLimit.UnwrapOr(
+			cfgs.GetForParty(proposer).DustLimit,
+		)
+		counterCsv := params.CsvDelay.UnwrapOr(
+			cfgs.GetForParty(proposer.CounterParty()).CsvDelay,
+		)
+
+		epochChange = fn.Some(channeldb.EpochParamChange{
+			WhoSpecified: proposer,
+			Params: channeldb.CommitmentParams{
+				DustLimit: proposerDust,
+				CsvDelay:  counterCsv,
+			},
+			LockInHeights: lockInHeights,
+		})
+	}
+
+	newFlags := params.ChannelFlags.UnwrapOr(lc.channelState.ChannelFlags)
+
+	return lc.channelState.ApplyChannelParams(
+		newLocal.ChannelStateBounds, newRemote.ChannelStateBounds,
+		newFlags, epochChange,
+	)
+}

--- a/lnwallet/chan_params_test.go
+++ b/lnwallet/chan_params_test.go
@@ -1,0 +1,401 @@
+package lnwallet
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/stretchr/testify/require"
+)
+
+// paramsTestCapacity is the channel capacity used by the validation tests. Its
+// fifth (the max reserve) is 200_000 sat.
+const paramsTestCapacity = btcutil.Amount(1_000_000)
+
+// paramsMaxCSV is the maximum CSV delay used by the validation tests.
+const paramsMaxCSV = uint16(2016)
+
+// validParamConfig returns a ChannelConfig whose dynamic parameters all satisfy
+// BOLT #2 and LND policy for a paramsTestCapacity channel.
+func validParamConfig(dust btcutil.Amount, csv uint16,
+	reserve btcutil.Amount, maxInFlight, minHTLC lnwire.MilliSatoshi,
+	maxAccepted uint16) channeldb.ChannelConfig {
+
+	return channeldb.ChannelConfig{
+		ChannelStateBounds: channeldb.ChannelStateBounds{
+			ChanReserve:      reserve,
+			MaxPendingAmount: maxInFlight,
+			MinHTLC:          minHTLC,
+			MaxAcceptedHtlcs: maxAccepted,
+		},
+		CommitmentParams: channeldb.CommitmentParams{
+			DustLimit: dust,
+			CsvDelay:  csv,
+		},
+	}
+}
+
+// TestValidateChannelParams verifies that ValidateChannelParams accepts a sane
+// resulting param set and rejects each cross-coupled or out-of-bounds violation
+// with the expected sentinel error.
+func TestValidateChannelParams(t *testing.T) {
+	t.Parallel()
+
+	// A fully valid baseline for both peers.
+	baseLocal := validParamConfig(
+		500, 144, 20_000, 500_000, 1_000, 100,
+	)
+	baseRemote := validParamConfig(
+		600, 144, 20_000, 500_000, 1_000, 100,
+	)
+
+	tests := []struct {
+		name    string
+		local   channeldb.ChannelConfig
+		remote  channeldb.ChannelConfig
+		wantErr error
+	}{
+		{
+			name:   "valid",
+			local:  baseLocal,
+			remote: baseRemote,
+		},
+		{
+			name: "dust below minimum",
+			local: validParamConfig(
+				300, 144, 20_000, 500_000, 1_000, 100,
+			),
+			remote:  baseRemote,
+			wantErr: ErrDynDustLimitTooSmall,
+		},
+		{
+			name:  "dust above maximum",
+			local: baseLocal,
+			remote: validParamConfig(
+				2_000, 144, 20_000, 500_000, 1_000, 100,
+			),
+			wantErr: ErrDynDustLimitTooLarge,
+		},
+		{
+			// Both dust limits are individually valid, but the
+			// smaller reserve drops below the larger dust limit.
+			name: "reserve below dust",
+			local: validParamConfig(
+				500, 144, 400, 500_000, 1_000, 100,
+			),
+			remote: validParamConfig(
+				600, 144, 20_000, 500_000, 1_000, 100,
+			),
+			wantErr: ErrDynReserveBelowDust,
+		},
+		{
+			name:  "reserve over capacity",
+			local: baseLocal,
+			remote: validParamConfig(
+				600, 144, 300_000, 500_000, 1_000, 100,
+			),
+			wantErr: ErrDynReserveTooLarge,
+		},
+		{
+			name: "csv too large",
+			local: validParamConfig(
+				500, 5_000, 20_000, 500_000, 1_000, 100,
+			),
+			remote:  baseRemote,
+			wantErr: ErrDynCsvDelayTooLarge,
+		},
+		{
+			name:  "max accepted htlcs too large",
+			local: baseLocal,
+			remote: validParamConfig(
+				600, 144, 20_000, 500_000, 1_000, 484,
+			),
+			wantErr: ErrDynMaxAcceptedTooLarge,
+		},
+		{
+			name: "htlc minimum exceeds max in flight",
+			local: validParamConfig(
+				500, 144, 20_000, 1_000, 2_000, 100,
+			),
+			remote:  baseRemote,
+			wantErr: ErrDynHtlcMinTooLarge,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ValidateChannelParams(
+				tc.local, tc.remote, paramsTestCapacity,
+				paramsMaxCSV,
+			)
+			if tc.wantErr == nil {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorIs(t, err, tc.wantErr)
+		})
+	}
+}
+
+// TestChannelParamsDynProposeRoundTrip verifies that a ChannelParams survives a
+// round-trip through the lnwire.DynPropose message, and that a partial proposal
+// only carries its set fields.
+func TestChannelParamsDynProposeRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	var chanID lnwire.ChannelID
+
+	// A full proposal round-trips losslessly.
+	full := ChannelParams{
+		DustLimit:        fn.Some(btcutil.Amount(500)),
+		MaxValueInFlight: fn.Some(lnwire.MilliSatoshi(600_000)),
+		HtlcMinimum:      fn.Some(lnwire.MilliSatoshi(1_000)),
+		ChannelReserve:   fn.Some(btcutil.Amount(20_000)),
+		CsvDelay:         fn.Some(uint16(288)),
+		MaxAcceptedHtlcs: fn.Some(uint16(100)),
+		ChannelFlags:     fn.Some(lnwire.FFAnnounceChannel),
+	}
+	require.Equal(
+		t, full,
+		ChannelParamsFromDynPropose(full.ToDynPropose(chanID)),
+	)
+
+	// A partial proposal only carries its set fields.
+	partial := ChannelParams{
+		CsvDelay:       fn.Some(uint16(144)),
+		ChannelReserve: fn.Some(btcutil.Amount(9_000)),
+	}
+	dp := partial.ToDynPropose(chanID)
+	require.True(t, dp.DustLimit.IsNone())
+	require.True(t, dp.MaxAcceptedHTLCs.IsNone())
+	require.True(t, dp.CsvDelay.IsSome())
+	require.True(t, dp.ChannelReserve.IsSome())
+	require.Equal(t, partial, ChannelParamsFromDynPropose(dp))
+}
+
+// TestChannelParamsConfigRoundTrip verifies that extracting a party's
+// advertised parameters from the channel configs and re-applying them yields
+// the original configs, for both parties.
+func TestChannelParamsConfigRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	local := validParamConfig(500, 5, 20_000, 500_000, 1_000, 100)
+	remote := validParamConfig(600, 4, 30_000, 400_000, 2_000, 200)
+
+	for _, party := range []lntypes.ChannelParty{
+		lntypes.Local, lntypes.Remote,
+	} {
+		t.Run(party.String(), func(t *testing.T) {
+			t.Parallel()
+
+			params := ChannelParamsFromConfigs(
+				party, local, remote, lnwire.FFAnnounceChannel,
+			)
+			gotLocal, gotRemote := params.ApplyToConfigs(
+				party, local, remote,
+			)
+			require.Equal(t, local, gotLocal)
+			require.Equal(t, remote, gotRemote)
+		})
+	}
+}
+
+// TestChannelParamsApplyToConfigs asserts the proposer-owned mapping: the
+// proposer's own dust limit updates its own config, while the remaining
+// parameters update the counterparty's config.
+func TestChannelParamsApplyToConfigs(t *testing.T) {
+	t.Parallel()
+
+	local := validParamConfig(500, 5, 20_000, 500_000, 1_000, 100)
+	remote := validParamConfig(600, 4, 30_000, 400_000, 2_000, 200)
+
+	params := ChannelParams{
+		DustLimit:        fn.Some(btcutil.Amount(400)),
+		CsvDelay:         fn.Some(uint16(288)),
+		ChannelReserve:   fn.Some(btcutil.Amount(25_000)),
+		MaxAcceptedHtlcs: fn.Some(uint16(150)),
+	}
+
+	// Local proposes: its own dust changes, and the rest land on Remote.
+	newLocal, newRemote := params.ApplyToConfigs(lntypes.Local, local, remote)
+	require.EqualValues(t, 400, newLocal.DustLimit)
+	require.EqualValues(t, 5, newLocal.CsvDelay)         // unchanged
+	require.EqualValues(t, 20_000, newLocal.ChanReserve) // unchanged
+	require.EqualValues(t, 288, newRemote.CsvDelay)
+	require.EqualValues(t, 25_000, newRemote.ChanReserve)
+	require.EqualValues(t, 150, newRemote.MaxAcceptedHtlcs)
+	require.EqualValues(t, 600, newRemote.DustLimit) // unchanged
+
+	// Remote proposes: its own dust changes, and the rest land on Local.
+	newLocal, newRemote = params.ApplyToConfigs(lntypes.Remote, local, remote)
+	require.EqualValues(t, 400, newRemote.DustLimit)
+	require.EqualValues(t, 288, newLocal.CsvDelay)
+	require.EqualValues(t, 25_000, newLocal.ChanReserve)
+	require.EqualValues(t, 150, newLocal.MaxAcceptedHtlcs)
+	require.EqualValues(t, 500, newLocal.DustLimit) // unchanged
+}
+
+// newParamsTestChannel returns a persisted LightningChannel whose dust limits
+// have been brought into the range dynamic-params validation enforces (the
+// default test dust limits of 200/1300 fall outside [354, 1062]).
+func newParamsTestChannel(t *testing.T) *LightningChannel {
+	t.Helper()
+
+	alice, _, err := CreateTestChannels(t, channeldb.SingleFunderTweaklessBit)
+	require.NoError(t, err)
+
+	cs := alice.channelState
+	heights := lntypes.Dual[uint64]{Local: 1, Remote: 1}
+
+	// Bring the Local dust into range (keeping the Remote's CSV).
+	require.NoError(t, cs.ApplyChannelParams(
+		cs.LocalChanCfg.ChannelStateBounds,
+		cs.RemoteChanCfg.ChannelStateBounds, cs.ChannelFlags,
+		fn.Some(channeldb.EpochParamChange{
+			WhoSpecified: lntypes.Local,
+			Params: channeldb.CommitmentParams{
+				DustLimit: 500,
+				CsvDelay:  cs.RemoteChanCfg.CsvDelay,
+			},
+			LockInHeights: heights,
+		}),
+	))
+
+	// Bring the Remote dust into range (keeping the Local's CSV).
+	require.NoError(t, cs.ApplyChannelParams(
+		cs.LocalChanCfg.ChannelStateBounds,
+		cs.RemoteChanCfg.ChannelStateBounds, cs.ChannelFlags,
+		fn.Some(channeldb.EpochParamChange{
+			WhoSpecified: lntypes.Remote,
+			Params: channeldb.CommitmentParams{
+				DustLimit: 600,
+				CsvDelay:  cs.LocalChanCfg.CsvDelay,
+			},
+			LockInHeights: heights,
+		}),
+	))
+
+	return alice
+}
+
+// epochCounts returns the number of closed epochs on each side.
+func epochCounts(c *channeldb.OpenChannel) (int, int) {
+	return len(c.CommitChainEpochHistory.Historical.Local),
+		len(c.CommitChainEpochHistory.Historical.Remote)
+}
+
+// TestLightningChannelApplyChannelParams exercises the end-to-end apply flow on
+// a LightningChannel: policy-only changes must not touch the epoch history,
+// CSV/dust changes must, invalid proposals are rejected without mutating state,
+// and an empty proposal is rejected.
+func TestLightningChannelApplyChannelParams(t *testing.T) {
+	t.Parallel()
+
+	heights := lntypes.Dual[uint64]{Local: 5, Remote: 4}
+
+	t.Run("policy-only records no epoch", func(t *testing.T) {
+		t.Parallel()
+
+		lc := newParamsTestChannel(t)
+		cs := lc.channelState
+		localEpochs, remoteEpochs := epochCounts(cs)
+
+		// Local proposes a new max_accepted_htlcs, which is a policy
+		// parameter imposed on the Remote counterparty.
+		params := ChannelParams{
+			MaxAcceptedHtlcs: fn.Some(uint16(200)),
+		}
+		require.NoError(t, lc.ApplyChannelParams(
+			lntypes.Local, params, paramsMaxCSV, heights,
+		))
+
+		// The counterparty's config reflects the change...
+		require.EqualValues(
+			t, 200, cs.RemoteChanCfg.MaxAcceptedHtlcs,
+		)
+
+		// ... and no new epoch was recorded on either side.
+		gotLocal, gotRemote := epochCounts(cs)
+		require.Equal(t, localEpochs, gotLocal)
+		require.Equal(t, remoteEpochs, gotRemote)
+	})
+
+	t.Run("csv change records epoch", func(t *testing.T) {
+		t.Parallel()
+
+		lc := newParamsTestChannel(t)
+		cs := lc.channelState
+		localEpochs, remoteEpochs := epochCounts(cs)
+		oldLocalCsv := cs.LocalChanCfg.CsvDelay
+
+		// Local proposes a new CSV, which is imposed on the Remote
+		// counterparty and is epoch-affecting.
+		params := ChannelParams{
+			CsvDelay: fn.Some(uint16(1_000)),
+		}
+		require.NoError(t, lc.ApplyChannelParams(
+			lntypes.Local, params, paramsMaxCSV, heights,
+		))
+
+		// The counterparty's CSV changed; the proposer's is untouched.
+		require.EqualValues(t, 1_000, cs.RemoteChanCfg.CsvDelay)
+		require.Equal(t, oldLocalCsv, cs.LocalChanCfg.CsvDelay)
+
+		// A new epoch was recorded on each side at the lock-in heights.
+		gotLocal, gotRemote := epochCounts(cs)
+		require.Equal(t, localEpochs+1, gotLocal)
+		require.Equal(t, remoteEpochs+1, gotRemote)
+
+		lastLocal := cs.CommitChainEpochHistory.Historical.Local[gotLocal-1]
+		lastRemote :=
+			cs.CommitChainEpochHistory.Historical.Remote[gotRemote-1]
+		require.EqualValues(t, heights.Local, lastLocal.LastHeight)
+		require.EqualValues(t, heights.Remote, lastRemote.LastHeight)
+
+		// The config's rendering params track the epoch history.
+		require.Equal(
+			t, cs.CommitChainEpochHistory.Current.Remote,
+			cs.RemoteChanCfg.CommitmentParams,
+		)
+	})
+
+	t.Run("invalid proposal rejected", func(t *testing.T) {
+		t.Parallel()
+
+		lc := newParamsTestChannel(t)
+		cs := lc.channelState
+		before := cs.RemoteChanCfg.MaxAcceptedHtlcs
+		localEpochs, remoteEpochs := epochCounts(cs)
+
+		// 484 exceeds the protocol maximum of 483.
+		params := ChannelParams{
+			MaxAcceptedHtlcs: fn.Some(uint16(484)),
+		}
+		err := lc.ApplyChannelParams(
+			lntypes.Local, params, paramsMaxCSV, heights,
+		)
+		require.ErrorIs(t, err, ErrDynMaxAcceptedTooLarge)
+
+		// No state was mutated.
+		require.Equal(t, before, cs.RemoteChanCfg.MaxAcceptedHtlcs)
+		gotLocal, gotRemote := epochCounts(cs)
+		require.Equal(t, localEpochs, gotLocal)
+		require.Equal(t, remoteEpochs, gotRemote)
+	})
+
+	t.Run("empty proposal rejected", func(t *testing.T) {
+		t.Parallel()
+
+		lc := newParamsTestChannel(t)
+		err := lc.ApplyChannelParams(
+			lntypes.Local, ChannelParams{}, paramsMaxCSV, heights,
+		)
+		require.True(t, errors.Is(err, ErrDynParamsNoChange))
+	})
+}


### PR DESCRIPTION
Part of the Dynamic Commitments milestone: #60

Canonical mutable channel-params API + validation (epoch-affecting vs policy-only).

**Stacked PR** — based on `yy-dyn-3-breach`; review after that branch (the base updates automatically as the parent merges).

Opened as a **draft**: this is part of the exploratory params-only stack (coarse commits, not final hygiene).