### PR TITLE
htlcswitch/dyn: core negotiation updater

### DIFF
--- a/htlcswitch/dyn/interfaces.go
+++ b/htlcswitch/dyn/interfaces.go
@@ -1,0 +1,153 @@
+package dyn
+
+import (
+	"context"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnwallet"
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+// Signer abstracts the production of and verification of dyn_ack signatures. It
+// hides the key material from the state machine: an implementation signs with
+// our node identity key and verifies against the peer's node identity key. The
+// digest inputs are supplied by the caller and match lnwire.DynAckSigDigest.
+//
+// Branch 6 wires this to the real keychain/signer; tests inject a fake.
+type Signer interface {
+	// SignDynAck produces our dyn_ack signature over the accepted proposal.
+	// The proposalTLVs must be the exact dyn_propose_tlvs stream, i.e. the
+	// output of DynPropose.SerializeTlvData.
+	SignDynAck(chainHash chainhash.Hash, chanID lnwire.ChannelID,
+		nextCommitHeight uint64, proposalTLVs []byte) (lnwire.Sig,
+		error)
+
+	// VerifyDynAck verifies the peer's dyn_ack signature over the proposal
+	// we sent. It returns nil on success and an error otherwise.
+	VerifyDynAck(sig lnwire.Sig, chainHash chainhash.Hash,
+		chanID lnwire.ChannelID, nextCommitHeight uint64,
+		proposalTLVs []byte) error
+}
+
+// ChannelView is the read-only window the state machine has onto the live
+// channel. It exposes the eligibility predicates the machine enforces as
+// preconditions, plus the channel data needed to build, validate, and bind a
+// proposal. It is deliberately narrow so the machine can be unit-tested without
+// a live link.
+//
+// Branch 6 implements this over the real channelLink/LightningChannel; tests
+// inject a fake.
+type ChannelView interface {
+	// ChanID returns the channel id this view is for.
+	ChanID() lnwire.ChannelID
+
+	// ChainHash returns the genesis hash of the chain the channel is on. It
+	// is bound into the dyn_ack signature digest.
+	ChainHash() chainhash.Hash
+
+	// LocalChanCfg returns our current channel configuration.
+	LocalChanCfg() channeldb.ChannelConfig
+
+	// RemoteChanCfg returns the peer's current channel configuration.
+	RemoteChanCfg() channeldb.ChannelConfig
+
+	// Capacity returns the total channel capacity, used to bound the
+	// channel reserve during validation.
+	Capacity() btcutil.Amount
+
+	// NextCommitHeight returns the commitment number the dynamic update will
+	// be committed at. At quiescence both commitment chains are synchronized
+	// and have no pending updates, so this value is unambiguous and shared
+	// by both peers when computing the dyn_ack digest.
+	NextCommitHeight() uint64
+
+	// BothChannelReady returns true only once both peers have sent and
+	// received channel_ready. A dynamic update may neither be sent nor
+	// accepted before this holds.
+	BothChannelReady() bool
+
+	// IsQuiescent returns true if the channel has been driven to
+	// quiescence. Dynamic updates require a quiescent channel.
+	IsQuiescent() bool
+
+	// QuiescenceInitiator returns the party that initiated quiescence. The
+	// proposer of a dynamic update must be the quiescence initiator. It
+	// returns an error if the channel is not currently quiescent.
+	QuiescenceInitiator() fn.Result[lntypes.ChannelParty]
+
+	// HasHTLCs returns true if either commitment has any HTLCs, including
+	// trimmed HTLCs. A dynamic update requires that there are none.
+	HasHTLCs() bool
+
+	// HasPendingUpdates returns true if there are update-log entries that
+	// are not yet bilaterally committed on both chains.
+	HasPendingUpdates() bool
+
+	// HasPendingShutdown returns true if a cooperative shutdown is in
+	// progress on the channel.
+	HasPendingShutdown() bool
+
+	// HasPendingSpliceOrRBF returns true if a splice or an RBF of a pending
+	// funding/close is in progress on the channel.
+	HasPendingSpliceOrRBF() bool
+}
+
+// AcceptedProposal is the context that must survive across the persistence
+// boundaries the extension BOLT calls out, so a reconnect (branch 8) can decide
+// whether to resume or forget a negotiation. It captures the accepted proposal,
+// which party proposed it, the commitment number it binds to, and, once known,
+// the responder's dyn_ack signature.
+type AcceptedProposal struct {
+	// Proposer is the party that sent the dyn_propose. If it equals
+	// lntypes.Local we are the proposer, otherwise we are the responder.
+	Proposer lntypes.ChannelParty
+
+	// Proposal is the accepted proposal message.
+	Proposal *lnwire.DynPropose
+
+	// NextCommitHeight is the commitment number the update binds to; it is
+	// bound into the dyn_ack signature digest.
+	NextCommitHeight uint64
+
+	// AckSig is the responder's dyn_ack signature. It is set on the
+	// responder once it signs, and on the proposer once it verifies the
+	// received dyn_ack.
+	AckSig fn.Option[lnwire.Sig]
+}
+
+// Params returns the canonical channel-params view of the accepted proposal.
+func (a *AcceptedProposal) Params() lnwallet.ChannelParams {
+	return lnwallet.ChannelParamsFromDynPropose(a.Proposal)
+}
+
+// Persister persists the accepted-proposal context at the boundaries the state
+// machine calls out. Branch 8 implements this over channeldb; the in-memory
+// MemPersister is provided for tests. The state machine never assumes a
+// particular storage medium.
+type Persister interface {
+	// StoreAcceptedProposal persists (or overwrites) the accepted-proposal
+	// context for the given channel.
+	StoreAcceptedProposal(ctx context.Context, chanID lnwire.ChannelID,
+		p AcceptedProposal) error
+
+	// FetchAcceptedProposal loads the persisted context for the given
+	// channel, if any.
+	FetchAcceptedProposal(ctx context.Context,
+		chanID lnwire.ChannelID) (fn.Option[AcceptedProposal], error)
+
+	// DeleteAcceptedProposal removes any persisted context for the given
+	// channel. It is a no-op if none exists.
+	DeleteAcceptedProposal(ctx context.Context,
+		chanID lnwire.ChannelID) error
+}
+
+// MessageSender sends wire messages to the peer on the other end of the
+// channel. Branch 6 wires this to the peer connection; tests inject a recorder.
+type MessageSender interface {
+	// SendMessage sends the given messages to the peer, in order.
+	SendMessage(ctx context.Context, msgs ...lnwire.Message) error
+}

--- a/htlcswitch/dyn/log.go
+++ b/htlcswitch/dyn/log.go
@@ -1,0 +1,32 @@
+package dyn
+
+import (
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightningnetwork/lnd/build"
+)
+
+// Subsystem defines the logging code for this subsystem.
+const Subsystem = "DYNC"
+
+// log is a logger that is initialized with no output filters. This means the
+// package will not perform any logging by default until the caller requests it.
+var log btclog.Logger
+
+// The default amount of logging is none.
+func init() {
+	logger := build.NewSubLogger(Subsystem, nil)
+
+	UseLogger(logger)
+}
+
+// DisableLog disables all library log output. Logging output is disabled by
+// default until UseLogger is called.
+func DisableLog() {
+	UseLogger(btclog.Disabled)
+}
+
+// UseLogger uses a specified Logger to output package logging info. This should
+// be used in preference to SetLogWriter if the caller is also using btclog.
+func UseLogger(logger btclog.Logger) {
+	log = logger
+}

--- a/htlcswitch/dyn/mem_persister.go
+++ b/htlcswitch/dyn/mem_persister.go
@@ -1,0 +1,74 @@
+package dyn
+
+import (
+	"context"
+	"sync"
+
+	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+// MemPersister is an in-memory Persister. It is primarily intended for tests
+// and as the reference implementation of the Persister contract; the durable
+// channeldb-backed implementation lands in the reestablish branch.
+type MemPersister struct {
+	mu    sync.Mutex
+	store map[lnwire.ChannelID]AcceptedProposal
+}
+
+// A compile-time assertion that MemPersister implements Persister.
+var _ Persister = (*MemPersister)(nil)
+
+// NewMemPersister constructs an empty in-memory Persister.
+func NewMemPersister() *MemPersister {
+	return &MemPersister{
+		store: make(map[lnwire.ChannelID]AcceptedProposal),
+	}
+}
+
+// StoreAcceptedProposal persists (or overwrites) the accepted-proposal context
+// for the given channel.
+//
+// NOTE: Part of the Persister interface.
+func (m *MemPersister) StoreAcceptedProposal(_ context.Context,
+	chanID lnwire.ChannelID, p AcceptedProposal) error {
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.store[chanID] = p
+
+	return nil
+}
+
+// FetchAcceptedProposal loads the persisted context for the given channel, if
+// any.
+//
+// NOTE: Part of the Persister interface.
+func (m *MemPersister) FetchAcceptedProposal(_ context.Context,
+	chanID lnwire.ChannelID) (fn.Option[AcceptedProposal], error) {
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	p, ok := m.store[chanID]
+	if !ok {
+		return fn.None[AcceptedProposal](), nil
+	}
+
+	return fn.Some(p), nil
+}
+
+// DeleteAcceptedProposal removes any persisted context for the given channel.
+//
+// NOTE: Part of the Persister interface.
+func (m *MemPersister) DeleteAcceptedProposal(_ context.Context,
+	chanID lnwire.ChannelID) error {
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	delete(m.store, chanID)
+
+	return nil
+}

--- a/htlcswitch/dyn/state.go
+++ b/htlcswitch/dyn/state.go
@@ -1,0 +1,232 @@
+package dyn
+
+import "fmt"
+
+// State enumerates the states of the dynamic-commitments negotiation state
+// machine. The machine negotiates a single parameter change per session; once a
+// terminal state is reached the caller must Reset (after a fresh quiescence
+// session) before a new negotiation can begin.
+//
+// The machine is role-aware: a session is driven either as the proposer (we
+// sent dyn_propose) or as the responder (the peer sent dyn_propose). The role
+// is fixed for the lifetime of a session.
+type State uint8
+
+const (
+	// StateIdle is the initial and reset state. No negotiation is in
+	// progress and the machine is ready to either start a local proposal or
+	// accept a remote one.
+	StateIdle State = iota
+
+	// StateAwaitingAck is the proposer state entered after we send a
+	// dyn_propose. We are waiting for the responder to reply with a dyn_ack
+	// (accept) or a dyn_reject (reject), or for the negotiation to time
+	// out.
+	StateAwaitingAck
+
+	// StateAckSent is the responder state entered after we validate an
+	// incoming dyn_propose and send our dyn_ack. We are waiting for the
+	// proposer's bundled dyn_commit_sig, or for the negotiation to time
+	// out. Per the extension BOLT the responder retains this acceptance
+	// until it observes the commit, a superseding proposal, or a timeout.
+	StateAckSent
+
+	// StateAccepted is the proposer state entered after we receive and
+	// verify the responder's dyn_ack. Negotiation has succeeded and the
+	// machine emits a ready-to-commit handoff: the link is expected to build
+	// and send the bundled dyn_commit_sig and then call MarkCommitSent.
+	StateAccepted
+
+	// StateCommitting is the committing-handoff state. Negotiation is
+	// complete and the commitment dance has been handed off to the link
+	// (branch 6 owns the dance). The proposer enters it once it has sent the
+	// bundled dyn_commit_sig; the responder enters it once it has received
+	// one. This is terminal for this state machine.
+	StateCommitting
+
+	// StateRejected is a terminal state entered when a dyn_reject is sent or
+	// received. Per the locked design decisions a rejection ends the current
+	// quiescence session; a retry requires fresh quiescence.
+	StateRejected
+
+	// StateFailed is a terminal state entered on an unrecoverable error: an
+	// invalid dyn_ack signature, an illegal protocol message, or a
+	// negotiation timeout. The caller is expected to disconnect.
+	StateFailed
+)
+
+// String returns a human-readable representation of the state.
+func (s State) String() string {
+	switch s {
+	case StateIdle:
+		return "Idle"
+
+	case StateAwaitingAck:
+		return "AwaitingAck"
+
+	case StateAckSent:
+		return "AckSent"
+
+	case StateAccepted:
+		return "Accepted"
+
+	case StateCommitting:
+		return "Committing"
+
+	case StateRejected:
+		return "Rejected"
+
+	case StateFailed:
+		return "Failed"
+
+	default:
+		return fmt.Sprintf("Unknown(%d)", s)
+	}
+}
+
+// IsTerminal returns true if no further transitions are possible from the state
+// without a Reset.
+func (s State) IsTerminal() bool {
+	switch s {
+	case StateCommitting, StateRejected, StateFailed:
+		return true
+
+	default:
+		return false
+	}
+}
+
+// eventType enumerates the inputs that drive the state machine. An event is the
+// already-resolved outcome of processing a request or a wire message: for
+// example, the decision of whether an incoming proposal is acceptable is made
+// by the caller before it is fed to the transition function as either
+// eventProposeOK or eventProposeBad. This keeps the transition function a
+// total, side-effect-free function of (state, event).
+type eventType uint8
+
+const (
+	// eventPropose is a local request to start a proposal. Valid from Idle
+	// and moves the machine to AwaitingAck (proposer role).
+	eventPropose eventType = iota
+
+	// eventProposeOK is a remote dyn_propose that passed preconditions and
+	// validation. Valid from Idle and moves the machine to AckSent
+	// (responder role).
+	eventProposeOK
+
+	// eventProposeBad is a remote dyn_propose that failed preconditions or
+	// validation. Valid from Idle and moves the machine to Rejected.
+	eventProposeBad
+
+	// eventAckOK is a valid dyn_ack received by the proposer. Valid from
+	// AwaitingAck and moves the machine to Accepted.
+	eventAckOK
+
+	// eventReject is a dyn_reject received by the proposer. Valid from
+	// AwaitingAck and moves the machine to Rejected.
+	eventReject
+
+	// eventCommitSent signals the proposer has sent the bundled
+	// dyn_commit_sig. Valid from Accepted and moves the machine to
+	// Committing.
+	eventCommitSent
+
+	// eventCommitRecv signals the responder has received the bundled
+	// dyn_commit_sig. Valid from AckSent and moves the machine to
+	// Committing.
+	eventCommitRecv
+
+	// eventTimeout signals the negotiation timeout has elapsed. Valid from
+	// the two waiting states (AwaitingAck, AckSent) and moves the machine to
+	// Failed.
+	eventTimeout
+
+	// eventFail signals an unrecoverable protocol error (bad signature,
+	// mismatched commit). Valid from any active state and moves the machine
+	// to Failed.
+	eventFail
+)
+
+// String returns a human-readable representation of the event.
+func (e eventType) String() string {
+	switch e {
+	case eventPropose:
+		return "Propose"
+
+	case eventProposeOK:
+		return "ProposeOK"
+
+	case eventProposeBad:
+		return "ProposeBad"
+
+	case eventAckOK:
+		return "AckOK"
+
+	case eventReject:
+		return "Reject"
+
+	case eventCommitSent:
+		return "CommitSent"
+
+	case eventCommitRecv:
+		return "CommitRecv"
+
+	case eventTimeout:
+		return "Timeout"
+
+	case eventFail:
+		return "Fail"
+
+	default:
+		return fmt.Sprintf("Unknown(%d)", e)
+	}
+}
+
+// transitions is the documented transition function of the state machine,
+// expressed as a table mapping the current state and an event to the next
+// state. An entry that is absent means the event is illegal in that state and
+// advance will return ErrInvalidTransition. Terminal states have no outgoing
+// entries.
+//
+// The table intentionally does not encode conditional targets (for example the
+// accept-vs-reject decision for an incoming proposal). Those decisions are made
+// by the caller, which then feeds the resolved event (eventProposeOK vs
+// eventProposeBad) to advance.
+var transitions = map[State]map[eventType]State{
+	StateIdle: {
+		eventPropose:    StateAwaitingAck,
+		eventProposeOK:  StateAckSent,
+		eventProposeBad: StateRejected,
+	},
+	StateAwaitingAck: {
+		eventAckOK:   StateAccepted,
+		eventReject:  StateRejected,
+		eventTimeout: StateFailed,
+		eventFail:    StateFailed,
+	},
+	StateAckSent: {
+		eventCommitRecv: StateCommitting,
+		eventTimeout:    StateFailed,
+		eventFail:       StateFailed,
+	},
+	StateAccepted: {
+		eventCommitSent: StateCommitting,
+		eventFail:       StateFailed,
+	},
+	StateCommitting: {},
+	StateRejected:   {},
+	StateFailed:     {},
+}
+
+// advance is the pure transition function. Given the current state and an
+// event it returns the next state, or ErrInvalidTransition if the event is not
+// legal in the current state. It performs no side effects.
+func advance(from State, e eventType) (State, error) {
+	next, ok := transitions[from][e]
+	if !ok {
+		return from, fmt.Errorf("%w: event %s in state %s",
+			ErrInvalidTransition, e, from)
+	}
+
+	return next, nil
+}

--- a/htlcswitch/dyn/state_test.go
+++ b/htlcswitch/dyn/state_test.go
@@ -1,0 +1,89 @@
+package dyn
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestAdvanceTable exercises the pure transition function directly, checking
+// both the legal edges and that every other (state, event) pair is rejected as
+// an invalid transition.
+func TestAdvanceTable(t *testing.T) {
+	t.Parallel()
+
+	allStates := []State{
+		StateIdle, StateAwaitingAck, StateAckSent, StateAccepted,
+		StateCommitting, StateRejected, StateFailed,
+	}
+	allEvents := []eventType{
+		eventPropose, eventProposeOK, eventProposeBad, eventAckOK,
+		eventReject, eventCommitSent, eventCommitRecv, eventTimeout,
+		eventFail,
+	}
+
+	// The complete set of legal edges, mirroring the transitions table.
+	legal := map[State]map[eventType]State{
+		StateIdle: {
+			eventPropose:    StateAwaitingAck,
+			eventProposeOK:  StateAckSent,
+			eventProposeBad: StateRejected,
+		},
+		StateAwaitingAck: {
+			eventAckOK:   StateAccepted,
+			eventReject:  StateRejected,
+			eventTimeout: StateFailed,
+			eventFail:    StateFailed,
+		},
+		StateAckSent: {
+			eventCommitRecv: StateCommitting,
+			eventTimeout:    StateFailed,
+			eventFail:       StateFailed,
+		},
+		StateAccepted: {
+			eventCommitSent: StateCommitting,
+			eventFail:       StateFailed,
+		},
+	}
+
+	for _, from := range allStates {
+		for _, e := range allEvents {
+			want, ok := legal[from][e]
+
+			to, err := advance(from, e)
+			if !ok {
+				require.ErrorIs(t, err, ErrInvalidTransition)
+				require.Equal(t, from, to)
+
+				continue
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, want, to)
+		}
+	}
+}
+
+// TestStateStrings checks that every state and event has a distinct,
+// non-default string form.
+func TestStateStrings(t *testing.T) {
+	t.Parallel()
+
+	states := []State{
+		StateIdle, StateAwaitingAck, StateAckSent, StateAccepted,
+		StateCommitting, StateRejected, StateFailed,
+	}
+	seen := make(map[string]struct{})
+	for _, s := range states {
+		str := s.String()
+		require.NotContains(t, str, "Unknown")
+		require.NotContains(t, seen, str)
+		seen[str] = struct{}{}
+	}
+
+	require.True(t, StateCommitting.IsTerminal())
+	require.True(t, StateRejected.IsTerminal())
+	require.True(t, StateFailed.IsTerminal())
+	require.False(t, StateIdle.IsTerminal())
+	require.False(t, StateAwaitingAck.IsTerminal())
+}

--- a/htlcswitch/dyn/updater.go
+++ b/htlcswitch/dyn/updater.go
@@ -1,0 +1,791 @@
+package dyn
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/lightningnetwork/lnd/clock"
+	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnwallet"
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+const (
+	// DefaultTimeout is the default negotiation timeout. If a negotiation
+	// does not reach the commitment-handoff boundary within this window the
+	// machine fails and the caller disconnects, matching the extension BOLT
+	// requirement that stale pre-commit negotiations are abandoned.
+	DefaultTimeout = 30 * time.Second
+)
+
+var (
+	// ErrInvalidTransition is returned when an event is fed to the state
+	// machine in a state that does not accept it. It wraps a description of
+	// the offending (state, event) pair.
+	ErrInvalidTransition = errors.New("invalid state transition")
+
+	// ErrNegotiationInProgress is returned when a new local proposal is
+	// requested while a negotiation is already in progress.
+	ErrNegotiationInProgress = errors.New("dyn negotiation in progress")
+
+	// ErrChannelNotReady is returned when a proposal is attempted or
+	// accepted before both peers have exchanged channel_ready.
+	ErrChannelNotReady = errors.New("channel_ready not exchanged")
+
+	// ErrNotQuiescent is returned when a proposal is attempted or accepted
+	// while the channel is not quiescent.
+	ErrNotQuiescent = errors.New("channel is not quiescent")
+
+	// ErrNotQuiescenceInitiator is returned when the proposer is not the
+	// quiescence initiator, which the extension BOLT requires.
+	ErrNotQuiescenceInitiator = errors.New(
+		"proposer is not the quiescence initiator",
+	)
+
+	// ErrHTLCsActive is returned when a proposal is attempted or accepted
+	// while either commitment carries HTLCs (including trimmed HTLCs).
+	ErrHTLCsActive = errors.New("channel has active HTLCs")
+
+	// ErrPendingUpdates is returned when a proposal is attempted or
+	// accepted while there are uncommitted update-log entries.
+	ErrPendingUpdates = errors.New("channel has pending updates")
+
+	// ErrPendingShutdown is returned when a proposal is attempted or
+	// accepted while a cooperative shutdown is in progress.
+	ErrPendingShutdown = errors.New("channel has a pending shutdown")
+
+	// ErrPendingSpliceOrRBF is returned when a proposal is attempted or
+	// accepted while a splice or RBF is in progress.
+	ErrPendingSpliceOrRBF = errors.New("channel has a pending splice/RBF")
+
+	// ErrProposalMismatch is returned when a received dyn_commit_sig does
+	// not carry the same proposal the responder previously acked.
+	ErrProposalMismatch = errors.New(
+		"dyn_commit_sig proposal does not match acked proposal",
+	)
+)
+
+// ProposalRequest is a local request to renegotiate the channel parameters. RPC
+// wiring that builds it lands in a later branch.
+type ProposalRequest struct {
+	// Params are the parameter changes to propose. Proposer-owned semantics
+	// apply: the change updates the values we advertised at channel open,
+	// except ChannelFlags, which is channel-wide.
+	Params lnwallet.ChannelParams
+}
+
+// CommitHandoff is the ready-to-commit signal the machine emits once
+// negotiation succeeds. It hands the agreed update to the link, which then
+// performs the commitment dance (branch 6). This state machine deliberately
+// does not perform the dance itself.
+type CommitHandoff struct {
+	// Proposer identifies who proposed the update. If it equals
+	// lntypes.Local we are the proposer and must build and send the bundled
+	// dyn_commit_sig; otherwise we are the responder and must verify and
+	// apply the received one.
+	Proposer lntypes.ChannelParty
+
+	// Params is the agreed parameter set.
+	Params lnwallet.ChannelParams
+
+	// Proposal is the accepted proposal message.
+	Proposal *lnwire.DynPropose
+
+	// NextCommitHeight is the commitment number the update binds to.
+	NextCommitHeight uint64
+
+	// AckSig is the responder's dyn_ack signature: the signature we
+	// verified (proposer handoff) or the one we produced (responder
+	// handoff).
+	AckSig lnwire.Sig
+
+	// ReceivedCommit is the bundled dyn_commit_sig, set only on the
+	// responder handoff.
+	ReceivedCommit fn.Option[*lnwire.DynCommit]
+}
+
+// Transition is the result of feeding an event to the machine. It reports the
+// states straddled by the event, any wire messages the machine sent to the peer
+// as a result, an optional ready-to-commit handoff, and whether the caller
+// should disconnect.
+type Transition struct {
+	// From is the state before the event was applied.
+	From State
+
+	// To is the state after the event was applied.
+	To State
+
+	// Messages are the wire messages the machine sent to the peer via the
+	// configured MessageSender as a result of the event, in send order. It
+	// is informational: the machine has already dispatched them.
+	Messages []lnwire.Message
+
+	// Handoff, when present, signals that negotiation succeeded and the link
+	// should drive the commitment dance.
+	Handoff fn.Option[CommitHandoff]
+
+	// Disconnect is true when the caller should drop the connection, i.e.
+	// on a fatal protocol error or a negotiation timeout.
+	Disconnect bool
+}
+
+// Config bundles the injected dependencies of an Updater. Every edge of the
+// machine is an interface so it unit-tests without a live link/peer.
+type Config struct {
+	// Signer signs and verifies dyn_ack signatures.
+	Signer Signer
+
+	// ChannelView is the read-only window onto the live channel.
+	ChannelView ChannelView
+
+	// Persister persists the accepted-proposal context.
+	Persister Persister
+
+	// Sender sends wire messages to the peer.
+	Sender MessageSender
+
+	// Clock provides the time reference for the negotiation timeout.
+	Clock clock.Clock
+
+	// Timeout is the negotiation timeout. If zero, DefaultTimeout is used.
+	Timeout time.Duration
+
+	// MaxLocalCSVDelay is our configured maximum acceptable to_self_delay,
+	// used when validating a proposal.
+	MaxLocalCSVDelay uint16
+}
+
+// Updater is the scoped dynamic-commitments negotiation state machine. It owns
+// dyn-param negotiation only: it drives dyn_propose/dyn_ack/dyn_reject to an
+// agreement and then hands off to the link for the commitment dance. It is safe
+// for concurrent use.
+type Updater struct {
+	// mu serializes all transitions, so the machine advances one event at a
+	// time and its observable state is always consistent.
+	mu sync.Mutex
+
+	// cfg holds the injected dependencies.
+	cfg Config
+
+	// chanID is the channel this updater manages, cached from the view.
+	chanID lnwire.ChannelID
+
+	// state is the current state of the machine.
+	state State
+
+	// role is the proposer party for the in-flight session: lntypes.Local
+	// if we proposed, lntypes.Remote if the peer did. It is only meaningful
+	// while a session is active.
+	role lntypes.ChannelParty
+
+	// proposal is the in-flight proposal message: the one we sent (proposer)
+	// or the one we acked (responder).
+	proposal *lnwire.DynPropose
+
+	// nextHeight is the commitment number the in-flight update binds to.
+	nextHeight uint64
+
+	// ackSig holds the responder's dyn_ack signature once known.
+	ackSig fn.Option[lnwire.Sig]
+
+	// deadline is the time at which the in-flight negotiation times out. It
+	// is only meaningful while timerArmed is true.
+	deadline time.Time
+
+	// timerArmed is true while a negotiation timeout is pending.
+	timerArmed bool
+}
+
+// NewUpdater constructs an Updater in the Idle state from the given config.
+func NewUpdater(cfg Config) *Updater {
+	if cfg.Timeout == 0 {
+		cfg.Timeout = DefaultTimeout
+	}
+
+	return &Updater{
+		cfg:    cfg,
+		chanID: cfg.ChannelView.ChanID(),
+		state:  StateIdle,
+	}
+}
+
+// State returns the current state of the machine.
+func (u *Updater) State() State {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	return u.state
+}
+
+// InitProposal starts a local proposal. It enforces the send-side
+// preconditions, validates the resulting channel, sends a dyn_propose, persists
+// the proposal context, and moves the machine to AwaitingAck. On any
+// precondition or validation failure it returns a typed error and leaves the
+// machine Idle so the caller can surface the reason and exit quiescence.
+func (u *Updater) InitProposal(ctx context.Context,
+	req ProposalRequest) (*Transition, error) {
+
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	if u.state != StateIdle {
+		return nil, ErrNegotiationInProgress
+	}
+
+	// We are the proposer, so we must be the quiescence initiator and the
+	// send-side preconditions must hold.
+	if err := u.checkPreconditions(lntypes.Local); err != nil {
+		return nil, err
+	}
+
+	view := u.cfg.ChannelView
+
+	// Validate the whole resulting channel with proposer-owned semantics
+	// before we commit to sending anything.
+	err := req.Params.Validate(
+		lntypes.Local, view.LocalChanCfg(), view.RemoteChanCfg(),
+		view.Capacity(), u.cfg.MaxLocalCSVDelay,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("invalid local proposal: %w", err)
+	}
+
+	dp := req.Params.ToDynPropose(u.chanID)
+
+	// Record the in-flight session state and persist the proposal context
+	// at the dyn_propose boundary.
+	u.role = lntypes.Local
+	u.proposal = dp
+	u.nextHeight = view.NextCommitHeight()
+	u.ackSig = fn.None[lnwire.Sig]()
+
+	if err := u.persist(ctx); err != nil {
+		u.resetLocked()
+		return nil, fmt.Errorf("persist proposal: %w", err)
+	}
+
+	t, err := u.applyEvent(eventPropose)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := u.send(ctx, t, dp); err != nil {
+		return nil, err
+	}
+
+	u.armTimeout()
+
+	log.Infof("Sent dyn_propose for ChannelID(%v), height=%d", u.chanID,
+		u.nextHeight)
+
+	return t, nil
+}
+
+// RecvPropose handles an incoming dyn_propose from the peer, i.e. the responder
+// flow. It enforces the accept-side preconditions and validates the proposal.
+// On success it signs and sends a dyn_ack, persists its acceptance, and moves
+// to AckSent. On any precondition or validation failure it sends a dyn_reject
+// with the offending bits (a bare reject for non-parameter failures) and moves
+// to Rejected.
+func (u *Updater) RecvPropose(ctx context.Context,
+	msg *lnwire.DynPropose) (*Transition, error) {
+
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	// A proposal is only legal from Idle. Receiving one at any other point
+	// is a protocol violation.
+	if u.state != StateIdle {
+		return nil, fmt.Errorf("%w: dyn_propose in state %s",
+			ErrInvalidTransition, u.state)
+	}
+
+	// The peer is the proposer, so it must be the quiescence initiator and
+	// the accept-side preconditions must hold. A precondition failure is a
+	// bare rejection (no specific parameter is at fault).
+	if err := u.checkPreconditions(lntypes.Remote); err != nil {
+		log.Warnf("Rejecting dyn_propose for ChannelID(%v): %v",
+			u.chanID, err)
+
+		return u.reject(ctx, msg, nil)
+	}
+
+	// Validate the whole resulting channel with proposer-owned semantics.
+	// The peer's own dust applies to its config; the rest constrain us.
+	view := u.cfg.ChannelView
+	params := lnwallet.ChannelParamsFromDynPropose(msg)
+	err := params.Validate(
+		lntypes.Remote, view.LocalChanCfg(), view.RemoteChanCfg(),
+		view.Capacity(), u.cfg.MaxLocalCSVDelay,
+	)
+	if err != nil {
+		log.Warnf("Rejecting dyn_propose for ChannelID(%v): %v",
+			u.chanID, err)
+
+		return u.reject(ctx, msg, rejectBitsForErr(err))
+	}
+
+	// The proposal is acceptable. Sign our dyn_ack over the exact proposal
+	// TLVs bound to the next commitment height and chain.
+	tlvs, err := msg.SerializeTlvData()
+	if err != nil {
+		return nil, fmt.Errorf("serialize proposal tlvs: %w", err)
+	}
+
+	nextHeight := view.NextCommitHeight()
+	sig, err := u.cfg.Signer.SignDynAck(
+		view.ChainHash(), u.chanID, nextHeight, tlvs,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("sign dyn_ack: %w", err)
+	}
+
+	// Record the in-flight session state and persist our acceptance before
+	// the dyn_ack goes out on the wire.
+	u.role = lntypes.Remote
+	u.proposal = msg
+	u.nextHeight = nextHeight
+	u.ackSig = fn.Some(sig)
+
+	if err := u.persist(ctx); err != nil {
+		u.resetLocked()
+		return nil, fmt.Errorf("persist acceptance: %w", err)
+	}
+
+	t, err := u.applyEvent(eventProposeOK)
+	if err != nil {
+		return nil, err
+	}
+
+	ack := &lnwire.DynAck{ChanID: u.chanID, Sig: sig}
+	if err := u.send(ctx, t, ack); err != nil {
+		return nil, err
+	}
+
+	u.armTimeout()
+
+	log.Infof("Accepted dyn_propose for ChannelID(%v), sent dyn_ack, "+
+		"height=%d", u.chanID, nextHeight)
+
+	return t, nil
+}
+
+// RecvAck handles an incoming dyn_ack from the peer, i.e. the proposer flow. It
+// verifies the signature over the proposal we sent; on success it records the
+// signature, persists the received-ack context, and emits a ready-to-commit
+// handoff. On a verification failure it moves to Failed and signals disconnect.
+func (u *Updater) RecvAck(ctx context.Context,
+	msg *lnwire.DynAck) (*Transition, error) {
+
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	if u.state != StateAwaitingAck {
+		return nil, fmt.Errorf("%w: dyn_ack in state %s",
+			ErrInvalidTransition, u.state)
+	}
+
+	tlvs, err := u.proposal.SerializeTlvData()
+	if err != nil {
+		return nil, fmt.Errorf("serialize proposal tlvs: %w", err)
+	}
+
+	view := u.cfg.ChannelView
+	err = u.cfg.Signer.VerifyDynAck(
+		msg.Sig, view.ChainHash(), u.chanID, u.nextHeight, tlvs,
+	)
+	if err != nil {
+		log.Errorf("Invalid dyn_ack for ChannelID(%v): %v", u.chanID,
+			err)
+
+		return u.fail(ctx)
+	}
+
+	// The ack is valid. Persist the received-ack context so a reconnect can
+	// tell an acked negotiation from an un-acked one.
+	u.ackSig = fn.Some(msg.Sig)
+	if err := u.persist(ctx); err != nil {
+		return nil, fmt.Errorf("persist received ack: %w", err)
+	}
+
+	t, err := u.applyEvent(eventAckOK)
+	if err != nil {
+		return nil, err
+	}
+
+	// Negotiation succeeded; the negotiation timer no longer applies.
+	u.clearTimeout()
+
+	t.Handoff = fn.Some(u.handoff(fn.None[*lnwire.DynCommit]()))
+
+	log.Infof("Received valid dyn_ack for ChannelID(%v), ready to commit",
+		u.chanID)
+
+	return t, nil
+}
+
+// RecvReject handles an incoming dyn_reject from the peer, i.e. the proposer
+// flow. It moves the machine to Rejected and forgets the negotiation; per the
+// locked design decisions a retry requires fresh quiescence.
+func (u *Updater) RecvReject(ctx context.Context,
+	msg *lnwire.DynReject) (*Transition, error) {
+
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	if u.state != StateAwaitingAck {
+		return nil, fmt.Errorf("%w: dyn_reject in state %s",
+			ErrInvalidTransition, u.state)
+	}
+
+	t, err := u.applyEvent(eventReject)
+	if err != nil {
+		return nil, err
+	}
+
+	u.clearTimeout()
+	if err := u.forget(ctx); err != nil {
+		return nil, err
+	}
+
+	log.Infof("Peer rejected dyn_propose for ChannelID(%v)", u.chanID)
+
+	return t, nil
+}
+
+// RecvCommit handles an incoming bundled dyn_commit_sig from the peer, i.e. the
+// responder flow. It checks that the bundled proposal matches the one we acked,
+// then moves to Committing and emits a ready-to-commit handoff carrying the
+// received message so the link can verify the commitment signature and drive
+// the dance. On a mismatch it moves to Failed and signals disconnect.
+func (u *Updater) RecvCommit(ctx context.Context,
+	msg *lnwire.DynCommit) (*Transition, error) {
+
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	if u.state != StateAckSent {
+		return nil, fmt.Errorf("%w: dyn_commit_sig in state %s",
+			ErrInvalidTransition, u.state)
+	}
+
+	// Defend against a peer that bundles a different proposal than the one
+	// we acked: the accepted TLVs must be byte-identical.
+	got, err := msg.DynPropose.SerializeTlvData()
+	if err != nil {
+		return nil, fmt.Errorf("serialize commit proposal: %w", err)
+	}
+	want, err := u.proposal.SerializeTlvData()
+	if err != nil {
+		return nil, fmt.Errorf("serialize acked proposal: %w", err)
+	}
+	if !bytes.Equal(got, want) {
+		log.Errorf("dyn_commit_sig proposal mismatch for "+
+			"ChannelID(%v)", u.chanID)
+
+		return u.fail(ctx)
+	}
+
+	t, err := u.applyEvent(eventCommitRecv)
+	if err != nil {
+		return nil, err
+	}
+
+	u.clearTimeout()
+
+	t.Handoff = fn.Some(u.handoff(fn.Some(msg)))
+
+	log.Infof("Received dyn_commit_sig for ChannelID(%v), ready to commit",
+		u.chanID)
+
+	return t, nil
+}
+
+// MarkCommitSent records that the proposer has sent the bundled dyn_commit_sig,
+// completing this machine's role and moving it to Committing. From here the
+// link owns the commitment dance and the negotiation is no longer abortable on
+// a reconnect.
+func (u *Updater) MarkCommitSent(_ context.Context) (*Transition, error) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	if u.state != StateAccepted {
+		return nil, fmt.Errorf("%w: commit-sent in state %s",
+			ErrInvalidTransition, u.state)
+	}
+
+	t, err := u.applyEvent(eventCommitSent)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Infof("Sent dyn_commit_sig for ChannelID(%v), dance handed off",
+		u.chanID)
+
+	return t, nil
+}
+
+// CheckTimeout advances the negotiation timeout. The caller ticks it (for
+// example from a select loop or a periodic sweep); the machine consults its
+// injected clock. If a waiting negotiation has passed its deadline the machine
+// moves to Failed, forgets the negotiation, and returns a transition that
+// signals disconnect. Otherwise it returns a no-op transition (From == To).
+func (u *Updater) CheckTimeout(ctx context.Context) (*Transition, error) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	if !u.timerArmed || u.cfg.Clock.Now().Before(u.deadline) {
+		return &Transition{From: u.state, To: u.state}, nil
+	}
+
+	log.Warnf("Dyn negotiation timed out for ChannelID(%v) in state %s",
+		u.chanID, u.state)
+
+	from := u.state
+	t, err := u.applyEvent(eventTimeout)
+	if err != nil {
+		return nil, err
+	}
+	t.From = from
+	t.Disconnect = true
+
+	if err := u.forget(ctx); err != nil {
+		return nil, err
+	}
+
+	return t, nil
+}
+
+// Reset returns the machine to Idle and drops any in-flight session state,
+// after clearing persisted context. It is used to begin a fresh negotiation
+// after a terminal state, which requires fresh quiescence.
+func (u *Updater) Reset(ctx context.Context) error {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	err := u.cfg.Persister.DeleteAcceptedProposal(ctx, u.chanID)
+	if err != nil {
+		return fmt.Errorf("delete proposal: %w", err)
+	}
+
+	u.resetLocked()
+
+	return nil
+}
+
+// checkPreconditions enforces the eligibility rules that must hold before a
+// proposal is sent or accepted, given the party that is the proposer. It
+// returns a typed error naming the first unmet precondition.
+func (u *Updater) checkPreconditions(proposer lntypes.ChannelParty) error {
+	view := u.cfg.ChannelView
+
+	if !view.BothChannelReady() {
+		return ErrChannelNotReady
+	}
+
+	if !view.IsQuiescent() {
+		return ErrNotQuiescent
+	}
+
+	// The proposer must be the quiescence initiator.
+	initiator, err := view.QuiescenceInitiator().Unpack()
+	if err != nil {
+		return ErrNotQuiescent
+	}
+	if initiator != proposer {
+		return ErrNotQuiescenceInitiator
+	}
+
+	if view.HasHTLCs() {
+		return ErrHTLCsActive
+	}
+
+	if view.HasPendingUpdates() {
+		return ErrPendingUpdates
+	}
+
+	if view.HasPendingShutdown() {
+		return ErrPendingShutdown
+	}
+
+	if view.HasPendingSpliceOrRBF() {
+		return ErrPendingSpliceOrRBF
+	}
+
+	return nil
+}
+
+// reject sends a dyn_reject with the given rejection bits (a bare reject when
+// bits is empty) and moves the machine to Rejected. It is the responder's
+// unhappy path.
+func (u *Updater) reject(ctx context.Context, msg *lnwire.DynPropose,
+	bits []lnwire.DynRejectBit) (*Transition, error) {
+
+	t, err := u.applyEvent(eventProposeBad)
+	if err != nil {
+		return nil, err
+	}
+
+	dr := lnwire.NewDynReject(msg.ChanID, bits...)
+	if err := u.send(ctx, t, dr); err != nil {
+		return nil, err
+	}
+
+	return t, nil
+}
+
+// fail moves the machine to Failed, forgets the negotiation, and returns a
+// transition that signals disconnect. It is the shared unrecoverable-error
+// path.
+func (u *Updater) fail(ctx context.Context) (*Transition, error) {
+	t, err := u.applyEvent(eventFail)
+	if err != nil {
+		return nil, err
+	}
+
+	u.clearTimeout()
+	if err := u.forget(ctx); err != nil {
+		return nil, err
+	}
+
+	t.Disconnect = true
+
+	return t, nil
+}
+
+// handoff builds the ready-to-commit handoff for the current in-flight session.
+func (u *Updater) handoff(
+	commit fn.Option[*lnwire.DynCommit]) CommitHandoff {
+
+	return CommitHandoff{
+		Proposer:         u.role,
+		Params:           lnwallet.ChannelParamsFromDynPropose(u.proposal),
+		Proposal:         u.proposal,
+		NextCommitHeight: u.nextHeight,
+		AckSig:           u.ackSig.UnwrapOr(lnwire.Sig{}),
+		ReceivedCommit:   commit,
+	}
+}
+
+// applyEvent runs the pure transition function for the given event, updates the
+// machine's state on success, and returns a Transition describing the state
+// change with no messages or handoff attached yet.
+func (u *Updater) applyEvent(e eventType) (*Transition, error) {
+	from := u.state
+	to, err := advance(from, e)
+	if err != nil {
+		return nil, err
+	}
+
+	u.state = to
+
+	log.Tracef("ChannelID(%v): %s --%s--> %s", u.chanID, from, e, to)
+
+	return &Transition{From: from, To: to}, nil
+}
+
+// send dispatches the given messages via the configured sender and records them
+// on the transition. It is a no-op when there are no messages.
+func (u *Updater) send(ctx context.Context, t *Transition,
+	msgs ...lnwire.Message) error {
+
+	if len(msgs) == 0 {
+		return nil
+	}
+
+	if err := u.cfg.Sender.SendMessage(ctx, msgs...); err != nil {
+		return fmt.Errorf("send message: %w", err)
+	}
+
+	t.Messages = append(t.Messages, msgs...)
+
+	return nil
+}
+
+// persist writes the current in-flight session as an AcceptedProposal.
+func (u *Updater) persist(ctx context.Context) error {
+	return u.cfg.Persister.StoreAcceptedProposal(
+		ctx, u.chanID, AcceptedProposal{
+			Proposer:         u.role,
+			Proposal:         u.proposal,
+			NextCommitHeight: u.nextHeight,
+			AckSig:           u.ackSig,
+		},
+	)
+}
+
+// forget clears any persisted context and drops the in-flight session data,
+// while preserving the current (typically terminal) state so the caller can
+// still observe why the negotiation ended.
+func (u *Updater) forget(ctx context.Context) error {
+	err := u.cfg.Persister.DeleteAcceptedProposal(ctx, u.chanID)
+	if err != nil {
+		return fmt.Errorf("delete proposal: %w", err)
+	}
+
+	u.clearInflight()
+
+	return nil
+}
+
+// clearInflight drops the in-flight session data (role, proposal, height, ack
+// signature, and timer) without touching the state. The caller must hold u.mu.
+func (u *Updater) clearInflight() {
+	u.role = lntypes.Local
+	u.proposal = nil
+	u.nextHeight = 0
+	u.ackSig = fn.None[lnwire.Sig]()
+	u.clearTimeout()
+}
+
+// resetLocked drops the in-flight session data and returns the machine to Idle.
+// The caller must hold u.mu.
+func (u *Updater) resetLocked() {
+	u.clearInflight()
+	u.state = StateIdle
+}
+
+// armTimeout arms the negotiation timeout relative to the injected clock.
+func (u *Updater) armTimeout() {
+	u.deadline = u.cfg.Clock.Now().Add(u.cfg.Timeout)
+	u.timerArmed = true
+}
+
+// clearTimeout disarms the negotiation timeout.
+func (u *Updater) clearTimeout() {
+	u.timerArmed = false
+}
+
+// rejectBitsForErr maps a ValidateChannelParams error to the dyn_reject bits
+// that identify the offending parameter. It returns nil for errors that do not
+// map to a specific parameter, which yields a bare rejection.
+func rejectBitsForErr(err error) []lnwire.DynRejectBit {
+	switch {
+	case errors.Is(err, lnwallet.ErrDynDustLimitTooSmall),
+		errors.Is(err, lnwallet.ErrDynDustLimitTooLarge):
+
+		return []lnwire.DynRejectBit{lnwire.DynRejectDustLimit}
+
+	case errors.Is(err, lnwallet.ErrDynReserveBelowDust),
+		errors.Is(err, lnwallet.ErrDynReserveTooLarge):
+
+		return []lnwire.DynRejectBit{lnwire.DynRejectChannelReserve}
+
+	case errors.Is(err, lnwallet.ErrDynCsvDelayTooLarge):
+		return []lnwire.DynRejectBit{lnwire.DynRejectCsvDelay}
+
+	case errors.Is(err, lnwallet.ErrDynMaxAcceptedTooLarge):
+		return []lnwire.DynRejectBit{lnwire.DynRejectMaxAcceptedHTLCs}
+
+	case errors.Is(err, lnwallet.ErrDynHtlcMinTooLarge):
+		return []lnwire.DynRejectBit{lnwire.DynRejectHtlcMinimum}
+
+	default:
+		return nil
+	}
+}

--- a/htlcswitch/dyn/updater_test.go
+++ b/htlcswitch/dyn/updater_test.go
@@ -1,0 +1,727 @@
+package dyn
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/clock"
+	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnwallet"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// testCapacity is the channel capacity used across the tests. Its fifth
+	// (the max reserve) is 200_000 sat.
+	testCapacity = btcutil.Amount(1_000_000)
+
+	// testMaxCSV is the maximum acceptable to_self_delay in the tests.
+	testMaxCSV = uint16(2016)
+
+	// testNextHeight is the next commitment number the dyn update binds to.
+	testNextHeight = uint64(7)
+)
+
+// mkConfig builds a ChannelConfig whose dynamic parameters all satisfy BOLT #2
+// and LND policy for a testCapacity channel.
+func mkConfig(dust btcutil.Amount, csv uint16, reserve btcutil.Amount,
+	maxInFlight, minHTLC lnwire.MilliSatoshi,
+	maxAccepted uint16) channeldb.ChannelConfig {
+
+	return channeldb.ChannelConfig{
+		ChannelStateBounds: channeldb.ChannelStateBounds{
+			ChanReserve:      reserve,
+			MaxPendingAmount: maxInFlight,
+			MinHTLC:          minHTLC,
+			MaxAcceptedHtlcs: maxAccepted,
+		},
+		CommitmentParams: channeldb.CommitmentParams{
+			DustLimit: dust,
+			CsvDelay:  csv,
+		},
+	}
+}
+
+var (
+	// baseLocal and baseRemote are fully valid baseline configs.
+	baseLocal  = mkConfig(500, 144, 20_000, 500_000, 1_000, 100)
+	baseRemote = mkConfig(600, 144, 20_000, 500_000, 1_000, 100)
+
+	testChanID    = lnwire.ChannelID{0x01, 0x02, 0x03}
+	testChainHash = chainhash.Hash{0xaa, 0xbb, 0xcc}
+)
+
+// fakeView is a configurable ChannelView for tests. Its zero value is not
+// eligible; use newFakeView for a fully-eligible starting point.
+type fakeView struct {
+	chanID     lnwire.ChannelID
+	chainHash  chainhash.Hash
+	local      channeldb.ChannelConfig
+	remote     channeldb.ChannelConfig
+	capacity   btcutil.Amount
+	nextHeight uint64
+
+	bothReady       bool
+	quiescent       bool
+	initiator       fn.Result[lntypes.ChannelParty]
+	htlcs           bool
+	pendingUpdates  bool
+	pendingShutdown bool
+	pendingSplice   bool
+}
+
+// newFakeView returns a fully-eligible view whose quiescence initiator is the
+// given proposer.
+func newFakeView(proposer lntypes.ChannelParty) *fakeView {
+	return &fakeView{
+		chanID:     testChanID,
+		chainHash:  testChainHash,
+		local:      baseLocal,
+		remote:     baseRemote,
+		capacity:   testCapacity,
+		nextHeight: testNextHeight,
+		bothReady:  true,
+		quiescent:  true,
+		initiator:  fn.Ok(proposer),
+	}
+}
+
+func (f *fakeView) ChanID() lnwire.ChannelID              { return f.chanID }
+func (f *fakeView) ChainHash() chainhash.Hash             { return f.chainHash }
+func (f *fakeView) LocalChanCfg() channeldb.ChannelConfig { return f.local }
+func (f *fakeView) RemoteChanCfg() channeldb.ChannelConfig {
+	return f.remote
+}
+func (f *fakeView) Capacity() btcutil.Amount { return f.capacity }
+func (f *fakeView) NextCommitHeight() uint64 { return f.nextHeight }
+func (f *fakeView) BothChannelReady() bool   { return f.bothReady }
+func (f *fakeView) IsQuiescent() bool        { return f.quiescent }
+func (f *fakeView) QuiescenceInitiator() fn.Result[lntypes.ChannelParty] {
+	return f.initiator
+}
+func (f *fakeView) HasHTLCs() bool           { return f.htlcs }
+func (f *fakeView) HasPendingUpdates() bool  { return f.pendingUpdates }
+func (f *fakeView) HasPendingShutdown() bool { return f.pendingShutdown }
+func (f *fakeView) HasPendingSpliceOrRBF() bool {
+	return f.pendingSplice
+}
+
+// fakeSigner produces and verifies dyn_ack signatures with real keys, so the
+// sign/verify round trip is exercised end to end.
+type fakeSigner struct {
+	signKey   *btcec.PrivateKey
+	verifyKey *btcec.PublicKey
+	signErr   error
+}
+
+func (s *fakeSigner) SignDynAck(chainHash chainhash.Hash,
+	chanID lnwire.ChannelID, nextCommitHeight uint64,
+	proposalTLVs []byte) (lnwire.Sig, error) {
+
+	if s.signErr != nil {
+		return lnwire.Sig{}, s.signErr
+	}
+
+	return lnwire.SignDynAck(
+		s.signKey, chainHash, chanID, nextCommitHeight, proposalTLVs,
+	)
+}
+
+func (s *fakeSigner) VerifyDynAck(sig lnwire.Sig, chainHash chainhash.Hash,
+	chanID lnwire.ChannelID, nextCommitHeight uint64,
+	proposalTLVs []byte) error {
+
+	return lnwire.VerifyDynAck(
+		s.verifyKey, sig, chainHash, chanID, nextCommitHeight,
+		proposalTLVs,
+	)
+}
+
+// fakeSender records the messages sent to the peer.
+type fakeSender struct {
+	mu   sync.Mutex
+	sent []lnwire.Message
+	err  error
+}
+
+func (s *fakeSender) SendMessage(_ context.Context,
+	msgs ...lnwire.Message) error {
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.err != nil {
+		return s.err
+	}
+
+	s.sent = append(s.sent, msgs...)
+
+	return nil
+}
+
+func (s *fakeSender) msgs() []lnwire.Message {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	out := make([]lnwire.Message, len(s.sent))
+	copy(out, s.sent)
+
+	return out
+}
+
+// testRig bundles an Updater with its injected fakes for assertions.
+type testRig struct {
+	u         *Updater
+	view      *fakeView
+	signer    *fakeSigner
+	sender    *fakeSender
+	persister *MemPersister
+	clk       *clock.TestClock
+}
+
+// newRig constructs a rig whose quiescence initiator is the given proposer.
+func newRig(t *testing.T, proposer lntypes.ChannelParty) *testRig {
+	t.Helper()
+
+	view := newFakeView(proposer)
+	sender := &fakeSender{}
+	persister := NewMemPersister()
+	clk := clock.NewTestClock(time.Unix(0, 0))
+
+	rig := &testRig{
+		view:      view,
+		signer:    &fakeSigner{},
+		sender:    sender,
+		persister: persister,
+		clk:       clk,
+	}
+
+	rig.u = NewUpdater(Config{
+		Signer:           rig.signer,
+		ChannelView:      view,
+		Persister:        persister,
+		Sender:           sender,
+		Clock:            clk,
+		Timeout:          DefaultTimeout,
+		MaxLocalCSVDelay: testMaxCSV,
+	})
+
+	return rig
+}
+
+// validProposal is a valid proposal that changes the proposer's own dust limit.
+func validProposal() lnwallet.ChannelParams {
+	return lnwallet.ChannelParams{
+		DustLimit: fn.Some(btcutil.Amount(700)),
+	}
+}
+
+// TestLocalInitToReadyToCommit walks the proposer happy path: propose, receive
+// a valid ack, and reach the ready-to-commit handoff, then hand off the dance.
+func TestLocalInitToReadyToCommit(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	// The responder holds respKey; as proposer we verify with its pubkey.
+	respKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	rig := newRig(t, lntypes.Local)
+	rig.signer.verifyKey = respKey.PubKey()
+
+	// Kick off the proposal.
+	tr, err := rig.u.InitProposal(ctx, ProposalRequest{
+		Params: validProposal(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, StateAwaitingAck, rig.u.State())
+	require.Equal(t, StateIdle, tr.From)
+	require.Equal(t, StateAwaitingAck, tr.To)
+
+	// A single dyn_propose must have been sent.
+	sent := rig.sender.msgs()
+	require.Len(t, sent, 1)
+	dp, ok := sent[0].(*lnwire.DynPropose)
+	require.True(t, ok)
+	require.Equal(t, tr.Messages, sent)
+
+	// The proposal context must be persisted with us as the proposer.
+	stored, err := rig.persister.FetchAcceptedProposal(ctx, testChanID)
+	require.NoError(t, err)
+	require.True(t, stored.IsSome())
+	require.Equal(t, lntypes.Local, stored.UnsafeFromSome().Proposer)
+
+	// The responder signs the exact proposal TLVs bound to the height.
+	tlvs, err := dp.SerializeTlvData()
+	require.NoError(t, err)
+	ackSig, err := lnwire.SignDynAck(
+		respKey, testChainHash, testChanID, testNextHeight, tlvs,
+	)
+	require.NoError(t, err)
+
+	// Feed the ack; we should reach Accepted with a ready-to-commit handoff.
+	tr, err = rig.u.RecvAck(ctx, &lnwire.DynAck{
+		ChanID: testChanID,
+		Sig:    ackSig,
+	})
+	require.NoError(t, err)
+	require.Equal(t, StateAccepted, rig.u.State())
+	require.False(t, tr.Disconnect)
+	require.True(t, tr.Handoff.IsSome())
+
+	handoff := tr.Handoff.UnsafeFromSome()
+	require.Equal(t, lntypes.Local, handoff.Proposer)
+	require.Equal(t, testNextHeight, handoff.NextCommitHeight)
+	require.Equal(t, ackSig, handoff.AckSig)
+	require.True(t, handoff.Params.DustLimit.IsSome())
+	require.True(t, handoff.ReceivedCommit.IsNone())
+
+	// Finally, hand off the dance.
+	tr, err = rig.u.MarkCommitSent(ctx)
+	require.NoError(t, err)
+	require.Equal(t, StateCommitting, rig.u.State())
+	require.True(t, rig.u.State().IsTerminal())
+}
+
+// TestRemoteProposalAccept walks the responder happy path: validate an incoming
+// proposal, sign and send a dyn_ack, then receive the bundled commit.
+func TestRemoteProposalAccept(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	// As responder we sign with ourKey.
+	ourKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	rig := newRig(t, lntypes.Remote)
+	rig.signer.signKey = ourKey
+
+	// The peer proposes a change to its own dust limit.
+	params := lnwallet.ChannelParams{DustLimit: fn.Some(btcutil.Amount(700))}
+	dp := params.ToDynPropose(testChanID)
+
+	tr, err := rig.u.RecvPropose(ctx, dp)
+	require.NoError(t, err)
+	require.Equal(t, StateAckSent, rig.u.State())
+
+	// A dyn_ack must have been sent, and it must verify under our pubkey.
+	sent := rig.sender.msgs()
+	require.Len(t, sent, 1)
+	ack, ok := sent[0].(*lnwire.DynAck)
+	require.True(t, ok)
+
+	tlvs, err := dp.SerializeTlvData()
+	require.NoError(t, err)
+	require.NoError(t, lnwire.VerifyDynAck(
+		ourKey.PubKey(), ack.Sig, testChainHash, testChanID,
+		testNextHeight, tlvs,
+	))
+
+	// Our acceptance must be persisted with the ack signature.
+	stored, err := rig.persister.FetchAcceptedProposal(ctx, testChanID)
+	require.NoError(t, err)
+	require.True(t, stored.IsSome())
+	require.Equal(t, lntypes.Remote, stored.UnsafeFromSome().Proposer)
+	require.True(t, stored.UnsafeFromSome().AckSig.IsSome())
+
+	// Now receive the bundled dyn_commit_sig for the same proposal.
+	commit := &lnwire.DynCommit{
+		DynPropose: *dp,
+		CommitSig:  testSig(t),
+		AckSig:     ack.Sig,
+	}
+	tr, err = rig.u.RecvCommit(ctx, commit)
+	require.NoError(t, err)
+	require.Equal(t, StateCommitting, rig.u.State())
+	require.True(t, tr.Handoff.IsSome())
+
+	handoff := tr.Handoff.UnsafeFromSome()
+	require.Equal(t, lntypes.Remote, handoff.Proposer)
+	require.True(t, handoff.ReceivedCommit.IsSome())
+	require.Equal(t, commit, handoff.ReceivedCommit.UnsafeFromSome())
+}
+
+// TestRejectInvalidParam checks that a proposal with an out-of-policy parameter
+// is rejected with the correct rejection bit set.
+func TestRejectInvalidParam(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	rig := newRig(t, lntypes.Remote)
+
+	// A CSV delay above our maximum must be rejected on the CSV bit.
+	params := lnwallet.ChannelParams{CsvDelay: fn.Some(uint16(5000))}
+	dp := params.ToDynPropose(testChanID)
+
+	tr, err := rig.u.RecvPropose(ctx, dp)
+	require.NoError(t, err)
+	require.Equal(t, StateRejected, rig.u.State())
+	require.True(t, rig.u.State().IsTerminal())
+
+	sent := rig.sender.msgs()
+	require.Len(t, sent, 1)
+	dr, ok := sent[0].(*lnwire.DynReject)
+	require.True(t, ok)
+	require.True(t, dr.IsRejected(lnwire.DynRejectCsvDelay))
+	require.False(t, dr.IsRejected(lnwire.DynRejectDustLimit))
+	require.Equal(t, tr.Messages, sent)
+}
+
+// TestInvalidAckSignature checks that a dyn_ack that fails verification fails
+// the negotiation and signals disconnect.
+func TestInvalidAckSignature(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	// The proposer verifies against wrongKey, but the ack is produced with
+	// respKey, so verification must fail.
+	respKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	wrongKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	rig := newRig(t, lntypes.Local)
+	rig.signer.verifyKey = wrongKey.PubKey()
+
+	_, err = rig.u.InitProposal(ctx, ProposalRequest{Params: validProposal()})
+	require.NoError(t, err)
+
+	dp := rig.sender.msgs()[0].(*lnwire.DynPropose)
+	tlvs, err := dp.SerializeTlvData()
+	require.NoError(t, err)
+	ackSig, err := lnwire.SignDynAck(
+		respKey, testChainHash, testChanID, testNextHeight, tlvs,
+	)
+	require.NoError(t, err)
+
+	tr, err := rig.u.RecvAck(ctx, &lnwire.DynAck{
+		ChanID: testChanID,
+		Sig:    ackSig,
+	})
+	require.NoError(t, err)
+	require.Equal(t, StateFailed, rig.u.State())
+	require.True(t, tr.Disconnect)
+
+	// A failed negotiation must forget its persisted context.
+	stored, err := rig.persister.FetchAcceptedProposal(ctx, testChanID)
+	require.NoError(t, err)
+	require.True(t, stored.IsNone())
+}
+
+// TestProposerPreconditions checks that every unmet precondition blocks a local
+// proposal with the right typed error and leaves the machine Idle.
+func TestProposerPreconditions(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		mutate  func(v *fakeView)
+		wantErr error
+	}{
+		{
+			name:    "channel not ready",
+			mutate:  func(v *fakeView) { v.bothReady = false },
+			wantErr: ErrChannelNotReady,
+		},
+		{
+			name:    "not quiescent",
+			mutate:  func(v *fakeView) { v.quiescent = false },
+			wantErr: ErrNotQuiescent,
+		},
+		{
+			name: "not quiescence initiator",
+			mutate: func(v *fakeView) {
+				v.initiator = fn.Ok(lntypes.Remote)
+			},
+			wantErr: ErrNotQuiescenceInitiator,
+		},
+		{
+			name:    "htlcs active",
+			mutate:  func(v *fakeView) { v.htlcs = true },
+			wantErr: ErrHTLCsActive,
+		},
+		{
+			name:    "pending updates",
+			mutate:  func(v *fakeView) { v.pendingUpdates = true },
+			wantErr: ErrPendingUpdates,
+		},
+		{
+			name:    "pending shutdown",
+			mutate:  func(v *fakeView) { v.pendingShutdown = true },
+			wantErr: ErrPendingShutdown,
+		},
+		{
+			name:    "pending splice",
+			mutate:  func(v *fakeView) { v.pendingSplice = true },
+			wantErr: ErrPendingSpliceOrRBF,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			rig := newRig(t, lntypes.Local)
+			tc.mutate(rig.view)
+
+			_, err := rig.u.InitProposal(ctx, ProposalRequest{
+				Params: validProposal(),
+			})
+			require.ErrorIs(t, err, tc.wantErr)
+			require.Equal(t, StateIdle, rig.u.State())
+			require.Empty(t, rig.sender.msgs())
+		})
+	}
+}
+
+// TestResponderPreconditionReject checks that a precondition failure on the
+// accept side yields a bare dyn_reject and moves to Rejected.
+func TestResponderPreconditionReject(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	rig := newRig(t, lntypes.Remote)
+	rig.view.htlcs = true
+
+	dp := validProposal().ToDynPropose(testChanID)
+	tr, err := rig.u.RecvPropose(ctx, dp)
+	require.NoError(t, err)
+	require.Equal(t, StateRejected, rig.u.State())
+
+	sent := rig.sender.msgs()
+	require.Len(t, sent, 1)
+	dr, ok := sent[0].(*lnwire.DynReject)
+	require.True(t, ok)
+
+	// A precondition rejection identifies no specific parameter.
+	require.False(t, dr.IsRejected(lnwire.DynRejectDustLimit))
+	require.False(t, dr.IsRejected(lnwire.DynRejectCsvDelay))
+	require.Equal(t, tr.Messages, sent)
+}
+
+// TestTimeout checks that a waiting negotiation fails and signals disconnect
+// once its deadline elapses, and is a no-op before then.
+func TestTimeout(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	rig := newRig(t, lntypes.Local)
+
+	_, err := rig.u.InitProposal(ctx, ProposalRequest{
+		Params: validProposal(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, StateAwaitingAck, rig.u.State())
+
+	// Before the deadline, ticking the timeout is a no-op.
+	tr, err := rig.u.CheckTimeout(ctx)
+	require.NoError(t, err)
+	require.Equal(t, StateAwaitingAck, tr.To)
+	require.False(t, tr.Disconnect)
+	require.Equal(t, StateAwaitingAck, rig.u.State())
+
+	// Advance past the deadline and tick again.
+	rig.clk.SetTime(time.Unix(0, 0).Add(DefaultTimeout + time.Second))
+
+	tr, err = rig.u.CheckTimeout(ctx)
+	require.NoError(t, err)
+	require.Equal(t, StateFailed, rig.u.State())
+	require.True(t, tr.Disconnect)
+
+	// The timed-out negotiation must be forgotten.
+	stored, err := rig.persister.FetchAcceptedProposal(ctx, testChanID)
+	require.NoError(t, err)
+	require.True(t, stored.IsNone())
+}
+
+// TestDuplicateProposal checks that a second local proposal, and an incoming
+// proposal while we are proposing, are both refused.
+func TestDuplicateProposal(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	rig := newRig(t, lntypes.Local)
+
+	_, err := rig.u.InitProposal(ctx, ProposalRequest{
+		Params: validProposal(),
+	})
+	require.NoError(t, err)
+
+	// A second local proposal is refused.
+	_, err = rig.u.InitProposal(ctx, ProposalRequest{
+		Params: validProposal(),
+	})
+	require.ErrorIs(t, err, ErrNegotiationInProgress)
+
+	// An incoming proposal while we are the in-flight proposer is a
+	// protocol violation.
+	dp := validProposal().ToDynPropose(testChanID)
+	_, err = rig.u.RecvPropose(ctx, dp)
+	require.ErrorIs(t, err, ErrInvalidTransition)
+
+	// State is unchanged.
+	require.Equal(t, StateAwaitingAck, rig.u.State())
+}
+
+// TestConcurrentProposals checks that concurrent local proposals are serialized
+// so that exactly one wins, with no data race (run with -race).
+func TestConcurrentProposals(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	rig := newRig(t, lntypes.Local)
+
+	const n = 12
+	var (
+		wg        sync.WaitGroup
+		mu        sync.Mutex
+		successes int
+	)
+
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			_, err := rig.u.InitProposal(ctx, ProposalRequest{
+				Params: validProposal(),
+			})
+			if err == nil {
+				mu.Lock()
+				successes++
+				mu.Unlock()
+			}
+		}()
+
+		// Concurrent readers exercise the read path under the race
+		// detector.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = rig.u.State()
+		}()
+	}
+
+	wg.Wait()
+
+	require.Equal(t, 1, successes)
+	require.Equal(t, StateAwaitingAck, rig.u.State())
+	require.Len(t, rig.sender.msgs(), 1)
+}
+
+// TestInvalidTransitions checks that messages arriving in the wrong state are
+// rejected as invalid transitions.
+func TestInvalidTransitions(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	rig := newRig(t, lntypes.Local)
+
+	// From Idle, an ack/reject/commit/commit-sent are all illegal.
+	_, err := rig.u.RecvAck(ctx, &lnwire.DynAck{ChanID: testChanID})
+	require.ErrorIs(t, err, ErrInvalidTransition)
+
+	_, err = rig.u.RecvReject(ctx, lnwire.NewDynReject(testChanID))
+	require.ErrorIs(t, err, ErrInvalidTransition)
+
+	_, err = rig.u.RecvCommit(ctx, &lnwire.DynCommit{})
+	require.ErrorIs(t, err, ErrInvalidTransition)
+
+	_, err = rig.u.MarkCommitSent(ctx)
+	require.ErrorIs(t, err, ErrInvalidTransition)
+
+	require.Equal(t, StateIdle, rig.u.State())
+}
+
+// TestRecvCommitMismatch checks that a bundled commit carrying a different
+// proposal than the one we acked fails the negotiation.
+func TestRecvCommitMismatch(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	ourKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	rig := newRig(t, lntypes.Remote)
+	rig.signer.signKey = ourKey
+
+	dp := validProposal().ToDynPropose(testChanID)
+	_, err = rig.u.RecvPropose(ctx, dp)
+	require.NoError(t, err)
+	require.Equal(t, StateAckSent, rig.u.State())
+
+	// Bundle a different proposal than the one we acked.
+	other := lnwallet.ChannelParams{CsvDelay: fn.Some(uint16(288))}
+	tr, err := rig.u.RecvCommit(ctx, &lnwire.DynCommit{
+		DynPropose: *other.ToDynPropose(testChanID),
+		CommitSig:  testSig(t),
+	})
+	require.NoError(t, err)
+	require.Equal(t, StateFailed, rig.u.State())
+	require.True(t, tr.Disconnect)
+}
+
+// TestEmptyProposalRejected checks that a proposal that changes nothing is
+// refused at init.
+func TestEmptyProposalRejected(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	rig := newRig(t, lntypes.Local)
+
+	_, err := rig.u.InitProposal(ctx, ProposalRequest{})
+	require.ErrorIs(t, err, lnwallet.ErrDynParamsNoChange)
+	require.Equal(t, StateIdle, rig.u.State())
+}
+
+// TestReset returns a terminal machine to Idle and clears persisted state.
+func TestReset(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	rig := newRig(t, lntypes.Remote)
+
+	// Reject a bad proposal to reach a terminal state.
+	bad := lnwallet.ChannelParams{CsvDelay: fn.Some(uint16(5000))}
+	_, err := rig.u.RecvPropose(ctx, bad.ToDynPropose(testChanID))
+	require.NoError(t, err)
+	require.Equal(t, StateRejected, rig.u.State())
+
+	require.NoError(t, rig.u.Reset(ctx))
+	require.Equal(t, StateIdle, rig.u.State())
+
+	stored, err := rig.persister.FetchAcceptedProposal(ctx, testChanID)
+	require.NoError(t, err)
+	require.True(t, stored.IsNone())
+}
+
+// testSig returns an arbitrary well-formed signature for use where the content
+// of a commitment signature is not under test.
+func testSig(t *testing.T) lnwire.Sig {
+	t.Helper()
+
+	priv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	sig, err := lnwire.SignDynAck(
+		priv, testChainHash, testChanID, 0, []byte{0x00},
+	)
+	require.NoError(t, err)
+
+	return sig
+}


### PR DESCRIPTION
Part of the Dynamic Commitments milestone: #60

Core `htlcswitch/dyn` negotiation state machine (negotiation only).

**Stacked PR** — based on `yy-dyn-4-params-api`; review after that branch (the base updates automatically as the parent merges).

Opened as a **draft**: this is part of the exploratory params-only stack (coarse commits, not final hygiene).