### PR TITLE
lnwallet: add dyn_commit update-log entry

### DIFF
--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -68,6 +68,14 @@ var (
 	ErrBelowChanReserve = fmt.Errorf("commitment transaction dips peer " +
 		"below chan reserve")
 
+	// ErrDynHtlcsPresent is returned when a dynamic-commitments parameter
+	// update (dyn_commit) is active in a commitment view that still carries
+	// HTLCs. The dynamic-commitments protocol requires the channel to be
+	// free of HTLCs (including trimmed ones) before a parameter change can
+	// be executed, so this indicates a violated precondition.
+	ErrDynHtlcsPresent = fmt.Errorf("cannot render dyn_commit update with " +
+		"HTLCs present")
+
 	// ErrBelowMinHTLC is returned when a proposed HTLC has a value that
 	// is below the minimum HTLC value constraint for either us or our
 	// peer depending on which flags are set.
@@ -1260,6 +1268,24 @@ func (lc *LightningChannel) logUpdateToPayDesc(logUpdate *channeldb.LogUpdate,
 				Remote: commitHeight,
 			},
 		}
+
+	// For dyn_commit updates we recover the proposed parameters from the
+	// accepted proposal TLVs. Like fee updates, the entry has no parent
+	// HTLC, so we set both the add and remove height to the commit height.
+	case *lnwire.DynCommit:
+		params := ChannelParamsFromDynPropose(&wireMsg.DynPropose)
+		pd = &paymentDescriptor{
+			ChanID:    wireMsg.ChanID,
+			LogIndex:  logUpdate.LogIndex,
+			EntryType: DynCommit,
+			DynParams: &params,
+			addCommitHeights: lntypes.Dual[uint64]{
+				Remote: commitHeight,
+			},
+			removeCommitHeights: lntypes.Dual[uint64]{
+				Remote: commitHeight,
+			},
+		}
 	}
 
 	return pd, nil
@@ -1346,6 +1372,21 @@ func (lc *LightningChannel) localLogUpdateToPayDesc(logUpdate *channeldb.LogUpda
 				btcutil.Amount(wireMsg.FeePerKw),
 			),
 			EntryType: FeeUpdate,
+			addCommitHeights: lntypes.Dual[uint64]{
+				Remote: commitHeight,
+			},
+			removeCommitHeights: lntypes.Dual[uint64]{
+				Remote: commitHeight,
+			},
+		}, nil
+
+	case *lnwire.DynCommit:
+		params := ChannelParamsFromDynPropose(&wireMsg.DynPropose)
+		return &paymentDescriptor{
+			ChanID:    wireMsg.ChanID,
+			LogIndex:  logUpdate.LogIndex,
+			EntryType: DynCommit,
+			DynParams: &params,
 			addCommitHeights: lntypes.Dual[uint64]{
 				Remote: commitHeight,
 			},
@@ -1471,6 +1512,21 @@ func (lc *LightningChannel) remoteLogUpdateToPayDesc(logUpdate *channeldb.LogUpd
 				btcutil.Amount(wireMsg.FeePerKw),
 			),
 			EntryType: FeeUpdate,
+			addCommitHeights: lntypes.Dual[uint64]{
+				Local: commitHeight,
+			},
+			removeCommitHeights: lntypes.Dual[uint64]{
+				Local: commitHeight,
+			},
+		}, nil
+
+	case *lnwire.DynCommit:
+		params := ChannelParamsFromDynPropose(&wireMsg.DynPropose)
+		return &paymentDescriptor{
+			ChanID:    wireMsg.ChanID,
+			LogIndex:  logUpdate.LogIndex,
+			EntryType: DynCommit,
+			DynParams: &params,
 			addCommitHeights: lntypes.Dual[uint64]{
 				Local: commitHeight,
 			},
@@ -1819,7 +1875,7 @@ func (lc *LightningChannel) restorePendingRemoteUpdates(
 		// final value was properly persisted with the last local
 		// commitment update.
 		switch payDesc.EntryType {
-		case FeeUpdate:
+		case FeeUpdate, DynCommit:
 			if heightSet {
 				payDesc.addCommitHeights.Remote = height
 				payDesc.removeCommitHeights.Remote = height
@@ -1862,11 +1918,13 @@ func (lc *LightningChannel) restorePeerLocalUpdates(updates []channeldb.LogUpdat
 
 		lc.updateLogs.Local.restoreUpdate(payDesc)
 
-		// Since Add updates are not stored and FeeUpdates don't have a
-		// corresponding entry in the remote update log, we only need to
-		// mark the htlc as modified if the update was Settle, Fail, or
-		// MalformedFail.
-		if payDesc.EntryType != FeeUpdate {
+		// Since Add updates are not stored and FeeUpdates/DynCommits
+		// don't have a corresponding entry in the remote update log, we
+		// only need to mark the htlc as modified if the update was
+		// Settle, Fail, or MalformedFail.
+		if payDesc.EntryType != FeeUpdate &&
+			payDesc.EntryType != DynCommit {
+
 			lc.updateLogs.Remote.markHtlcModified(
 				payDesc.ParentIndex,
 			)
@@ -1953,7 +2011,7 @@ func (lc *LightningChannel) restorePendingLocalUpdates(
 
 			lc.updateLogs.Local.appendHtlc(payDesc)
 
-		case FeeUpdate:
+		case FeeUpdate, DynCommit:
 			lc.updateLogs.Local.appendUpdate(payDesc)
 
 		default:
@@ -2833,6 +2891,29 @@ type HtlcView struct {
 
 	// FeePerKw is the fee rate in sat/kw of the commitment transaction.
 	FeePerKw chainfee.SatPerKWeight
+
+	// DynParams, if set, carries an active dynamic-commitments parameter
+	// update (a dyn_commit update-log entry) that this commitment view must
+	// be rendered with. When present, the commitment transaction is built
+	// with the proposer's proposed dust limit and to_self_delay (CSV) in
+	// place of the channel's current configs, mirroring how a FeePerKw drawn
+	// from an update_fee entry overrides the commitment fee. The dynamic-
+	// commitments precondition guarantees the view carries no HTLCs whenever
+	// this is set.
+	DynParams fn.Option[DynCommitParams]
+}
+
+// DynCommitParams bundles an active dynamic-commitments parameter proposal with
+// the identity of the proposing party. Together they determine how the affected
+// commitment outputs are rendered: the params are proposer-relative, so the
+// proposer identity is required to map them onto the local/remote channel
+// configs via ChannelParams.ApplyToConfigs.
+type DynCommitParams struct {
+	// Proposer is the party that proposed (and owns) the parameter change.
+	Proposer lntypes.ChannelParty
+
+	// Params is the proposed change to the mutable channel parameters.
+	Params ChannelParams
 }
 
 // AuxOurUpdates returns the outgoing HTLCs as a read-only copy of
@@ -2945,6 +3026,23 @@ func (lc *LightningChannel) fetchCommitmentView(
 		return nil, err
 	}
 	feePerKw := filteredHTLCView.FeePerKw
+
+	// If an active dyn_commit entry re-renders this commitment with new
+	// parameters, the stored dust limit for this view must reflect the
+	// proposer's proposed dust limit for whichever chain we're building, so
+	// that any later dust classification on this commitment stays
+	// consistent with the transaction we actually build below.
+	filteredHTLCView.DynParams.WhenSome(func(d DynCommitParams) {
+		effLocal, effRemote := d.Params.ApplyToConfigs(
+			d.Proposer, lc.channelState.LocalChanCfg,
+			lc.channelState.RemoteChanCfg,
+		)
+
+		dustLimit = effLocal.DustLimit
+		if whoseCommitChain.IsRemote() {
+			dustLimit = effRemote.DustLimit
+		}
+	})
 
 	htlcView.NextHeight = nextHeight
 	filteredHTLCView.NextHeight = nextHeight
@@ -3098,6 +3196,31 @@ func (lc *LightningChannel) evaluateHTLCView(view *HtlcView,
 		)
 	})
 
+	// A dyn_commit update-log entry, if present, re-renders the commitment
+	// with the proposer's proposed parameters (new dust limit and CSV). Like
+	// fee updates, such an entry lives in the log of the party that sent it,
+	// so the log it sits in identifies the proposer. The dynamic-commitments
+	// protocol permits at most one active parameter negotiation at a time, so
+	// we take the last dyn_commit entry found across both logs.
+	for _, party := range lntypes.BothParties {
+		partyUpdates := view.Updates.GetForParty(party)
+		dynUpdates := fn.Filter(
+			partyUpdates, func(u *paymentDescriptor) bool {
+				return u.EntryType == DynCommit
+			},
+		)
+		fn.Last(dynUpdates).WhenSome(func(pd *paymentDescriptor) {
+			if pd.DynParams == nil {
+				return
+			}
+
+			newView.DynParams = fn.Some(DynCommitParams{
+				Proposer: party,
+				Params:   *pd.DynParams,
+			})
+		})
+	}
+
 	// We use two maps, one for the local log and one for the remote log to
 	// keep track of which entries we need to skip when creating the final
 	// htlc view. We skip an entry whenever we find a settle or a timeout
@@ -3229,6 +3352,22 @@ func (lc *LightningChannel) evaluateHTLCView(view *HtlcView,
 		newView.Updates.SetForParty(party, liveAdds)
 	}
 
+	// Enforce the dynamic-commitments precondition: a parameter update may
+	// only ride a commitment that carries no HTLCs (including trimmed ones,
+	// which are still Add entries in the view). If a dyn_commit entry is
+	// active while any HTLC survives in the filtered view, the negotiation
+	// reached the commitment dance in an illegal state, so we refuse to
+	// render it rather than sign a commitment that both peers could
+	// reconstruct differently.
+	if newView.DynParams.IsSome() {
+		if len(newView.Updates.Local) != 0 ||
+			len(newView.Updates.Remote) != 0 {
+
+			noDeltas := lntypes.Dual[int64]{}
+			return nil, noUncommitted, noDeltas, ErrDynHtlcsPresent
+		}
+	}
+
 	// Create a function that is capable of identifying whether or not the
 	// paymentDescriptor has been committed in the commitment chain
 	// corresponding to whoseCommitmentChain.
@@ -3239,7 +3378,7 @@ func (lc *LightningChannel) evaluateHTLCView(view *HtlcView,
 				whoseCommitChain,
 			) == 0
 
-		case FeeUpdate:
+		case FeeUpdate, DynCommit:
 			return update.addCommitHeights.GetForParty(
 				whoseCommitChain,
 			) == 0
@@ -3685,8 +3824,10 @@ func (lc *LightningChannel) createCommitDiff(newCommit *commitment,
 				)
 			}
 
-		case FeeUpdate:
-			// Nothing special to do.
+		case FeeUpdate, DynCommit:
+			// Nothing special to do; these carry no HTLC-level
+			// references and are serialized straight to the log
+			// below.
 		}
 
 		logUpdates = append(logUpdates, pd.toLogUpdate())
@@ -6015,9 +6156,9 @@ func (lc *LightningChannel) ReceiveRevocation(revMsg *lnwire.RevokeAndAck) (
 	for e := lc.updateLogs.Remote.Front(); e != nil; e = e.Next() {
 		pd := e.Value
 
-		// Fee updates are local to this particular channel, and should
-		// never be forwarded.
-		if pd.EntryType == FeeUpdate {
+		// Fee updates and dyn_commit updates are local to this
+		// particular channel, and should never be forwarded.
+		if pd.EntryType == FeeUpdate || pd.EntryType == DynCommit {
 			continue
 		}
 
@@ -9591,6 +9732,105 @@ func (lc *LightningChannel) ReceiveUpdateFee(feePerKw chainfee.SatPerKWeight) er
 	lc.updateLogs.Remote.appendUpdate(pd)
 
 	return nil
+}
+
+// hasAnyHtlcs reports whether either update log currently carries an HTLC Add
+// entry (offered or trimmed). It is used to enforce the dynamic-commitments
+// no-HTLC precondition.
+//
+// NOTE: The caller must hold the channel lock.
+func (lc *LightningChannel) hasAnyHtlcs() bool {
+	logs := []*updateLog{lc.updateLogs.Local, lc.updateLogs.Remote}
+	for _, log := range logs {
+		for e := log.Front(); e != nil; e = e.Next() {
+			if e.Value.isAdd() {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// addDynUpdate stages a dyn_commit update-log entry, carrying an agreed
+// dynamic-commitments parameter change proposed by the given party, into that
+// party's update log. Staging the entry causes the next commitment rendered for
+// the relevant chain to use the proposed parameters (see evaluateHTLCView and
+// createUnsignedCommitmentTx). The caller must hold the channel lock.
+func (lc *LightningChannel) addDynUpdate(params ChannelParams,
+	proposer lntypes.ChannelParty) (uint64, error) {
+
+	// An empty proposal changes nothing and must never reach the log.
+	if params.IsEmpty() {
+		return 0, ErrDynParamsNoChange
+	}
+
+	// The dynamic-commitments protocol forbids a parameter change while any
+	// HTLC is in flight, including trimmed ones. Enforce that here so a
+	// caller can never desync the channel by staging a dyn update on a busy
+	// channel; the commitment renderer enforces the same invariant as a
+	// second line of defense.
+	if lc.hasAnyHtlcs() {
+		return 0, ErrDynHtlcsPresent
+	}
+
+	log := lc.updateLogs.Local
+	if proposer.IsRemote() {
+		log = lc.updateLogs.Remote
+	}
+
+	// Copy the params so the staged entry doesn't alias the caller's value.
+	p := params
+	pd := &paymentDescriptor{
+		ChanID:    lc.ChannelID(),
+		LogIndex:  log.logIndex,
+		EntryType: DynCommit,
+		DynParams: &p,
+	}
+
+	log.appendUpdate(pd)
+
+	return pd.LogIndex, nil
+}
+
+// AddDynUpdate stages an agreed dynamic-commitments parameter change into our
+// local update log, so that the next commitment we sign for the remote party is
+// rendered with the new parameters. It is the dynamic-commitments analogue of
+// UpdateFee: the proposer calls it once negotiation has produced an accepted
+// proposal and before signing the bundled dyn_commit_sig. We are the proposer,
+// so the change is applied with proposer == Local semantics.
+//
+// The channel must be free of HTLCs, including trimmed ones, otherwise
+// ErrDynHtlcsPresent is returned; an empty proposal is rejected with
+// ErrDynParamsNoChange. The returned log index identifies the staged entry.
+//
+// NOTE: This only stages the update. Driving the commitment dance (signing and
+// exchanging the bundled dyn_commit_sig, then revoking) reuses the normal
+// SignNextCommitment / ReceiveNewCommitment / revocation machinery, exactly as
+// for any other log entry, and advances the commitment height like any other
+// commitment_signed. Baking the change into the persistent channel configs and
+// epoch history when each chain locks in is a separate step performed via
+// ApplyChannelParams; see that method for the intended call order.
+func (lc *LightningChannel) AddDynUpdate(params ChannelParams) (uint64, error) {
+	lc.Lock()
+	defer lc.Unlock()
+
+	return lc.addDynUpdate(params, lntypes.Local)
+}
+
+// ReceiveDynUpdate stages an agreed dynamic-commitments parameter change
+// proposed by the remote party into our remote update log, so that the next
+// commitment the remote party signs for us is validated against the new
+// parameters. It is the responder-side counterpart to AddDynUpdate; the remote
+// party is the proposer, so the change is applied with proposer == Remote
+// semantics. The same preconditions as AddDynUpdate apply.
+func (lc *LightningChannel) ReceiveDynUpdate(params ChannelParams) (uint64,
+	error) {
+
+	lc.Lock()
+	defer lc.Unlock()
+
+	return lc.addDynUpdate(params, lntypes.Remote)
 }
 
 // generateRevocation generates the revocation message for a given height.

--- a/lnwallet/commitment.go
+++ b/lnwallet/commitment.go
@@ -715,9 +715,30 @@ func (cb *CommitmentBuilder) createUnsignedCommitmentTx(ourBalance,
 	filteredHTLCView *HtlcView, keyRing *CommitmentKeyRing,
 	prevCommit *commitment) (*unsignedCommitmentTx, error) {
 
-	dustLimit := cb.chanState.LocalChanCfg.DustLimit
+	// Determine the channel configs this commitment is rendered with. When a
+	// dyn_commit update-log entry is active in the view, we re-render the
+	// affected outputs (the to_local CSV delay and the output dust limits)
+	// using the proposer's proposed parameters instead of the channel's
+	// current configs. This mirrors how a fee update carried in the view
+	// overrides the commitment fee rate.
+	//
+	// Applying the proposal on top of the current configs is idempotent, so
+	// once the change locks in and LightningChannel.ApplyChannelParams bakes
+	// it into the persistent configs, this rendering keeps producing the same
+	// transaction until the (now redundant) log entry is compacted away. The
+	// dynamic-commitments precondition guarantees no HTLCs are present here,
+	// so only the to_local/to_remote(+anchor) outputs are affected.
+	localCfg := cb.chanState.LocalChanCfg
+	remoteCfg := cb.chanState.RemoteChanCfg
+	filteredHTLCView.DynParams.WhenSome(func(d DynCommitParams) {
+		localCfg, remoteCfg = d.Params.ApplyToConfigs(
+			d.Proposer, localCfg, remoteCfg,
+		)
+	})
+
+	dustLimit := localCfg.DustLimit
 	if whoseCommit.IsRemote() {
-		dustLimit = cb.chanState.RemoteChanCfg.DustLimit
+		dustLimit = remoteCfg.DustLimit
 	}
 
 	numHTLCs := int64(0)
@@ -804,7 +825,7 @@ func (cb *CommitmentBuilder) createUnsignedCommitmentTx(ourBalance,
 	if whoseCommit.IsLocal() {
 		commitTx, err = CreateCommitTx(
 			cb.chanState.ChanType, fundingTxIn(cb.chanState), keyRing,
-			&cb.chanState.LocalChanCfg, &cb.chanState.RemoteChanCfg,
+			&localCfg, &remoteCfg,
 			ourBalance.ToSatoshis(), theirBalance.ToSatoshis(),
 			numHTLCs, cb.chanState.IsInitiator, leaseExpiry,
 			auxResult.AuxLeaves,
@@ -812,7 +833,7 @@ func (cb *CommitmentBuilder) createUnsignedCommitmentTx(ourBalance,
 	} else {
 		commitTx, err = CreateCommitTx(
 			cb.chanState.ChanType, fundingTxIn(cb.chanState), keyRing,
-			&cb.chanState.RemoteChanCfg, &cb.chanState.LocalChanCfg,
+			&remoteCfg, &localCfg,
 			theirBalance.ToSatoshis(), ourBalance.ToSatoshis(),
 			numHTLCs, !cb.chanState.IsInitiator, leaseExpiry,
 			auxResult.AuxLeaves,

--- a/lnwallet/dyn_commit_test.go
+++ b/lnwallet/dyn_commit_test.go
@@ -1,0 +1,279 @@
+package lnwallet
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/stretchr/testify/require"
+)
+
+// hasOutputScript reports whether the given transaction has an output paying to
+// the passed pkScript.
+func hasOutputScript(tx *wire.MsgTx, pkScript []byte) bool {
+	for _, txOut := range tx.TxOut {
+		if bytes.Equal(txOut.PkScript, pkScript) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// deriveDynViewKeyRing derives the commitment key ring the channel would use
+// for the next commitment on the requested chain, mirroring the derivation done
+// inside SignNextCommitment / restoreCommitState.
+func deriveDynViewKeyRing(t *testing.T, lc *LightningChannel,
+	whoseCommit lntypes.ChannelParty,
+	chanType channeldb.ChannelType) *CommitmentKeyRing {
+
+	t.Helper()
+
+	var commitPoint *btcec.PublicKey
+	if whoseCommit.IsRemote() {
+		commitPoint = lc.channelState.RemoteNextRevocation
+		require.NotNil(t, commitPoint, "no remote next revocation")
+	} else {
+		nextHeight := lc.commitChains.Local.tip().height + 1
+		secret, err := lc.channelState.RevocationProducer.AtIndex(
+			nextHeight,
+		)
+		require.NoError(t, err, "unable to derive commit secret")
+		commitPoint = input.ComputeCommitmentPoint(secret[:])
+	}
+
+	return DeriveCommitmentKeys(
+		commitPoint, whoseCommit, chanType,
+		&lc.channelState.LocalChanCfg, &lc.channelState.RemoteChanCfg,
+	)
+}
+
+// buildDynCommitView constructs the commitment view for the requested chain
+// including all of the channel's currently staged updates.
+func buildDynCommitView(t *testing.T, lc *LightningChannel,
+	whoseCommit lntypes.ChannelParty,
+	keyRing *CommitmentKeyRing) *commitment {
+
+	t.Helper()
+
+	remoteACKedIndex := lc.commitChains.Local.tail().messageIndices.Remote
+	remoteHtlcIndex := lc.commitChains.Local.tail().theirHtlcIndex
+
+	view, err := lc.fetchCommitmentView(
+		whoseCommit, lc.updateLogs.Local.logIndex,
+		lc.updateLogs.Local.htlcCounter, remoteACKedIndex,
+		remoteHtlcIndex, keyRing,
+	)
+	require.NoError(t, err, "unable to build commitment view")
+
+	return view
+}
+
+// TestDynCommitRendersNewParams asserts that a staged dyn_commit update-log
+// entry re-renders the commitment transactions with the proposer's proposed
+// parameters: the proposer's own dust limit governs the proposer's own
+// commitment, while the proposed to_self_delay (CSV) governs the counterparty's
+// to_local output. This mirrors the proposer-owned semantics enforced by
+// ChannelParams.ApplyToConfigs.
+func TestDynCommitRendersNewParams(t *testing.T) {
+	t.Parallel()
+
+	const chanType = channeldb.SingleFunderTweaklessBit
+
+	// Alice is the channel funder and, here, the dynamic-commitments
+	// proposer.
+	aliceChannel, _, err := CreateTestChannels(t, chanType)
+	require.NoError(t, err, "unable to create test channels")
+
+	oldRemoteCSV := aliceChannel.channelState.RemoteChanCfg.CsvDelay
+	oldLocalCSV := aliceChannel.channelState.LocalChanCfg.CsvDelay
+	oldRemoteDust := aliceChannel.channelState.RemoteChanCfg.DustLimit
+	newCSV := oldRemoteCSV + 42
+	newDust := aliceChannel.channelState.LocalChanCfg.DustLimit + 500
+
+	params := ChannelParams{
+		DustLimit: fn.Some(newDust),
+		CsvDelay:  fn.Some(newCSV),
+	}
+
+	logIndex, err := aliceChannel.AddDynUpdate(params)
+	require.NoError(t, err, "unable to stage dyn update")
+	require.Equal(t, uint64(0), logIndex, "unexpected dyn log index")
+
+	// The remote (Bob's) commitment must render Bob's to_local output with
+	// Alice's proposed CSV, and must NOT retain the old CSV.
+	remoteKeyRing := deriveDynViewKeyRing(
+		t, aliceChannel, lntypes.Remote, chanType,
+	)
+	remoteView := buildDynCommitView(
+		t, aliceChannel, lntypes.Remote, remoteKeyRing,
+	)
+
+	// Bob is not the funder, so initiator=false for his commitment; the type
+	// has no lease, so leaseExpiry is unused.
+	newScript, err := CommitScriptToSelf(
+		chanType, false, remoteKeyRing.ToLocalKey,
+		remoteKeyRing.RevocationKey, uint32(newCSV), 0,
+		input.NoneTapLeaf(),
+	)
+	require.NoError(t, err, "unable to build new to_local script")
+	require.True(t, hasOutputScript(remoteView.txn, newScript.PkScript()),
+		"remote commitment missing to_local with proposed CSV")
+
+	oldScript, err := CommitScriptToSelf(
+		chanType, false, remoteKeyRing.ToLocalKey,
+		remoteKeyRing.RevocationKey, uint32(oldRemoteCSV), 0,
+		input.NoneTapLeaf(),
+	)
+	require.NoError(t, err, "unable to build old to_local script")
+	require.False(t, hasOutputScript(remoteView.txn, oldScript.PkScript()),
+		"remote commitment still uses old CSV")
+
+	// Alice's dust proposal governs her own commitment, so the remote
+	// (Bob's) commitment dust limit is unchanged.
+	require.Equal(t, oldRemoteDust, remoteView.dustLimit,
+		"remote commitment dust should be unchanged")
+
+	// Alice's own (local) commitment must reflect her new dust limit, while
+	// her own to_local CSV stays put (her proposal only constrains the
+	// counterparty's to_local delay).
+	localKeyRing := deriveDynViewKeyRing(
+		t, aliceChannel, lntypes.Local, chanType,
+	)
+	localView := buildDynCommitView(
+		t, aliceChannel, lntypes.Local, localKeyRing,
+	)
+	require.Equal(t, newDust, localView.dustLimit,
+		"local commitment dust not updated to proposed value")
+
+	localToLocal, err := CommitScriptToSelf(
+		chanType, true, localKeyRing.ToLocalKey,
+		localKeyRing.RevocationKey, uint32(oldLocalCSV), 0,
+		input.NoneTapLeaf(),
+	)
+	require.NoError(t, err, "unable to build local to_local script")
+	require.True(t, hasOutputScript(localView.txn, localToLocal.PkScript()),
+		"proposer's own to_local CSV should be unchanged")
+}
+
+// TestDynCommitStateTransition drives a full commitment dance across a staged
+// dyn_commit update and asserts that (a) both commitment heights advance exactly
+// as they would for a normal commitment_signed, and (b) the committed
+// transactions are rendered with the new parameters. A successful transition is
+// itself proof that both peers render the dyn commitment identically, since
+// otherwise signature verification inside ReceiveNewCommitment would fail.
+func TestDynCommitStateTransition(t *testing.T) {
+	t.Parallel()
+
+	const chanType = channeldb.SingleFunderTweaklessBit
+
+	aliceChannel, bobChannel, err := CreateTestChannels(t, chanType)
+	require.NoError(t, err, "unable to create test channels")
+
+	newCSV := aliceChannel.channelState.RemoteChanCfg.CsvDelay + 42
+	newDust := aliceChannel.channelState.LocalChanCfg.DustLimit + 500
+	params := ChannelParams{
+		DustLimit: fn.Some(newDust),
+		CsvDelay:  fn.Some(newCSV),
+	}
+
+	aliceHeightBefore := aliceChannel.channelState.LocalCommitment.
+		CommitHeight
+	bobHeightBefore := bobChannel.channelState.LocalCommitment.CommitHeight
+
+	// Alice is the proposer; Bob mirrors the agreed update into his remote
+	// log.
+	_, err = aliceChannel.AddDynUpdate(params)
+	require.NoError(t, err, "alice unable to stage dyn update")
+	_, err = bobChannel.ReceiveDynUpdate(params)
+	require.NoError(t, err, "bob unable to stage dyn update")
+
+	// Execute the bundled dyn_commit dance as a standard commitment/revoke
+	// round trip.
+	require.NoError(t, ForceStateTransition(aliceChannel, bobChannel),
+		"dyn commitment dance failed")
+
+	// The dyn commitment advances the height like any commitment_signed.
+	require.Equal(t, aliceHeightBefore+1,
+		aliceChannel.channelState.LocalCommitment.CommitHeight,
+		"alice commit height did not advance")
+	require.Equal(t, bobHeightBefore+1,
+		bobChannel.channelState.LocalCommitment.CommitHeight,
+		"bob commit height did not advance")
+
+	// Bob's freshly committed local commitment must render his to_local
+	// output with the CSV Alice proposed.
+	bobHeight := bobChannel.channelState.LocalCommitment.CommitHeight
+	secret, err := bobChannel.channelState.RevocationProducer.AtIndex(
+		bobHeight,
+	)
+	require.NoError(t, err, "unable to derive bob commit secret")
+	bobPoint := input.ComputeCommitmentPoint(secret[:])
+	bobKeyRing := DeriveCommitmentKeys(
+		bobPoint, lntypes.Local, chanType,
+		&bobChannel.channelState.LocalChanCfg,
+		&bobChannel.channelState.RemoteChanCfg,
+	)
+
+	wantScript, err := CommitScriptToSelf(
+		chanType, bobChannel.channelState.IsInitiator,
+		bobKeyRing.ToLocalKey, bobKeyRing.RevocationKey,
+		uint32(newCSV), 0, input.NoneTapLeaf(),
+	)
+	require.NoError(t, err, "unable to build expected to_local script")
+	require.True(t, hasOutputScript(
+		bobChannel.channelState.LocalCommitment.CommitTx,
+		wantScript.PkScript(),
+	), "bob's committed to_local missing proposed CSV")
+}
+
+// TestDynCommitRejectsHtlcs asserts the no-HTLC precondition of the dynamic-
+// commitments protocol is enforced at two layers: the staging API refuses to
+// add a dyn update while an HTLC is in flight, and the commitment renderer
+// refuses to build a commitment that carries both a dyn update and an HTLC even
+// if an entry is force-staged.
+func TestDynCommitRejectsHtlcs(t *testing.T) {
+	t.Parallel()
+
+	const chanType = channeldb.SingleFunderTweaklessBit
+
+	aliceChannel, bobChannel, err := CreateTestChannels(t, chanType)
+	require.NoError(t, err, "unable to create test channels")
+
+	// Put an HTLC in flight on both sides.
+	htlcAmt := lnwire.NewMSatFromSatoshis(btcutil.Amount(30000))
+	htlc, _ := createHTLC(0, htlcAmt)
+	addAndReceiveHTLC(t, aliceChannel, bobChannel, htlc, nil)
+
+	params := ChannelParams{CsvDelay: fn.Some(uint16(46))}
+
+	// The staging API rejects the update on both the proposer and responder
+	// side.
+	_, err = aliceChannel.AddDynUpdate(params)
+	require.ErrorIs(t, err, ErrDynHtlcsPresent,
+		"AddDynUpdate should reject with HTLC in flight")
+	_, err = bobChannel.ReceiveDynUpdate(params)
+	require.ErrorIs(t, err, ErrDynHtlcsPresent,
+		"ReceiveDynUpdate should reject with HTLC in flight")
+
+	// Force-stage a dyn entry alongside the HTLC to bypass the API check,
+	// then confirm the renderer still refuses to sign the commitment.
+	staged := params
+	aliceChannel.updateLogs.Local.appendUpdate(&paymentDescriptor{
+		ChanID:    aliceChannel.ChannelID(),
+		LogIndex:  aliceChannel.updateLogs.Local.logIndex,
+		EntryType: DynCommit,
+		DynParams: &staged,
+	})
+
+	_, err = aliceChannel.SignNextCommitment(ctxb)
+	require.ErrorIs(t, err, ErrDynHtlcsPresent,
+		"renderer should reject dyn update with HTLC present")
+}

--- a/lnwallet/payment_descriptor.go
+++ b/lnwallet/payment_descriptor.go
@@ -49,6 +49,16 @@ const (
 	// receiver. The criteria about whether the balance will go back to the
 	// sender is whether the receiver is sitting above the channel reserve.
 	NoOpAdd
+
+	// DynCommit is an update type sent by a dynamic-commitments proposer
+	// that renegotiates the "static" channel parameters (dust limit,
+	// to_self_delay, etc.) by committing a new channel state. Like
+	// FeeUpdate, it is not an HTLC: it changes how the next commitment
+	// transaction is rendered rather than moving a balance. On the wire it
+	// is carried by the bundled dyn_commit_sig message. The dynamic-
+	// commitments precondition guarantees no HTLCs are in flight while such
+	// an entry is active.
+	DynCommit
 )
 
 // String returns a human readable string that uniquely identifies the target
@@ -67,6 +77,8 @@ func (u updateType) String() string {
 		return "FeeUpdate"
 	case NoOpAdd:
 		return "NoOpAdd"
+	case DynCommit:
+		return "DynCommit"
 	default:
 		return "<unknown type>"
 	}
@@ -246,6 +258,15 @@ type paymentDescriptor struct {
 	// CustomRecords also stores the set of optional custom records that
 	// may have been attached to a sent HTLC.
 	CustomRecords lnwire.CustomRecords
+
+	// DynParams carries the proposed dynamic-commitments channel parameters
+	// for a DynCommit update-log entry. It is nil for every other entry
+	// type. The entry always lives in the proposer's update log, so the log
+	// it sits in identifies the proposing party; the params themselves are
+	// proposer-relative (see ChannelParams.ApplyToConfigs).
+	//
+	// NOTE: Populated only in payment descriptors with the DynCommit type.
+	DynParams *ChannelParams
 }
 
 // toLogUpdate recovers the underlying LogUpdate from the paymentDescriptor.
@@ -293,6 +314,17 @@ func (pd *paymentDescriptor) toLogUpdate() channeldb.LogUpdate {
 			ChanID:   pd.ChanID,
 			FeePerKw: uint32(pd.Amount.ToSatoshis()),
 		}
+	case DynCommit:
+		// The DynParams field holds the proposed parameters. We recover
+		// the on-the-wire dyn_commit_sig representation carrying just
+		// the accepted proposal TLVs; the commitment/ack signatures are
+		// tracked separately (in the CommitDiff and by the link) and are
+		// not part of the update-log payload.
+		dp := lnwire.DynPropose{ChanID: pd.ChanID}
+		if pd.DynParams != nil {
+			dp = *pd.DynParams.ToDynPropose(pd.ChanID)
+		}
+		msg = &lnwire.DynCommit{DynPropose: dp}
 	}
 
 	return channeldb.LogUpdate{
@@ -320,6 +352,19 @@ func (pd *paymentDescriptor) setCommitHeight(
 		// after they are sent/received, so we consider
 		// them being added and removed at the same
 		// height.
+		pd.addCommitHeights.SetForParty(
+			whoseCommitChain, nextHeight,
+		)
+		pd.removeCommitHeights.SetForParty(
+			whoseCommitChain, nextHeight,
+		)
+
+	case DynCommit:
+		// Like fee updates, a dyn_commit entry re-renders every
+		// commitment after it is sent/received, so we mark it added and
+		// removed at the same height. Once both chains have locked in
+		// the change (and it has been baked into the channel configs by
+		// ApplyChannelParams) the entry can be compacted away.
 		pd.addCommitHeights.SetForParty(
 			whoseCommitChain, nextHeight,
 		)

--- a/lnwallet/update_log.go
+++ b/lnwallet/update_log.go
@@ -174,9 +174,12 @@ func compactLogs(ourLog, theirLog *updateLog,
 			if remoteChainTail >= rmvHeights.Remote &&
 				localChainTail >= rmvHeights.Local {
 
-				// Fee updates have no parent htlcs, so we only
-				// remove the update itself.
-				if htlc.EntryType == FeeUpdate {
+				// Fee updates and dyn_commit updates have no
+				// parent htlcs, so we only remove the update
+				// itself.
+				if htlc.EntryType == FeeUpdate ||
+					htlc.EntryType == DynCommit {
+
 					logA.removeUpdate(htlc.LogIndex)
 					continue
 				}


### PR DESCRIPTION
Part of the Dynamic Commitments milestone: #60

`lnwallet` `dyn_commit` update-log entry — the commitment-dance linchpin.

**Stacked PR** — based on `yy-dyn-5-updater`; review after that branch (the base updates automatically as the parent merges).

Opened as a **draft**: this is part of the exploratory params-only stack (coarse commits, not final hygiene).