### PR TITLE
htlcswitch: link integration + commitment dance

### DIFF
--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lightningnetwork/lnd/contractcourt"
 	"github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/graph/db/models"
+	"github.com/lightningnetwork/lnd/htlcswitch/dyn"
 	"github.com/lightningnetwork/lnd/htlcswitch/hodl"
 	"github.com/lightningnetwork/lnd/htlcswitch/hop"
 	"github.com/lightningnetwork/lnd/input"
@@ -312,6 +313,23 @@ type ChannelLinkConfig struct {
 	// etc.) must finish their operations under this timeout value,
 	// otherwise the node will disconnect.
 	QuiescenceTimeout time.Duration
+
+	// DynAckSigner produces and verifies dyn_ack signatures for the dynamic
+	// commitments protocol. It is optional: when nil (or when quiescence is
+	// disabled) the link does not mount a dyn.Updater and the dynamic
+	// commitments feature is inert for this channel. Non-dyn channels are
+	// therefore byte-for-byte unaffected by this branch.
+	//
+	// NOTE: the production adapter is constructed at the point the feature
+	// is advertised/gated on (the RPC branch). This branch defines the seam
+	// and the concrete adapter (see newDynAckSigner) so the link path is
+	// complete and unit-testable ahead of activation.
+	DynAckSigner dyn.Signer
+
+	// MaxLocalCSVDelay is the maximum to_self_delay we will accept in a
+	// dynamic-commitments proposal. It bounds the CSV validation the mounted
+	// dyn.Updater performs. If zero, defaultMaxLinkCSVDelay is used.
+	MaxLocalCSVDelay uint16
 }
 
 // channelLink is the service which drives a channel's commitment update
@@ -423,6 +441,22 @@ type channelLink struct {
 	// the result.
 	quiescenceReqs chan StfuReq
 
+	// updater is the dynamic-commitments negotiation state machine mounted
+	// on this link. It is nil unless the dynamic commitments feature is
+	// enabled for this channel (see NewChannelLink). All dyn code paths are
+	// guarded on it being non-nil so non-dyn channels are unaffected.
+	updater *dyn.Updater
+
+	// dynProposalReqs carries locally-initiated dynamic-commitments
+	// proposal requests into the htlcManager event loop. It is only ever fed
+	// by initDynProposal, which errors out when the feature is not enabled.
+	dynProposalReqs chan dynProposalReq
+
+	// pendingDynProposal holds a locally-requested proposal that is waiting
+	// for the channel to reach quiescence before it can be initiated. It is
+	// only ever accessed from the htlcManager event loop.
+	pendingDynProposal fn.Option[dynProposalReq]
+
 	// cg is a helper that encapsulates a wait group and quit channel and
 	// allows contexts that either block or cancel on those depending on
 	// the use case.
@@ -521,7 +555,7 @@ func NewChannelLink(cfg ChannelLinkConfig,
 		chan fn.Req[fn.Unit, fn.Result[lntypes.ChannelParty]], 1,
 	)
 
-	return &channelLink{
+	l := &channelLink{
 		cfg:                 cfg,
 		channel:             channel,
 		hodlMap:             make(map[models.CircuitKey]hodlHtlc),
@@ -532,8 +566,20 @@ func NewChannelLink(cfg ChannelLinkConfig,
 		incomingCommitHooks: newHookMap(),
 		quiescer:            qsm,
 		quiescenceReqs:      quiescenceReqs,
+		dynProposalReqs:     make(chan dynProposalReq, 1),
 		cg:                  fn.NewContextGuard(),
 	}
+
+	// Mount the dynamic-commitments negotiation state machine only when the
+	// feature is enabled for this channel: quiescence must be available
+	// (dyn depends on it) and a dyn_ack signer must be provided. When either
+	// is missing the updater stays nil and every dyn code path is skipped,
+	// so the link behaves identically to before this branch.
+	if !cfg.DisallowQuiescence && cfg.DynAckSigner != nil {
+		l.updater = l.newDynUpdater()
+	}
+
+	return l
 }
 
 // A compile time check to ensure channelLink implements the ChannelLink
@@ -1450,6 +1496,12 @@ func (l *channelLink) htlcManager(ctx context.Context) {
 					"req: %v", err)
 			}
 
+		// A locally-initiated dynamic-commitments proposal was
+		// requested. We drive quiescence first and initiate the
+		// negotiation once the channel is quiescent.
+		case dReq := <-l.dynProposalReqs:
+			l.handleDynProposalReq(ctx, dReq)
+
 		case <-l.cg.Done():
 			return
 		}
@@ -1852,10 +1904,22 @@ func (l *channelLink) handleUpstreamMsg(ctx context.Context,
 		err = l.processRemoteUpdateFee(msg)
 
 	case *lnwire.Stfu:
-		err = l.handleStfu(msg)
+		err = l.handleStfu(ctx, msg)
 		if err != nil {
 			l.stfuFailf("handleStfu: %v", err)
 		}
+
+	case *lnwire.DynPropose:
+		err = l.handleDynMessage(ctx, msg)
+
+	case *lnwire.DynAck:
+		err = l.handleDynMessage(ctx, msg)
+
+	case *lnwire.DynReject:
+		err = l.handleDynMessage(ctx, msg)
+
+	case *lnwire.DynCommit:
+		err = l.handleDynMessage(ctx, msg)
 
 	// In the case where we receive a warning message from our peer, just
 	// log it and move on. We choose not to disconnect from our peer,
@@ -1879,7 +1943,8 @@ func (l *channelLink) handleUpstreamMsg(ctx context.Context,
 
 // handleStfu implements the top-level logic for handling the Stfu message from
 // our peer.
-func (l *channelLink) handleStfu(stfu *lnwire.Stfu) error {
+func (l *channelLink) handleStfu(ctx context.Context,
+	stfu *lnwire.Stfu) error {
 	if !l.noDanglingUpdates(lntypes.Remote) {
 		return ErrPendingRemoteUpdates
 	}
@@ -1890,8 +1955,14 @@ func (l *channelLink) handleStfu(stfu *lnwire.Stfu) error {
 
 	// If we can immediately send an Stfu response back, we will.
 	if l.noDanglingUpdates(lntypes.Local) {
-		return l.quiescer.SendOwedStfu()
+		if err := l.quiescer.SendOwedStfu(); err != nil {
+			return err
+		}
 	}
+
+	// Reaching quiescence may be the trigger a locally-requested dynamic
+	// commitments proposal was waiting on, so give it a chance to start.
+	l.maybeStartDynNegotiation(ctx)
 
 	return nil
 }

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -457,6 +457,15 @@ type channelLink struct {
 	// only ever accessed from the htlcManager event loop.
 	pendingDynProposal fn.Option[dynProposalReq]
 
+	// pendingDynDance holds an in-flight dynamic-commitments commitment
+	// dance while the bundled dyn_commit_sig round trip completes. It is set
+	// when the dance begins (the proposer after sending dyn_commit_sig, the
+	// responder after receiving it) and consumed by maybeFinishDynDance once
+	// both commitment chains have locked in the agreed parameter change, at
+	// which point the params are applied and quiescence is exited. It is only
+	// ever accessed from the htlcManager event loop.
+	pendingDynDance fn.Option[dynDance]
+
 	// cg is a helper that encapsulates a wait group and quit channel and
 	// allows contexts that either block or cancel on those depending on
 	// the use case.
@@ -4502,6 +4511,12 @@ func (l *channelLink) processRemoteCommitSig(ctx context.Context,
 	}
 	l.Unlock()
 
+	// A dyn_commit_sig is treated as a commitment_signed, so an in-flight
+	// dynamic-commitments dance may have just locked in its final chain
+	// here; apply the agreed params and exit quiescence if so. This is a
+	// no-op for non-dyn channels and any non-terminating dance step.
+	l.maybeFinishDynDance(ctx)
+
 	return nil
 }
 
@@ -4606,6 +4621,12 @@ func (l *channelLink) processRemoteRevokeAndAck(ctx context.Context,
 		l.flushHooks.invoke()
 	}
 	l.Unlock()
+
+	// A revoke_and_ack may lock in the final chain of an in-flight
+	// dynamic-commitments dance; apply the agreed params and exit quiescence
+	// if so. This is a no-op for non-dyn channels and any non-terminating
+	// dance step.
+	l.maybeFinishDynDance(ctx)
 
 	return nil
 }

--- a/htlcswitch/link_dyn.go
+++ b/htlcswitch/link_dyn.go
@@ -476,8 +476,13 @@ func (l *channelLink) processDynTransition(ctx context.Context,
 
 	t.Handoff.WhenSome(func(h dyn.CommitHandoff) {
 		if herr := l.handleDynCommitHandoff(ctx, h); herr != nil {
-			l.log.Errorf("dyn commit handoff failed for "+
-				"ChannelID(%v): %v", l.ChanID(), herr)
+			// A failure to send, sign, stage, or record the bundled
+			// dyn_commit_sig aborts the dance mid-flight. Reset the
+			// negotiation by failing the link so the peer disconnects
+			// cleanly and a fresh reestablish recovers, rather than
+			// leaving the channel quiesced or with a stale
+			// pendingDynDance.
+			l.dynFailf("dyn commit handoff failed: %v", herr)
 		}
 	})
 }
@@ -521,6 +526,20 @@ func (l *channelLink) handleDynCommitHandoff(ctx context.Context,
 		"height=%d, params=%s", l.ChanID(), h.Proposer,
 		h.NextCommitHeight, h.Params)
 
+	// Drive our side of the bundled dyn_commit_sig dance first. Only once it
+	// succeeds do we record the pending dance, so that a mid-flight failure
+	// (which the caller turns into a link reset) never leaves stale
+	// pendingDynDance state behind.
+	var err error
+	if h.Proposer.IsLocal() {
+		err = l.driveDynProposerCommit(ctx, h)
+	} else {
+		err = l.driveDynResponderCommit(ctx, h)
+	}
+	if err != nil {
+		return err
+	}
+
 	// Both commitment chains are synchronized at quiescence, so the agreed
 	// update binds to the same next commitment height on both, and the
 	// outgoing (pre-update) params applied through the prior height on each
@@ -535,11 +554,7 @@ func (l *channelLink) handleDynCommitHandoff(ctx context.Context,
 		},
 	})
 
-	if h.Proposer.IsLocal() {
-		return l.driveDynProposerCommit(ctx, h)
-	}
-
-	return l.driveDynResponderCommit(ctx, h)
+	return nil
 }
 
 // driveDynProposerCommit executes the proposer side of the bundled

--- a/htlcswitch/link_dyn.go
+++ b/htlcswitch/link_dyn.go
@@ -510,15 +510,19 @@ type dynDance struct {
 // SignNextCommitment / ReceiveNewCommitment machinery renders and validates the
 // next commitment under the new params with zero HTLCs. The proposer sends the
 // bundled dyn_commit_sig; the responder feeds the received one through the
-// ordinary commitment_signed handler. The remaining revoke_and_ack /
-// commitment_signed exchange rides the normal commitment-dance handlers, which
-// call maybeFinishDynDance to apply the params and exit quiescence at the
-// termination point (once both chains have locked in).
+// ordinary commitment_signed handler. This works for both non-taproot channels
+// (ECDSA commit_signature) and taproot channels (musig2
+// partial_signature_with_nonce, signed against the channel's ambient
+// next_local_nonce). The remaining revoke_and_ack / commitment_signed exchange
+// rides the normal commitment-dance handlers, which call maybeFinishDynDance to
+// apply the params and exit quiescence at the termination point (once both
+// chains have locked in).
 //
-// TODO(dyn): retransmitting the bundled dyn_commit_sig when a peer's
-// channel_reestablish expects it (and forgetting a negotiation that disconnects
-// before dyn_commit_sig) is handled by the reestablish branch (branch 9); it is
-// out of scope here.
+// What remains for the reestablish branch (branch 9): retransmitting the
+// bundled dyn_commit_sig when a peer's channel_reestablish expects it,
+// forgetting a negotiation that disconnects before dyn_commit_sig, and durably
+// persisting the bundled sig so the dance survives a restart. Those are out of
+// scope here.
 func (l *channelLink) handleDynCommitHandoff(ctx context.Context,
 	h dyn.CommitHandoff) error {
 
@@ -582,19 +586,17 @@ func (l *channelLink) driveDynProposerCommit(ctx context.Context,
 		return fmt.Errorf("sign dyn commitment: %w", err)
 	}
 
-	// TODO(dyn): taproot/musig2 channels produce a partial signature that
-	// the current dyn_commit_sig wire message cannot carry (it has no
-	// partial-sig field). Taproot dynamic commitments are out of scope for
-	// this milestone.
-	if newCommit.PartialSig.IsSome() {
-		return fmt.Errorf("dyn commitments unsupported for taproot " +
-			"channels")
-	}
-
+	// Bundle the produced signature exactly as a normal commitment_signed
+	// carries it. For taproot (musig2) channels SignNextCommitment produces
+	// a partial_signature_with_nonce (and leaves the ECDSA CommitSig as the
+	// blank 64 zero bytes); for non-taproot channels it produces the ECDSA
+	// CommitSig (and PartialSig is absent). The nonce used is the channel's
+	// ambient next_local_nonce, so no separate nonce exchange is needed.
 	dynCommit := &lnwire.DynCommit{
 		DynPropose: *h.Proposal,
 		CommitSig:  newCommit.CommitSig,
 		AckSig:     h.AckSig,
+		PartialSig: newCommit.PartialSig,
 	}
 	if err := l.cfg.Peer.SendMessage(false, dynCommit); err != nil {
 		return fmt.Errorf("send dyn_commit_sig: %w", err)
@@ -643,12 +645,21 @@ func (l *channelLink) driveDynResponderCommit(ctx context.Context,
 	// exactly as for any commitment dance. Dynamic updates carry no HTLCs and
 	// hence no HTLC/aux signatures.
 	//
+	// For taproot channels the signature rides the
+	// partial_signature_with_nonce field and the ECDSA CommitSig is blank;
+	// for non-taproot channels the ECDSA CommitSig carries it and PartialSig
+	// is absent. Forwarding both mirrors how a normal commitment_signed is
+	// handled: ReceiveNewCommitment verifies the partial sig against our next
+	// commitment using the channel's existing nonce state for taproot, and
+	// the ECDSA sig otherwise.
+	//
 	// The accepted proposal TLVs and dyn_ack signature were already persisted
 	// by the negotiation state machine at accept time; durable persistence of
 	// the received dyn_commit_sig for reconnect resume is branch 9.
 	return l.processRemoteCommitSig(ctx, &lnwire.CommitSig{
-		ChanID:    l.ChanID(),
-		CommitSig: dynCommit.CommitSig,
+		ChanID:     l.ChanID(),
+		CommitSig:  dynCommit.CommitSig,
+		PartialSig: dynCommit.PartialSig,
 	})
 }
 

--- a/htlcswitch/link_dyn.go
+++ b/htlcswitch/link_dyn.go
@@ -482,51 +482,209 @@ func (l *channelLink) processDynTransition(ctx context.Context,
 	})
 }
 
-// handleDynCommitHandoff drives the commitment dance once negotiation has
-// produced an agreed parameter update. Negotiation itself is owned by the
-// dyn.Updater; from here the link + wallet must execute the bundled
-// dyn_commit_sig commitment dance and apply the params at lock-in.
+// dynDance carries the state needed to finish a dynamic-commitments commitment
+// dance once both commitment chains have locked in the agreed parameter change.
+type dynDance struct {
+	// handoff is the agreed parameter update handed off by the negotiation
+	// state machine.
+	handoff dyn.CommitHandoff
+
+	// lockIn is, per commitment chain, the last height the outgoing
+	// (pre-update) parameters applied to. Both chains lock in the new
+	// parameters at the bound commitment height, so this is that height
+	// minus one on each side.
+	lockIn lntypes.Dual[uint64]
+}
+
+// handleDynCommitHandoff drives the bundled dyn_commit_sig commitment dance
+// once negotiation has produced an agreed parameter update. Negotiation is
+// owned by the dyn.Updater; from here the link + wallet execute the dance and
+// apply the params once both chains lock in.
 //
-// TODO(dyn): the on-chain commitment dance is not executed yet. Completing it
-// requires lnwallet support that does not exist in the branches this one is
-// stacked on (branches 1-5 provide the epoch persistence, the mutable-params
-// apply API, and the wire/negotiation machinery, but not a dyn update-log
-// entry). The precise remaining sub-steps are:
+// The agreed update is staged into the channel's update log so the ordinary
+// SignNextCommitment / ReceiveNewCommitment machinery renders and validates the
+// next commitment under the new params with zero HTLCs. The proposer sends the
+// bundled dyn_commit_sig; the responder feeds the received one through the
+// ordinary commitment_signed handler. The remaining revoke_and_ack /
+// commitment_signed exchange rides the normal commitment-dance handlers, which
+// call maybeFinishDynDance to apply the params and exit quiescence at the
+// termination point (once both chains have locked in).
 //
-//  1. Add the agreed update to the channel as a dyn update-log entry (like
-//     update_fee) so that SignNextCommitment / ReceiveNewCommitment build and
-//     validate the next commitment with the proposed params applied and zero
-//     HTLCs. This lnwallet primitive does not exist yet.
-//  2. Proposer (h.Proposer == lntypes.Local): build the bundled DynCommit —
-//     the commitment signature over the responder's next commitment (from the
-//     new lnwallet primitive), the echoed responder dyn_ack signature
-//     (h.AckSig), and the accepted proposal TLVs (h.Proposal) — send it, then
-//     call updater.MarkCommitSent.
-//  3. Responder (h.Proposer == lntypes.Remote): verify h.ReceivedCommit's
-//     commitment signature against our next local commitment (again via the new
-//     primitive). Persist the received dyn_commit_sig + accepted TLVs +
-//     resulting commitment state BEFORE sending revoke_and_ack.
-//  4. Execute commitment_signed / revoke_and_ack in the required order,
-//     treating dyn_commit_sig as commitment_signed-equivalent for
-//     commitment-number accounting and retransmission (retransmission is
-//     branch 8).
-//  5. Apply the params to the local/remote config exactly when each chain
-//     locks in, via l.applyDynParams (already wired and unit-tested below);
-//     lock-in for a chain happens when the corresponding revocation is
-//     processed, so the per-side heights differ.
-//  6. Exit quiescence via l.quiescer.Resume() at the BOLT-defined termination
-//     point (after both chains have locked in).
-//
-// Until (1) lands, executing any of (2)-(6) against the live channel would
-// desync it with the peer, so we deliberately do not mutate channel state here.
-func (l *channelLink) handleDynCommitHandoff(_ context.Context,
+// TODO(dyn): retransmitting the bundled dyn_commit_sig when a peer's
+// channel_reestablish expects it (and forgetting a negotiation that disconnects
+// before dyn_commit_sig) is handled by the reestablish branch (branch 9); it is
+// out of scope here.
+func (l *channelLink) handleDynCommitHandoff(ctx context.Context,
 	h dyn.CommitHandoff) error {
 
 	l.log.Infof("Dyn negotiation agreed for ChannelID(%v): proposer=%v, "+
 		"height=%d, params=%s", l.ChanID(), h.Proposer,
 		h.NextCommitHeight, h.Params)
 
+	// Both commitment chains are synchronized at quiescence, so the agreed
+	// update binds to the same next commitment height on both, and the
+	// outgoing (pre-update) params applied through the prior height on each
+	// side. Stash the handoff so maybeFinishDynDance can apply the params
+	// and exit quiescence once both chains have locked in.
+	lockInHeight := h.NextCommitHeight - 1
+	l.pendingDynDance = fn.Some(dynDance{
+		handoff: h,
+		lockIn: lntypes.Dual[uint64]{
+			Local:  lockInHeight,
+			Remote: lockInHeight,
+		},
+	})
+
+	if h.Proposer.IsLocal() {
+		return l.driveDynProposerCommit(ctx, h)
+	}
+
+	return l.driveDynResponderCommit(ctx, h)
+}
+
+// driveDynProposerCommit executes the proposer side of the bundled
+// dyn_commit_sig dance. It stages the agreed update into our local update log,
+// signs the responder's next commitment under the new params, sends the bundled
+// dyn_commit_sig, and records the send with the negotiation state machine. The
+// responder then replies with a normal revoke_and_ack and commitment_signed,
+// which flow through the ordinary commitment-dance handlers.
+//
+// NOTE: MUST be called from the htlcManager event loop.
+func (l *channelLink) driveDynProposerCommit(ctx context.Context,
+	h dyn.CommitHandoff) error {
+
+	// Stage the agreed change so the next commitment we sign for the remote
+	// party is rendered with the new params and zero HTLCs.
+	if _, err := l.channel.AddDynUpdate(h.Params); err != nil {
+		return fmt.Errorf("stage dyn update: %w", err)
+	}
+
+	// Sign the responder's next commitment. dyn_commit_sig is the
+	// commitment_signed for that state; dynamic updates carry no HTLCs, so
+	// there are no HTLC signatures.
+	newCommit, err := l.channel.SignNextCommitment(ctx)
+	if err != nil {
+		return fmt.Errorf("sign dyn commitment: %w", err)
+	}
+
+	// TODO(dyn): taproot/musig2 channels produce a partial signature that
+	// the current dyn_commit_sig wire message cannot carry (it has no
+	// partial-sig field). Taproot dynamic commitments are out of scope for
+	// this milestone.
+	if newCommit.PartialSig.IsSome() {
+		return fmt.Errorf("dyn commitments unsupported for taproot " +
+			"channels")
+	}
+
+	dynCommit := &lnwire.DynCommit{
+		DynPropose: *h.Proposal,
+		CommitSig:  newCommit.CommitSig,
+		AckSig:     h.AckSig,
+	}
+	if err := l.cfg.Peer.SendMessage(false, dynCommit); err != nil {
+		return fmt.Errorf("send dyn_commit_sig: %w", err)
+	}
+
+	// Record that we have sent the bundled dyn_commit_sig, moving the state
+	// machine to its committing terminal state.
+	if _, err := l.updater.MarkCommitSent(ctx); err != nil {
+		return fmt.Errorf("mark commit sent: %w", err)
+	}
+
 	return nil
+}
+
+// driveDynResponderCommit executes the responder side of the bundled
+// dyn_commit_sig dance. It stages the agreed update into the remote
+// (proposer's) update log, then feeds the bundled commitment sig through the
+// commitment_signed handler, which validates and persists our newly rendered
+// commitment before sending revoke_and_ack, and signs the proposer's next
+// commitment (a normal commitment_signed). The proposer's final revoke_and_ack
+// then flows through the ordinary handler.
+//
+// NOTE: MUST be called from the htlcManager event loop.
+func (l *channelLink) driveDynResponderCommit(ctx context.Context,
+	h dyn.CommitHandoff) error {
+
+	dynCommit, err := h.ReceivedCommit.UnwrapOrErr(
+		fmt.Errorf("responder handoff missing dyn_commit_sig"),
+	)
+	if err != nil {
+		return err
+	}
+
+	// Stage the agreed change proposed by the remote party so our next local
+	// commitment is validated, and the proposer's next commitment is signed,
+	// under the new params.
+	if _, err := l.channel.ReceiveDynUpdate(h.Params); err != nil {
+		return fmt.Errorf("stage dyn update: %w", err)
+	}
+
+	// dyn_commit_sig is the commitment_signed for our next commitment. Reuse
+	// the ordinary handler so the received signature is validated and the
+	// resulting commitment is persisted (via ReceiveNewCommitment) before we
+	// send revoke_and_ack, and so our reply (revoke_and_ack plus a normal
+	// commitment_signed for the proposer's next commitment) is produced
+	// exactly as for any commitment dance. Dynamic updates carry no HTLCs and
+	// hence no HTLC/aux signatures.
+	//
+	// The accepted proposal TLVs and dyn_ack signature were already persisted
+	// by the negotiation state machine at accept time; durable persistence of
+	// the received dyn_commit_sig for reconnect resume is branch 9.
+	return l.processRemoteCommitSig(ctx, &lnwire.CommitSig{
+		ChanID:    l.ChanID(),
+		CommitSig: dynCommit.CommitSig,
+	})
+}
+
+// maybeFinishDynDance completes an in-flight dynamic-commitments commitment
+// dance once both commitment chains have locked in the agreed parameter change.
+// It is invoked at each commitment-dance step that may have just locked in the
+// last chain (after processing a revoke_and_ack or a commitment_signed). It is
+// a no-op unless a dance is in flight and the channel has returned to a clean
+// state, i.e. both chains sign the same updates with the dyn update committed
+// and compacted away.
+//
+// On completion it applies the agreed params to the persistent channel config
+// (recording a commit-chain epoch for script-rendering changes), clears the
+// negotiation state so a fresh proposal is possible, and exits quiescence at
+// the BOLT-defined termination point.
+//
+// NOTE: MUST be called from the htlcManager event loop.
+func (l *channelLink) maybeFinishDynDance(ctx context.Context) {
+	l.pendingDynDance.WhenSome(func(d dynDance) {
+		// The dance is only complete once both chains sign the same
+		// updates again: the agreed update has been committed on both
+		// commitments and compacted out of the logs.
+		if !l.channel.IsChannelClean() {
+			return
+		}
+
+		// Apply the agreed params to the persistent local/remote config
+		// and, for script-rendering changes, record the commit-chain
+		// epoch at the per-side lock-in heights.
+		if err := l.applyDynParams(d.handoff, d.lockIn); err != nil {
+			l.dynFailf("apply dyn params: %v", err)
+
+			return
+		}
+
+		l.pendingDynDance = fn.None[dynDance]()
+
+		// Clear the negotiation state so the channel can negotiate a
+		// fresh update after a new quiescence session.
+		if err := l.updater.Reset(ctx); err != nil {
+			l.log.Errorf("Unable to reset dyn updater for "+
+				"ChannelID(%v): %v", l.ChanID(), err)
+		}
+
+		// Both chains have locked in; exit quiescence at the
+		// BOLT-defined termination point.
+		l.quiescer.Resume()
+
+		l.log.Infof("Dyn update locked in for ChannelID(%v): params=%s",
+			l.ChanID(), d.handoff.Params)
+	})
 }
 
 // applyDynParams applies an agreed dynamic-commitments parameter update to the

--- a/htlcswitch/link_dyn.go
+++ b/htlcswitch/link_dyn.go
@@ -1,0 +1,559 @@
+package htlcswitch
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/clock"
+	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/htlcswitch/dyn"
+	"github.com/lightningnetwork/lnd/htlcswitch/hop"
+	"github.com/lightningnetwork/lnd/lnpeer"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+// defaultMaxLinkCSVDelay is the fallback maximum to_self_delay accepted in a
+// dynamic-commitments proposal when the link config does not specify one. It
+// matches the daemon-wide default maximum local CSV delay.
+const defaultMaxLinkCSVDelay uint16 = 2016
+
+// errDynDisabled is returned when a dynamic-commitments operation is requested
+// on a link that does not have the feature enabled.
+var errDynDisabled = fmt.Errorf("dynamic commitments not enabled for channel")
+
+// dynProposalReq is a locally-initiated dynamic-commitments proposal request
+// handed to the htlcManager event loop via initDynProposal.
+type dynProposalReq struct {
+	// req is the parameter-change proposal to negotiate.
+	req dyn.ProposalRequest
+
+	// resp receives the outcome of starting the negotiation: nil once the
+	// dyn_propose has been sent, or an error if quiescence or a
+	// precondition failed. It is buffered so the loop never blocks on it.
+	resp chan error
+}
+
+// dynAckSigner is the concrete dyn.Signer used by the link. It signs dyn_ack
+// messages with our node identity key and verifies the peer's dyn_ack against
+// its node identity key, delegating to the domain-separated lnwire helpers.
+type dynAckSigner struct {
+	// nodePriv is our node identity private key, used to produce dyn_ack
+	// signatures.
+	nodePriv *btcec.PrivateKey
+
+	// peerPub is the peer's node identity public key, used to verify the
+	// dyn_ack signatures they send us.
+	peerPub *btcec.PublicKey
+}
+
+// A compile-time assertion that dynAckSigner implements dyn.Signer.
+var _ dyn.Signer = (*dynAckSigner)(nil)
+
+// newDynAckSigner constructs a dyn.Signer over the given node identity private
+// key and peer node identity public key.
+func newDynAckSigner(nodePriv *btcec.PrivateKey,
+	peerPub *btcec.PublicKey) *dynAckSigner {
+
+	return &dynAckSigner{
+		nodePriv: nodePriv,
+		peerPub:  peerPub,
+	}
+}
+
+// SignDynAck produces our dyn_ack signature over the accepted proposal.
+//
+// NOTE: Part of the dyn.Signer interface.
+func (s *dynAckSigner) SignDynAck(chainHash chainhash.Hash,
+	chanID lnwire.ChannelID, nextCommitHeight uint64,
+	proposalTLVs []byte) (lnwire.Sig, error) {
+
+	return lnwire.SignDynAck(
+		s.nodePriv, chainHash, chanID, nextCommitHeight, proposalTLVs,
+	)
+}
+
+// VerifyDynAck verifies the peer's dyn_ack signature over the proposal we sent.
+//
+// NOTE: Part of the dyn.Signer interface.
+func (s *dynAckSigner) VerifyDynAck(sig lnwire.Sig, chainHash chainhash.Hash,
+	chanID lnwire.ChannelID, nextCommitHeight uint64,
+	proposalTLVs []byte) error {
+
+	return lnwire.VerifyDynAck(
+		s.peerPub, sig, chainHash, chanID, nextCommitHeight,
+		proposalTLVs,
+	)
+}
+
+// dynMessageSender is the concrete dyn.MessageSender used by the link. It sends
+// dyn wire messages to the peer over the same send path the link uses for all
+// other channel messages.
+type dynMessageSender struct {
+	// peer is the peer connection the messages are sent to.
+	peer lnpeer.Peer
+}
+
+// A compile-time assertion that dynMessageSender implements dyn.MessageSender.
+var _ dyn.MessageSender = (*dynMessageSender)(nil)
+
+// SendMessage sends the given messages to the peer, in order.
+//
+// NOTE: Part of the dyn.MessageSender interface.
+func (s *dynMessageSender) SendMessage(_ context.Context,
+	msgs ...lnwire.Message) error {
+
+	return s.peer.SendMessage(false, msgs...)
+}
+
+// dynChannelView is the concrete dyn.ChannelView used by the link. It exposes a
+// read-only window onto the live channelLink/LightningChannel state that the
+// dyn.Updater consults for its eligibility preconditions and proposal
+// validation.
+type dynChannelView struct {
+	// link is the channel link this view reads from.
+	link *channelLink
+}
+
+// A compile-time assertion that dynChannelView implements dyn.ChannelView.
+var _ dyn.ChannelView = (*dynChannelView)(nil)
+
+// ChanID returns the channel id this view is for.
+//
+// NOTE: Part of the dyn.ChannelView interface.
+func (v *dynChannelView) ChanID() lnwire.ChannelID {
+	return v.link.ChanID()
+}
+
+// ChainHash returns the genesis hash of the chain the channel is on.
+//
+// NOTE: Part of the dyn.ChannelView interface.
+func (v *dynChannelView) ChainHash() chainhash.Hash {
+	return v.link.channel.State().ChainHash
+}
+
+// LocalChanCfg returns our current channel configuration.
+//
+// NOTE: Part of the dyn.ChannelView interface.
+func (v *dynChannelView) LocalChanCfg() channeldb.ChannelConfig {
+	return v.link.channel.State().LocalChanCfg
+}
+
+// RemoteChanCfg returns the peer's current channel configuration.
+//
+// NOTE: Part of the dyn.ChannelView interface.
+func (v *dynChannelView) RemoteChanCfg() channeldb.ChannelConfig {
+	return v.link.channel.State().RemoteChanCfg
+}
+
+// Capacity returns the total channel capacity.
+//
+// NOTE: Part of the dyn.ChannelView interface.
+func (v *dynChannelView) Capacity() btcutil.Amount {
+	return v.link.channel.State().Capacity
+}
+
+// NextCommitHeight returns the commitment number the dynamic update will be
+// committed at. At quiescence both commitment chains are synchronized and have
+// no pending updates, so the next local commitment height is shared by both
+// peers and is the value bound into the dyn_ack digest.
+//
+// NOTE: Part of the dyn.ChannelView interface.
+func (v *dynChannelView) NextCommitHeight() uint64 {
+	return v.link.channel.State().LocalCommitment.CommitHeight + 1
+}
+
+// BothChannelReady returns true only once both peers have sent and received
+// channel_ready and the reestablish dance has completed. This mirrors the
+// link's own eligibility check without the quiescence gate (which is
+// necessarily active while a dyn update is negotiated).
+//
+// NOTE: Part of the dyn.ChannelView interface.
+func (v *dynChannelView) BothChannelReady() bool {
+	return v.link.channel.RemoteNextRevocation() != nil &&
+		v.link.channel.ShortChanID() != hop.Source &&
+		v.link.isReestablished()
+}
+
+// IsQuiescent returns true if the channel has been driven to quiescence.
+//
+// NOTE: Part of the dyn.ChannelView interface.
+func (v *dynChannelView) IsQuiescent() bool {
+	return v.link.quiescer.IsQuiescent()
+}
+
+// QuiescenceInitiator returns the party that initiated quiescence.
+//
+// NOTE: Part of the dyn.ChannelView interface.
+func (v *dynChannelView) QuiescenceInitiator() fn.Result[lntypes.ChannelParty] {
+	return v.link.quiescer.QuiescenceInitiator()
+}
+
+// HasHTLCs returns true if either commitment has any HTLCs, including trimmed
+// HTLCs. Trimmed HTLCs (those below the applicable dust limit) carry no output
+// but are still recorded on the persisted commitment with an OutputIndex of -1,
+// so counting the commitment HTLC sets captures them too.
+//
+// NOTE: Part of the dyn.ChannelView interface.
+func (v *dynChannelView) HasHTLCs() bool {
+	state := v.link.channel.State()
+
+	return len(state.LocalCommitment.Htlcs) > 0 ||
+		len(state.RemoteCommitment.Htlcs) > 0
+}
+
+// HasPendingUpdates returns true if there are update-log entries that are not
+// yet bilaterally committed on both chains.
+//
+// NOTE: Part of the dyn.ChannelView interface.
+func (v *dynChannelView) HasPendingUpdates() bool {
+	return v.link.channel.OweCommitment() ||
+		v.link.channel.NeedCommitment()
+}
+
+// HasPendingShutdown returns true if a cooperative shutdown is in progress on
+// the channel.
+//
+// NOTE: for this branch we surface the shutdown state the link tracks, i.e.
+// whether we have previously sent a shutdown for the channel. Full bilateral
+// shutdown coordination lives in the peer, which will not initiate a dyn update
+// while a shutdown is outstanding.
+//
+// NOTE: Part of the dyn.ChannelView interface.
+func (v *dynChannelView) HasPendingShutdown() bool {
+	return v.link.cfg.PreviouslySentShutdown.IsSome()
+}
+
+// HasPendingSpliceOrRBF returns true if a splice or an RBF of a pending
+// funding/close is in progress on the channel.
+//
+// NOTE: the link does not track splice/RBF state; that coordination lives in
+// the peer/funding layer, which gates dyn initiation. There is no in-link
+// signal to consult today, so this conservatively returns false and relies on
+// the higher layer not to drive a dyn update mid-splice.
+//
+// NOTE: Part of the dyn.ChannelView interface.
+func (v *dynChannelView) HasPendingSpliceOrRBF() bool {
+	return false
+}
+
+// newDynUpdater constructs the dyn.Updater for this link, wiring the concrete
+// adapters over the live link/channel/peer objects. The Persister is the
+// in-memory reference implementation for now; durable channeldb persistence and
+// the reconnect logic land in the reestablish branch.
+func (l *channelLink) newDynUpdater() *dyn.Updater {
+	return dyn.NewUpdater(dyn.Config{
+		Signer:      l.cfg.DynAckSigner,
+		ChannelView: &dynChannelView{link: l},
+
+		// TODO(dyn): branch 8 replaces this with a channeldb-backed
+		// Persister so accepted-proposal context survives a restart and
+		// drives reconnect resume/forget decisions.
+		Persister: dyn.NewMemPersister(),
+
+		Sender:           &dynMessageSender{peer: l.cfg.Peer},
+		Clock:            clock.NewDefaultClock(),
+		MaxLocalCSVDelay: l.dynMaxCSVDelay(),
+	})
+}
+
+// dynMaxCSVDelay returns the maximum to_self_delay accepted in a
+// dynamic-commitments proposal for this link.
+func (l *channelLink) dynMaxCSVDelay() uint16 {
+	if l.cfg.MaxLocalCSVDelay == 0 {
+		return defaultMaxLinkCSVDelay
+	}
+
+	return l.cfg.MaxLocalCSVDelay
+}
+
+// initDynProposal requests a locally-initiated dynamic-commitments parameter
+// change. It hands the request to the htlcManager event loop, which drives the
+// channel to quiescence (with us as the quiescence initiator) and then starts
+// the negotiation. It returns a channel that receives nil once the negotiation
+// has been kicked off (dyn_propose sent), or an error if the feature is
+// disabled or a precondition failed.
+//
+// This is the entry point the RPC branch drives; tests exercise it directly.
+func (l *channelLink) initDynProposal(
+	req dyn.ProposalRequest) <-chan error {
+
+	resp := make(chan error, 1)
+
+	if l.updater == nil {
+		resp <- errDynDisabled
+
+		return resp
+	}
+
+	dReq := dynProposalReq{
+		req:  req,
+		resp: resp,
+	}
+
+	select {
+	case l.dynProposalReqs <- dReq:
+	case <-l.cg.Done():
+		resp <- ErrLinkShuttingDown
+	}
+
+	return resp
+}
+
+// handleDynProposalReq starts servicing a locally-initiated dyn proposal from
+// within the event loop. It stashes the request, drives quiescence with us as
+// the initiator, and starts the negotiation immediately if the channel is
+// already quiescent. If quiescence cannot begin yet the request stays pending
+// and is picked up by maybeStartDynNegotiation once quiescence completes.
+//
+// NOTE: MUST be called from the htlcManager event loop.
+func (l *channelLink) handleDynProposalReq(ctx context.Context,
+	req dynProposalReq) {
+
+	if l.updater == nil {
+		l.replyDynProposal(req, errDynDisabled)
+
+		return
+	}
+
+	// Refuse to clobber an in-flight negotiation or a pending request.
+	if l.pendingDynProposal.IsSome() ||
+		l.updater.State() != dyn.StateIdle {
+
+		l.replyDynProposal(req, dyn.ErrNegotiationInProgress)
+
+		return
+	}
+
+	// Stash the request so we can start it once we reach quiescence.
+	l.pendingDynProposal = fn.Some(req)
+
+	// Drive quiescence with us as the initiator. We must be the quiescence
+	// initiator to be the dyn proposer.
+	stfuReq, _ := fn.NewReq[fn.Unit, fn.Result[lntypes.ChannelParty]](
+		fn.Unit{},
+	)
+	l.quiescer.InitStfu(stfuReq)
+
+	if err := l.quiescer.SendOwedStfu(); err != nil {
+		l.pendingDynProposal = fn.None[dynProposalReq]()
+		l.replyDynProposal(req, err)
+		l.stfuFailf("dyn SendOwedStfu: %v", err)
+
+		return
+	}
+
+	// If the channel is already quiescent (for example the peer initiated
+	// concurrently and we won the initiator tie), start right away.
+	// Otherwise the negotiation begins when the peer's stfu arrives.
+	l.maybeStartDynNegotiation(ctx)
+}
+
+// maybeStartDynNegotiation starts a pending locally-initiated dyn negotiation
+// if the channel has reached quiescence. It is invoked at each point quiescence
+// may have just completed. It is a no-op if the feature is disabled, no request
+// is pending, or the channel is not yet quiescent.
+//
+// NOTE: MUST be called from the htlcManager event loop.
+func (l *channelLink) maybeStartDynNegotiation(ctx context.Context) {
+	if l.updater == nil {
+		return
+	}
+
+	l.pendingDynProposal.WhenSome(func(req dynProposalReq) {
+		if !l.quiescer.IsQuiescent() {
+			return
+		}
+
+		// We are about to act on the request; clear it first so a
+		// failure path does not leave it pending.
+		l.pendingDynProposal = fn.None[dynProposalReq]()
+
+		t, err := l.updater.InitProposal(ctx, req.req)
+		l.replyDynProposal(req, err)
+		if err != nil {
+			l.log.Warnf("Unable to start dyn proposal for "+
+				"ChannelID(%v): %v", l.ChanID(), err)
+
+			// The negotiation never got off the ground, so there is
+			// nothing to commit; release the channel from
+			// quiescence.
+			l.quiescer.Resume()
+
+			return
+		}
+
+		l.processDynTransition(ctx, t, nil)
+	})
+}
+
+// replyDynProposal delivers the outcome of a proposal request back to the
+// caller. The response channel is buffered, so this never blocks.
+func (l *channelLink) replyDynProposal(req dynProposalReq, err error) {
+	select {
+	case req.resp <- err:
+	default:
+	}
+}
+
+// handleDynMessage routes an incoming dyn wire message into the mounted
+// dyn.Updater and processes the resulting transition. When the feature is not
+// enabled for this channel the message is logged and ignored; a well-behaved
+// peer will not send dyn messages unless the feature was negotiated.
+//
+// NOTE: MUST be called from the htlcManager event loop.
+func (l *channelLink) handleDynMessage(ctx context.Context,
+	msg lnwire.Message) error {
+
+	if l.updater == nil {
+		l.log.Warnf("Received %v but dynamic commitments not enabled "+
+			"for ChannelID(%v); ignoring", msg.MsgType(),
+			l.ChanID())
+
+		return nil
+	}
+
+	var (
+		t   *dyn.Transition
+		err error
+	)
+
+	switch m := msg.(type) {
+	case *lnwire.DynPropose:
+		t, err = l.updater.RecvPropose(ctx, m)
+
+	case *lnwire.DynAck:
+		t, err = l.updater.RecvAck(ctx, m)
+
+	case *lnwire.DynReject:
+		t, err = l.updater.RecvReject(ctx, m)
+
+	case *lnwire.DynCommit:
+		t, err = l.updater.RecvCommit(ctx, m)
+
+	default:
+		return fmt.Errorf("unexpected dyn message type %T", msg)
+	}
+
+	l.processDynTransition(ctx, t, err)
+
+	return err
+}
+
+// processDynTransition acts on the result of feeding an event to the
+// dyn.Updater. A processing error or a transition that requests disconnect
+// drops the connection, matching how quiescence-protocol violations are
+// handled. When the transition carries a ready-to-commit handoff, the
+// commitment dance is driven.
+//
+// NOTE: MUST be called from the htlcManager event loop.
+func (l *channelLink) processDynTransition(ctx context.Context,
+	t *dyn.Transition, err error) {
+
+	if err != nil {
+		// A processing error on an incoming dyn message is a protocol
+		// violation by the peer during quiescence; drop the connection
+		// as we do for other stfu-protocol violations.
+		l.dynFailf("dyn negotiation error: %v", err)
+
+		return
+	}
+
+	if t == nil {
+		return
+	}
+
+	if t.Disconnect {
+		l.dynFailf("dyn negotiation requires disconnect (%s->%s)",
+			t.From, t.To)
+
+		return
+	}
+
+	t.Handoff.WhenSome(func(h dyn.CommitHandoff) {
+		if herr := l.handleDynCommitHandoff(ctx, h); herr != nil {
+			l.log.Errorf("dyn commit handoff failed for "+
+				"ChannelID(%v): %v", l.ChanID(), herr)
+		}
+	})
+}
+
+// handleDynCommitHandoff drives the commitment dance once negotiation has
+// produced an agreed parameter update. Negotiation itself is owned by the
+// dyn.Updater; from here the link + wallet must execute the bundled
+// dyn_commit_sig commitment dance and apply the params at lock-in.
+//
+// TODO(dyn): the on-chain commitment dance is not executed yet. Completing it
+// requires lnwallet support that does not exist in the branches this one is
+// stacked on (branches 1-5 provide the epoch persistence, the mutable-params
+// apply API, and the wire/negotiation machinery, but not a dyn update-log
+// entry). The precise remaining sub-steps are:
+//
+//  1. Add the agreed update to the channel as a dyn update-log entry (like
+//     update_fee) so that SignNextCommitment / ReceiveNewCommitment build and
+//     validate the next commitment with the proposed params applied and zero
+//     HTLCs. This lnwallet primitive does not exist yet.
+//  2. Proposer (h.Proposer == lntypes.Local): build the bundled DynCommit —
+//     the commitment signature over the responder's next commitment (from the
+//     new lnwallet primitive), the echoed responder dyn_ack signature
+//     (h.AckSig), and the accepted proposal TLVs (h.Proposal) — send it, then
+//     call updater.MarkCommitSent.
+//  3. Responder (h.Proposer == lntypes.Remote): verify h.ReceivedCommit's
+//     commitment signature against our next local commitment (again via the new
+//     primitive). Persist the received dyn_commit_sig + accepted TLVs +
+//     resulting commitment state BEFORE sending revoke_and_ack.
+//  4. Execute commitment_signed / revoke_and_ack in the required order,
+//     treating dyn_commit_sig as commitment_signed-equivalent for
+//     commitment-number accounting and retransmission (retransmission is
+//     branch 8).
+//  5. Apply the params to the local/remote config exactly when each chain
+//     locks in, via l.applyDynParams (already wired and unit-tested below);
+//     lock-in for a chain happens when the corresponding revocation is
+//     processed, so the per-side heights differ.
+//  6. Exit quiescence via l.quiescer.Resume() at the BOLT-defined termination
+//     point (after both chains have locked in).
+//
+// Until (1) lands, executing any of (2)-(6) against the live channel would
+// desync it with the peer, so we deliberately do not mutate channel state here.
+func (l *channelLink) handleDynCommitHandoff(_ context.Context,
+	h dyn.CommitHandoff) error {
+
+	l.log.Infof("Dyn negotiation agreed for ChannelID(%v): proposer=%v, "+
+		"height=%d, params=%s", l.ChanID(), h.Proposer,
+		h.NextCommitHeight, h.Params)
+
+	return nil
+}
+
+// applyDynParams applies an agreed dynamic-commitments parameter update to the
+// underlying channel at the point the given commitment chains lock in. It is
+// the "apply at lock-in" step of the commitment dance: it validates and
+// atomically persists the resulting local/remote config and, for
+// script-rendering params (CSV/dust), records a commit-chain epoch at the given
+// per-side lock-in heights so historical scripts stay reconstructable.
+//
+// lockIn gives, per commitment chain, the last height the outgoing (pre-update)
+// params applied to; it is only consulted for epoch-affecting changes.
+func (l *channelLink) applyDynParams(h dyn.CommitHandoff,
+	lockIn lntypes.Dual[uint64]) error {
+
+	return l.channel.ApplyChannelParams(
+		h.Proposer, h.Params, l.dynMaxCSVDelay(), lockIn,
+	)
+}
+
+// dynFailf fails the link on a dynamic-commitments protocol violation. As with
+// quiescence violations, only link state (not channel state) is affected, so we
+// opt to drop the connection and let a fresh reestablish recover.
+func (l *channelLink) dynFailf(format string, args ...interface{}) {
+	l.failf(LinkFailureError{
+		code:             ErrStfuViolation,
+		FailureAction:    LinkFailureDisconnect,
+		PermanentFailure: false,
+		Warning:          true,
+	}, format, args...)
+}

--- a/htlcswitch/link_dyn_test.go
+++ b/htlcswitch/link_dyn_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/htlcswitch/dyn"
 	"github.com/lightningnetwork/lnd/lntypes"
@@ -53,9 +54,11 @@ func enableLinkDyn(t *testing.T, link *channelLink,
 		},
 	})
 
-	// Bump both dust limits into the dyn-valid range. Only validation reads
-	// these values in these tests (the dance is not executed), so mutating
-	// the in-memory config is sufficient and safe here.
+	// Bump both dust limits into the dyn-valid range so whole-channel
+	// proposal validation passes. The parameters exercised by these tests do
+	// not move any commitment output near the dust threshold, so mutating
+	// this in-memory config is sufficient and does not desync the rendered
+	// commitments across the dance.
 	st := link.channel.State()
 	st.LocalChanCfg.DustLimit = dynTestDust
 	st.RemoteChanCfg.DustLimit = dynTestDust
@@ -81,9 +84,12 @@ func recvLinkMsg(t *testing.T, msgs chan lnwire.Message) lnwire.Message {
 
 // newDynLinkHarness spins up a single-link harness with the dynamic-commitments
 // feature enabled on Alice's link, returning the started harness, the concrete
-// link, and the channel Alice sends messages on.
-func newDynLinkHarness(t *testing.T) (singleLinkTestHarness, *channelLink,
-	chan lnwire.Message) {
+// link, and the channel Alice sends messages on. An optional channel type may
+// be supplied (for example a taproot channel) that both the link's channel and
+// the peer's bobChannel are opened with.
+func newDynLinkHarness(t *testing.T,
+	chanType ...channeldb.ChannelType) (singleLinkTestHarness,
+	*channelLink, chan lnwire.Message) {
 
 	t.Helper()
 
@@ -92,7 +98,9 @@ func newDynLinkHarness(t *testing.T) (singleLinkTestHarness, *channelLink,
 		chanReserve = btcutil.SatoshiPerBitcoin * 1
 	)
 
-	harness, err := newSingleLinkTestHarness(t, chanAmt, chanReserve)
+	harness, err := newSingleLinkTestHarness(
+		t, chanAmt, chanReserve, chanType...,
+	)
 	require.NoError(t, err)
 
 	//nolint:forcetypeassert
@@ -576,4 +584,253 @@ func TestChannelLinkDynDisabled(t *testing.T) {
 
 		return coreLink.failed
 	}, 200*time.Millisecond, 20*time.Millisecond)
+}
+
+// TestChannelLinkDynResponderCommitTaproot drives the responder happy path end
+// to end on a taproot (musig2) channel. It is the taproot variant of
+// TestChannelLinkDynResponderCommit: the bundled dyn_commit_sig carries the
+// proposer's commitment signature as a musig2 partial_signature_with_nonce
+// rather than an ECDSA signature, and the responder's reply commitment_signed
+// does likewise. The dance must still complete, apply the agreed params,
+// advance both commitment heights, and exit quiescence.
+func TestChannelLinkDynResponderCommitTaproot(t *testing.T) {
+	t.Parallel()
+
+	harness, coreLink, msgs := newDynLinkHarness(
+		t, channeldb.SimpleTaprootFeatureBit,
+	)
+	bob := harness.bobChannel
+	require.True(t, coreLink.channel.State().ChanType.IsTaproot(),
+		"expected a taproot channel")
+	quiesceAsResponder(t, coreLink, msgs)
+
+	chanID := coreLink.ChanID()
+
+	// The peer (Bob) is the proposer, so a max_accepted_htlcs change
+	// constrains our (the counterparty's) local config.
+	params := lnwallet.ChannelParams{
+		MaxAcceptedHtlcs: fn.Some(uint16(20)),
+	}
+	require.NotEqual(t, uint16(20),
+		coreLink.channel.State().LocalChanCfg.MaxAcceptedHtlcs)
+
+	aliceHeightBefore := coreLink.channel.State().LocalCommitment.CommitHeight
+	bobHeightBefore := bob.State().LocalCommitment.CommitHeight
+
+	dp := params.ToDynPropose(chanID)
+	coreLink.HandleChannelUpdate(dp)
+
+	// Our link acks the proposal.
+	msg := recvLinkMsg(t, msgs)
+	ack, ok := msg.(*lnwire.DynAck)
+	require.Truef(t, ok, "expected DynAck, got %T", msg)
+
+	// Bob (the proposer) stages the agreed update into his own log and signs
+	// our next commitment. Because this is a taproot channel, the produced
+	// signature is a musig2 partial signature carried in the PartialSig
+	// field; the ECDSA CommitSig is left blank.
+	_, err := bob.AddDynUpdate(params)
+	require.NoError(t, err, "bob unable to stage dyn update")
+	bobCommit, err := bob.SignNextCommitment(t.Context())
+	require.NoError(t, err, "bob unable to sign dyn commitment")
+	require.True(t, bobCommit.PartialSig.IsSome(),
+		"taproot dyn_commit_sig must carry a partial sig")
+
+	dc := &lnwire.DynCommit{
+		DynPropose: *dp,
+		CommitSig:  bobCommit.CommitSig,
+		AckSig:     ack.Sig,
+		PartialSig: bobCommit.PartialSig,
+	}
+	coreLink.HandleChannelUpdate(dc)
+
+	// Our link validates the bundled partial sig, revokes, and replies with
+	// its own revoke_and_ack followed by a commitment_signed for the
+	// proposer's next commitment (also carrying a partial sig).
+	aliceRev, ok := recvLinkMsg(t, msgs).(*lnwire.RevokeAndAck)
+	require.True(t, ok, "expected RevokeAndAck from link")
+	aliceSig, ok := recvLinkMsg(t, msgs).(*lnwire.CommitSig)
+	require.True(t, ok, "expected CommitSig from link")
+	require.True(t, aliceSig.PartialSig.IsSome(),
+		"taproot commitment_signed must carry a partial sig")
+
+	// Bob processes our reply and sends his final revoke_and_ack.
+	_, _, err = bob.ReceiveRevocation(aliceRev)
+	require.NoError(t, err, "bob unable to receive revocation")
+	err = bob.ReceiveNewCommitment(&lnwallet.CommitSigs{
+		CommitSig:  aliceSig.CommitSig,
+		PartialSig: aliceSig.PartialSig,
+	})
+	require.NoError(t, err, "bob unable to receive new commitment")
+	bobRev, _, _, err := bob.RevokeCurrentCommitment()
+	require.NoError(t, err, "bob unable to revoke commitment")
+
+	coreLink.HandleChannelUpdate(bobRev)
+
+	// Wait for both chains to lock in.
+	require.Eventually(t, func() bool {
+		return coreLink.updater.State() == dyn.StateIdle
+	}, 5*time.Second, 10*time.Millisecond, "dance did not complete")
+
+	// The agreed params are applied with proposer-owned semantics: a remote
+	// proposer's max_accepted_htlcs change lands in our local config.
+	require.Equal(t, uint16(20),
+		coreLink.channel.State().LocalChanCfg.MaxAcceptedHtlcs,
+		"agreed params not applied after lock-in")
+
+	// The dyn commit advanced both commitment heights like a normal
+	// commitment_signed.
+	require.Equal(t, aliceHeightBefore+1,
+		coreLink.channel.State().LocalCommitment.CommitHeight,
+		"our commit height did not advance")
+	require.Equal(t, bobHeightBefore+1,
+		bob.State().LocalCommitment.CommitHeight,
+		"bob commit height did not advance")
+
+	// Quiescence was exited so htlc traffic can resume.
+	require.False(t, coreLink.quiescer.IsQuiescent(),
+		"channel should no longer be quiescent")
+}
+
+// TestChannelLinkDynProposerTaproot drives the proposer path end to end on a
+// taproot (musig2) channel. It is the taproot variant of
+// TestChannelLinkDynProposer: the bundled dyn_commit_sig our link emits carries
+// its commitment signature as a musig2 partial_signature_with_nonce (with the
+// ECDSA CommitSig blank), verified against the responder's next commitment
+// using the channel's ambient nonce state. The dance must still apply the
+// agreed params, advance both heights, and exit quiescence.
+func TestChannelLinkDynProposerTaproot(t *testing.T) {
+	t.Parallel()
+
+	harness, coreLink, msgs := newDynLinkHarness(
+		t, channeldb.SimpleTaprootFeatureBit,
+	)
+	bob := harness.bobChannel
+	require.True(t, coreLink.channel.State().ChanType.IsTaproot(),
+		"expected a taproot channel")
+
+	chanID := coreLink.ChanID()
+
+	// We are the proposer, so a max_accepted_htlcs change constrains the
+	// counterparty (remote) config.
+	params := lnwallet.ChannelParams{
+		MaxAcceptedHtlcs: fn.Some(uint16(20)),
+	}
+	require.NotEqual(t, uint16(20),
+		coreLink.channel.State().RemoteChanCfg.MaxAcceptedHtlcs)
+
+	aliceHeightBefore := coreLink.channel.State().LocalCommitment.CommitHeight
+	bobHeightBefore := bob.State().LocalCommitment.CommitHeight
+
+	// Request a local proposal. This drives quiescence first.
+	errCh := coreLink.initDynProposal(dyn.ProposalRequest{Params: params})
+
+	// The link should send its Stfu as the quiescence initiator.
+	msg := recvLinkMsg(t, msgs)
+	stfu, ok := msg.(*lnwire.Stfu)
+	require.Truef(t, ok, "expected Stfu, got %T", msg)
+	require.True(t, stfu.Initiator, "we should be the quiescence initiator")
+
+	// The peer completes quiescence by replying with its own Stfu.
+	coreLink.HandleChannelUpdate(&lnwire.Stfu{
+		ChanID:    chanID,
+		Initiator: false,
+	})
+
+	// Now that the channel is quiescent, the pending proposal is initiated.
+	msg = recvLinkMsg(t, msgs)
+	dp, ok := msg.(*lnwire.DynPropose)
+	require.Truef(t, ok, "expected DynPropose, got %T", msg)
+
+	// Starting the negotiation should have reported success.
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for proposal result")
+	}
+
+	require.Equal(t, dyn.StateAwaitingAck, coreLink.updater.State())
+
+	// Bob (the responder) mirrors the agreed update into his remote log, then
+	// accepts by returning a valid dyn_ack over the exact proposal TLVs.
+	_, err := bob.ReceiveDynUpdate(params)
+	require.NoError(t, err, "bob unable to stage dyn update")
+
+	tlvs, err := dp.SerializeTlvData()
+	require.NoError(t, err)
+
+	bobNodePriv, _ := btcec.PrivKeyFromBytes(bobPrivKey)
+	height := coreLink.channel.State().LocalCommitment.CommitHeight + 1
+	ackSig, err := lnwire.SignDynAck(
+		bobNodePriv, coreLink.channel.State().ChainHash, chanID, height,
+		tlvs,
+	)
+	require.NoError(t, err)
+
+	coreLink.HandleChannelUpdate(&lnwire.DynAck{
+		ChanID: chanID,
+		Sig:    ackSig,
+	})
+
+	// The valid ack triggers the bundled dyn_commit_sig. For a taproot
+	// channel the commitment signature rides the PartialSig field.
+	dc, ok := recvLinkMsg(t, msgs).(*lnwire.DynCommit)
+	require.True(t, ok, "expected DynCommit from link")
+	require.Equal(t, ackSig, dc.AckSig, "dyn_commit_sig echoed wrong ack")
+	require.True(t, dc.PartialSig.IsSome(),
+		"taproot dyn_commit_sig must carry a partial sig")
+
+	// Bob validates the bundled partial sig against his newly rendered
+	// commitment, revokes, and signs our next commitment (a normal
+	// commitment_signed, also carrying a partial sig for taproot).
+	err = bob.ReceiveNewCommitment(&lnwallet.CommitSigs{
+		CommitSig:  dc.CommitSig,
+		PartialSig: dc.PartialSig,
+	})
+	require.NoError(t, err, "bob unable to receive dyn commitment")
+	bobRev, _, _, err := bob.RevokeCurrentCommitment()
+	require.NoError(t, err, "bob unable to revoke commitment")
+	bobCommit, err := bob.SignNextCommitment(t.Context())
+	require.NoError(t, err, "bob unable to sign next commitment")
+	require.True(t, bobCommit.PartialSig.IsSome(),
+		"taproot commitment_signed must carry a partial sig")
+
+	// Our link processes the peer's revoke_and_ack and commitment_signed,
+	// then replies with its final revoke_and_ack.
+	coreLink.HandleChannelUpdate(bobRev)
+	coreLink.HandleChannelUpdate(&lnwire.CommitSig{
+		ChanID:     chanID,
+		CommitSig:  bobCommit.CommitSig,
+		PartialSig: bobCommit.PartialSig,
+	})
+
+	aliceRev, ok := recvLinkMsg(t, msgs).(*lnwire.RevokeAndAck)
+	require.True(t, ok, "expected final RevokeAndAck from link")
+	_, _, err = bob.ReceiveRevocation(aliceRev)
+	require.NoError(t, err, "bob unable to receive final revocation")
+
+	// Wait for both chains to lock in.
+	require.Eventually(t, func() bool {
+		return coreLink.updater.State() == dyn.StateIdle
+	}, 5*time.Second, 10*time.Millisecond, "dance did not complete")
+
+	// The agreed params are applied with proposer-owned semantics: a local
+	// proposer's max_accepted_htlcs change lands in the remote config.
+	require.Equal(t, uint16(20),
+		coreLink.channel.State().RemoteChanCfg.MaxAcceptedHtlcs,
+		"agreed params not applied after lock-in")
+
+	// The dyn commit advanced both commitment heights like a normal
+	// commitment_signed.
+	require.Equal(t, aliceHeightBefore+1,
+		coreLink.channel.State().LocalCommitment.CommitHeight,
+		"our commit height did not advance")
+	require.Equal(t, bobHeightBefore+1,
+		bob.State().LocalCommitment.CommitHeight,
+		"bob commit height did not advance")
+
+	// Quiescence was exited so htlc traffic can resume.
+	require.False(t, coreLink.quiescer.IsQuiescent(),
+		"channel should no longer be quiescent")
 }

--- a/htlcswitch/link_dyn_test.go
+++ b/htlcswitch/link_dyn_test.go
@@ -1,0 +1,453 @@
+package htlcswitch
+
+import (
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/htlcswitch/dyn"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnwallet"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/stretchr/testify/require"
+)
+
+// dynTestDust is a dust limit that satisfies the dynamic-commitments validation
+// bounds. The default test channel opens with dust limits below the dyn minimum
+// (354 sat), so the dyn helpers bump both sides to this value before enabling
+// the feature so proposals validate against the whole resulting channel.
+const dynTestDust = btcutil.Amount(500)
+
+// enableLinkDyn turns on the dynamic-commitments feature for the given link
+// before it is started. It injects a concrete dyn_ack signer built over the
+// provided node keys, rebuilds the quiescer with a non-zero timeout, mounts the
+// dyn.Updater, and bumps both dust limits into the dyn-valid range so that
+// whole-channel proposal validation can pass.
+//
+// It must be called before the link's htlcManager is started.
+func enableLinkDyn(t *testing.T, link *channelLink,
+	nodePriv *btcec.PrivateKey, peerPub *btcec.PublicKey) {
+
+	t.Helper()
+
+	link.cfg.DynAckSigner = newDynAckSigner(nodePriv, peerPub)
+	link.cfg.MaxLocalCSVDelay = defaultMaxLinkCSVDelay
+	link.cfg.QuiescenceTimeout = time.Hour
+
+	// Rebuild the quiescer so it honors the non-zero timeout we just set
+	// (it was built with the zero-value timeout inside NewChannelLink).
+	link.quiescer = NewQuiescer(QuiescerCfg{
+		chanID: lnwire.NewChanIDFromOutPoint(
+			link.channel.ChannelPoint(),
+		),
+		channelInitiator: link.channel.Initiator(),
+		sendMsg: func(s lnwire.Stfu) error {
+			return link.cfg.Peer.SendMessage(false, &s)
+		},
+		timeoutDuration: link.cfg.QuiescenceTimeout,
+		onTimeout: func() {
+			link.cfg.Peer.Disconnect(ErrQuiescenceTimeout)
+		},
+	})
+
+	// Bump both dust limits into the dyn-valid range. Only validation reads
+	// these values in these tests (the dance is not executed), so mutating
+	// the in-memory config is sufficient and safe here.
+	st := link.channel.State()
+	st.LocalChanCfg.DustLimit = dynTestDust
+	st.RemoteChanCfg.DustLimit = dynTestDust
+
+	link.updater = link.newDynUpdater()
+}
+
+// recvLinkMsg reads the next message the link sent to its peer, failing
+// the test on timeout.
+func recvLinkMsg(t *testing.T, msgs chan lnwire.Message) lnwire.Message {
+	t.Helper()
+
+	select {
+	case m := <-msgs:
+		return m
+
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timeout waiting for link message")
+
+		return nil
+	}
+}
+
+// newDynLinkHarness spins up a single-link harness with the dynamic-commitments
+// feature enabled on Alice's link, returning the started harness, the concrete
+// link, and the channel Alice sends messages on.
+func newDynLinkHarness(t *testing.T) (singleLinkTestHarness, *channelLink,
+	chan lnwire.Message) {
+
+	t.Helper()
+
+	const (
+		chanAmt     = btcutil.SatoshiPerBitcoin * 5
+		chanReserve = btcutil.SatoshiPerBitcoin * 1
+	)
+
+	harness, err := newSingleLinkTestHarness(t, chanAmt, chanReserve)
+	require.NoError(t, err)
+
+	//nolint:forcetypeassert
+	coreLink := harness.aliceLink.(*channelLink)
+
+	aliceNodePriv, _ := btcec.PrivKeyFromBytes(alicePrivKey)
+	_, bobNodePub := btcec.PrivKeyFromBytes(bobPrivKey)
+	enableLinkDyn(t, coreLink, aliceNodePriv, bobNodePub)
+
+	require.NoError(t, harness.start())
+	t.Cleanup(func() { harness.aliceLink.Stop() })
+
+	//nolint:forcetypeassert
+	aliceMsgs := coreLink.cfg.Peer.(*mockPeer).sentMsgs
+
+	return harness, coreLink, aliceMsgs
+}
+
+// quiesceAsResponder drives the link into quiescence with the peer as the
+// quiescence initiator, returning once the link has sent its own Stfu reply.
+func quiesceAsResponder(t *testing.T, link *channelLink,
+	msgs chan lnwire.Message) {
+
+	t.Helper()
+
+	link.HandleChannelUpdate(&lnwire.Stfu{
+		ChanID:    link.ChanID(),
+		Initiator: true,
+	})
+
+	msg := recvLinkMsg(t, msgs)
+	stfu, ok := msg.(*lnwire.Stfu)
+	require.Truef(t, ok, "expected Stfu, got %T", msg)
+	require.False(t, stfu.Initiator, "we are not the quiescence initiator")
+
+	require.Eventually(t, link.quiescer.IsQuiescent, 5*time.Second,
+		10*time.Millisecond)
+}
+
+// TestDynAckSignerRoundTrip verifies the concrete dyn.Signer adapter signs with
+// our node key and verifies against the peer's node key, and that a tampered
+// payload fails verification.
+func TestDynAckSignerRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	alicePriv, alicePub := btcec.PrivKeyFromBytes([]byte("alice node key"))
+	bobPriv, bobPub := btcec.PrivKeyFromBytes([]byte("bob node key"))
+
+	// Alice signs with her key and encodes the peer (Bob) as verifier.
+	aliceSigner := newDynAckSigner(alicePriv, bobPub)
+
+	// Bob's adapter verifies signatures Alice made (peerPub == alicePub).
+	bobSigner := newDynAckSigner(bobPriv, alicePub)
+
+	var (
+		chanID    lnwire.ChannelID
+		chainHash chainhash.Hash
+	)
+	tlvs := []byte{0x01, 0x02, 0x03}
+	height := uint64(7)
+
+	sig, err := aliceSigner.SignDynAck(chainHash, chanID, height, tlvs)
+	require.NoError(t, err)
+
+	require.NoError(t, bobSigner.VerifyDynAck(
+		sig, chainHash, chanID, height, tlvs,
+	))
+
+	// A tampered payload must fail verification.
+	require.Error(t, bobSigner.VerifyDynAck(
+		sig, chainHash, chanID, height, []byte{0x09},
+	))
+
+	// The wrong height must fail verification.
+	require.Error(t, bobSigner.VerifyDynAck(
+		sig, chainHash, chanID, height+1, tlvs,
+	))
+}
+
+// TestDynChannelViewPredicates checks the concrete dyn.ChannelView adapter
+// reports the channel state the state machine relies on.
+func TestDynChannelViewPredicates(t *testing.T) {
+	t.Parallel()
+
+	_, coreLink, msgs := newDynLinkHarness(t)
+
+	view := &dynChannelView{link: coreLink}
+
+	require.Equal(t, coreLink.ChanID(), view.ChanID())
+	require.Equal(t, coreLink.channel.State().ChainHash, view.ChainHash())
+	require.Equal(t, coreLink.channel.State().Capacity, view.Capacity())
+	require.Equal(t, dynTestDust, view.LocalChanCfg().DustLimit)
+	require.Equal(t, dynTestDust, view.RemoteChanCfg().DustLimit)
+
+	// A freshly opened, clean channel has no HTLCs and no pending updates,
+	// and both peers are ready (once the link has finished reestablishing).
+	require.Eventually(t, view.BothChannelReady, 5*time.Second,
+		10*time.Millisecond)
+	require.False(t, view.HasHTLCs())
+	require.False(t, view.HasPendingUpdates())
+	require.False(t, view.HasPendingShutdown())
+	require.False(t, view.HasPendingSpliceOrRBF())
+
+	// The next commitment height is one past the current local height.
+	nextHeight := coreLink.channel.State().LocalCommitment.CommitHeight + 1
+	require.Equal(t, nextHeight, view.NextCommitHeight())
+
+	// Not quiescent yet; once we drive quiescence the view reflects it.
+	require.False(t, view.IsQuiescent())
+	quiesceAsResponder(t, coreLink, msgs)
+	require.True(t, view.IsQuiescent())
+
+	initiator, err := view.QuiescenceInitiator().Unpack()
+	require.NoError(t, err)
+	require.Equal(t, lntypes.Remote, initiator)
+}
+
+// TestChannelLinkDynResponderAccept exercises the responder happy path: after
+// quiescence the peer's dyn_propose is routed to the mounted updater, which
+// validates it and replies with a signed dyn_ack.
+func TestChannelLinkDynResponderAccept(t *testing.T) {
+	t.Parallel()
+
+	_, coreLink, msgs := newDynLinkHarness(t)
+	quiesceAsResponder(t, coreLink, msgs)
+
+	chanID := coreLink.ChanID()
+
+	// The peer (proposer) proposes a new max_accepted_htlcs. Proposer-owned
+	// semantics apply the change to our (the counterparty's) config.
+	params := lnwallet.ChannelParams{
+		MaxAcceptedHtlcs: fn.Some(uint16(20)),
+	}
+	dp := params.ToDynPropose(chanID)
+	coreLink.HandleChannelUpdate(dp)
+
+	// We should reply with a dyn_ack carrying a valid signature over the
+	// proposal we accepted.
+	msg := recvLinkMsg(t, msgs)
+	ack, ok := msg.(*lnwire.DynAck)
+	require.Truef(t, ok, "expected DynAck, got %T", msg)
+
+	tlvs, err := dp.SerializeTlvData()
+	require.NoError(t, err)
+
+	_, alicePub := btcec.PrivKeyFromBytes(alicePrivKey)
+	height := coreLink.channel.State().LocalCommitment.CommitHeight + 1
+	require.NoError(t, lnwire.VerifyDynAck(
+		alicePub, ack.Sig, coreLink.channel.State().ChainHash, chanID,
+		height, tlvs,
+	))
+
+	require.Equal(t, dyn.StateAckSent, coreLink.updater.State())
+}
+
+// TestChannelLinkDynResponderReject exercises the responder unhappy path: a
+// dyn_propose that fails validation is rejected with the offending parameter
+// bit set.
+func TestChannelLinkDynResponderReject(t *testing.T) {
+	t.Parallel()
+
+	_, coreLink, msgs := newDynLinkHarness(t)
+	quiesceAsResponder(t, coreLink, msgs)
+
+	chanID := coreLink.ChanID()
+
+	// Propose a to_self_delay well above our configured maximum.
+	params := lnwallet.ChannelParams{
+		CsvDelay: fn.Some(uint16(5000)),
+	}
+	dp := params.ToDynPropose(chanID)
+	coreLink.HandleChannelUpdate(dp)
+
+	msg := recvLinkMsg(t, msgs)
+	reject, ok := msg.(*lnwire.DynReject)
+	require.Truef(t, ok, "expected DynReject, got %T", msg)
+	require.True(t, reject.IsRejected(lnwire.DynRejectCsvDelay))
+
+	require.Eventually(t, func() bool {
+		return coreLink.updater.State() == dyn.StateRejected
+	}, 5*time.Second, 10*time.Millisecond)
+}
+
+// TestChannelLinkDynResponderCommit continues the responder happy path: after
+// acking a proposal, a matching bundled dyn_commit_sig is routed to the
+// updater, which hands off to the link's commitment dance and reaches the
+// committing terminal state.
+func TestChannelLinkDynResponderCommit(t *testing.T) {
+	t.Parallel()
+
+	_, coreLink, msgs := newDynLinkHarness(t)
+	quiesceAsResponder(t, coreLink, msgs)
+
+	chanID := coreLink.ChanID()
+	params := lnwallet.ChannelParams{
+		MaxAcceptedHtlcs: fn.Some(uint16(20)),
+	}
+	dp := params.ToDynPropose(chanID)
+	coreLink.HandleChannelUpdate(dp)
+
+	msg := recvLinkMsg(t, msgs)
+	ack, ok := msg.(*lnwire.DynAck)
+	require.Truef(t, ok, "expected DynAck, got %T", msg)
+
+	// The proposer now sends the bundled dyn_commit_sig echoing the
+	// accepted proposal and our dyn_ack signature. The commitment signature
+	// is verified by the (TODO) commitment dance, so a zero value is fine.
+	dc := &lnwire.DynCommit{
+		DynPropose: *dp,
+		AckSig:     ack.Sig,
+	}
+	coreLink.HandleChannelUpdate(dc)
+
+	require.Eventually(t, func() bool {
+		return coreLink.updater.State() == dyn.StateCommitting
+	}, 5*time.Second, 10*time.Millisecond)
+}
+
+// TestChannelLinkDynProposer exercises the proposer path end to end at the link
+// level: a local proposal request first drives quiescence with us as the
+// initiator, then sends a dyn_propose, and a valid dyn_ack reply drives the
+// updater to the accepted (ready-to-commit) state.
+func TestChannelLinkDynProposer(t *testing.T) {
+	t.Parallel()
+
+	_, coreLink, msgs := newDynLinkHarness(t)
+
+	chanID := coreLink.ChanID()
+
+	// Request a local proposal. This drives quiescence first.
+	errCh := coreLink.initDynProposal(dyn.ProposalRequest{
+		Params: lnwallet.ChannelParams{
+			MaxAcceptedHtlcs: fn.Some(uint16(20)),
+		},
+	})
+
+	// The link should send its Stfu as the quiescence initiator.
+	msg := recvLinkMsg(t, msgs)
+	stfu, ok := msg.(*lnwire.Stfu)
+	require.Truef(t, ok, "expected Stfu, got %T", msg)
+	require.True(t, stfu.Initiator, "we should be the quiescence initiator")
+
+	// The peer completes quiescence by replying with its own Stfu.
+	coreLink.HandleChannelUpdate(&lnwire.Stfu{
+		ChanID:    chanID,
+		Initiator: false,
+	})
+
+	// Now that the channel is quiescent, the pending proposal is initiated.
+	msg = recvLinkMsg(t, msgs)
+	dp, ok := msg.(*lnwire.DynPropose)
+	require.Truef(t, ok, "expected DynPropose, got %T", msg)
+
+	// Starting the negotiation should have reported success.
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for proposal result")
+	}
+
+	require.Equal(t, dyn.StateAwaitingAck, coreLink.updater.State())
+
+	// The peer accepts by returning a valid dyn_ack over the exact proposal
+	// TLVs, bound to the next commitment height and chain.
+	tlvs, err := dp.SerializeTlvData()
+	require.NoError(t, err)
+
+	bobNodePriv, _ := btcec.PrivKeyFromBytes(bobPrivKey)
+	height := coreLink.channel.State().LocalCommitment.CommitHeight + 1
+	sig, err := lnwire.SignDynAck(
+		bobNodePriv, coreLink.channel.State().ChainHash, chanID, height,
+		tlvs,
+	)
+	require.NoError(t, err)
+
+	coreLink.HandleChannelUpdate(&lnwire.DynAck{
+		ChanID: chanID,
+		Sig:    sig,
+	})
+
+	// The valid ack drives the updater to the accepted state and emits the
+	// ready-to-commit handoff (the dance itself is a TODO).
+	require.Eventually(t, func() bool {
+		return coreLink.updater.State() == dyn.StateAccepted
+	}, 5*time.Second, 10*time.Millisecond)
+}
+
+// TestChannelLinkApplyDynParams verifies the apply-at-lock-in step: applying an
+// agreed proposal mutates the underlying channel config with proposer-owned
+// semantics.
+func TestChannelLinkApplyDynParams(t *testing.T) {
+	t.Parallel()
+
+	_, coreLink, _ := newDynLinkHarness(t)
+
+	// Sanity check the starting value differs from what we will apply.
+	require.NotEqual(t, uint16(25),
+		coreLink.channel.State().RemoteChanCfg.MaxAcceptedHtlcs)
+
+	handoff := dyn.CommitHandoff{
+		Proposer: lntypes.Local,
+		Params: lnwallet.ChannelParams{
+			MaxAcceptedHtlcs: fn.Some(uint16(25)),
+		},
+	}
+	lockIn := lntypes.Dual[uint64]{Local: 0, Remote: 0}
+
+	require.NoError(t, coreLink.applyDynParams(handoff, lockIn))
+
+	// Proposer-owned semantics: a Local proposer's max_accepted_htlcs
+	// change constrains the counterparty (remote) config.
+	require.Equal(t, uint16(25),
+		coreLink.channel.State().RemoteChanCfg.MaxAcceptedHtlcs)
+}
+
+// TestChannelLinkDynDisabled ensures a link without the feature enabled ignores
+// incoming dyn messages and refuses local proposals, leaving non-dyn behavior
+// untouched.
+func TestChannelLinkDynDisabled(t *testing.T) {
+	t.Parallel()
+
+	const (
+		chanAmt     = btcutil.SatoshiPerBitcoin * 5
+		chanReserve = btcutil.SatoshiPerBitcoin * 1
+	)
+
+	harness, err := newSingleLinkTestHarness(t, chanAmt, chanReserve)
+	require.NoError(t, err)
+	require.NoError(t, harness.start())
+	t.Cleanup(func() { harness.aliceLink.Stop() })
+
+	//nolint:forcetypeassert
+	coreLink := harness.aliceLink.(*channelLink)
+
+	// No updater is mounted when the feature is disabled.
+	require.Nil(t, coreLink.updater)
+
+	// A local proposal request is rejected.
+	select {
+	case err := <-coreLink.initDynProposal(dyn.ProposalRequest{}):
+		require.ErrorIs(t, err, errDynDisabled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for proposal result")
+	}
+
+	// An incoming dyn message is ignored (no disconnect / link failure).
+	coreLink.HandleChannelUpdate(&lnwire.DynPropose{
+		ChanID: coreLink.ChanID(),
+	})
+
+	require.Never(t, func() bool {
+		coreLink.RLock()
+		defer coreLink.RUnlock()
+
+		return coreLink.failed
+	}, 200*time.Millisecond, 20*time.Millisecond)
+}

--- a/htlcswitch/link_dyn_test.go
+++ b/htlcswitch/link_dyn_test.go
@@ -276,58 +276,128 @@ func TestChannelLinkDynResponderReject(t *testing.T) {
 	}, 5*time.Second, 10*time.Millisecond)
 }
 
-// TestChannelLinkDynResponderCommit continues the responder happy path: after
-// acking a proposal, a matching bundled dyn_commit_sig is routed to the
-// updater, which hands off to the link's commitment dance and reaches the
-// committing terminal state.
+// TestChannelLinkDynResponderCommit drives the responder happy path end to end:
+// the peer proposes, our link acks, the peer sends the bundled dyn_commit_sig,
+// and our link runs the full commitment dance (revoke_and_ack + a normal
+// commitment_signed) with the peer replying with its final revoke_and_ack. Once
+// both chains lock in, the agreed params are applied to our config, both commit
+// heights advance, and quiescence is exited.
 func TestChannelLinkDynResponderCommit(t *testing.T) {
 	t.Parallel()
 
-	_, coreLink, msgs := newDynLinkHarness(t)
+	harness, coreLink, msgs := newDynLinkHarness(t)
+	bob := harness.bobChannel
 	quiesceAsResponder(t, coreLink, msgs)
 
 	chanID := coreLink.ChanID()
+
+	// The peer (Bob) is the proposer, so a max_accepted_htlcs change
+	// constrains our (the counterparty's) local config.
 	params := lnwallet.ChannelParams{
 		MaxAcceptedHtlcs: fn.Some(uint16(20)),
 	}
+	require.NotEqual(t, uint16(20),
+		coreLink.channel.State().LocalChanCfg.MaxAcceptedHtlcs)
+
+	aliceHeightBefore := coreLink.channel.State().LocalCommitment.CommitHeight
+	bobHeightBefore := bob.State().LocalCommitment.CommitHeight
+
 	dp := params.ToDynPropose(chanID)
 	coreLink.HandleChannelUpdate(dp)
 
+	// Our link acks the proposal.
 	msg := recvLinkMsg(t, msgs)
 	ack, ok := msg.(*lnwire.DynAck)
 	require.Truef(t, ok, "expected DynAck, got %T", msg)
 
-	// The proposer now sends the bundled dyn_commit_sig echoing the
-	// accepted proposal and our dyn_ack signature. The commitment signature
-	// is verified by the (TODO) commitment dance, so a zero value is fine.
+	// Bob (the proposer) stages the agreed update into his own log and signs
+	// our next commitment, producing the bundled dyn_commit_sig.
+	_, err := bob.AddDynUpdate(params)
+	require.NoError(t, err, "bob unable to stage dyn update")
+	bobCommit, err := bob.SignNextCommitment(t.Context())
+	require.NoError(t, err, "bob unable to sign dyn commitment")
+
 	dc := &lnwire.DynCommit{
 		DynPropose: *dp,
+		CommitSig:  bobCommit.CommitSig,
 		AckSig:     ack.Sig,
 	}
 	coreLink.HandleChannelUpdate(dc)
 
+	// Our link validates the bundled sig, revokes, and replies with its own
+	// revoke_and_ack followed by a normal commitment_signed for the
+	// proposer's next commitment.
+	aliceRev, ok := recvLinkMsg(t, msgs).(*lnwire.RevokeAndAck)
+	require.True(t, ok, "expected RevokeAndAck from link")
+	aliceSig, ok := recvLinkMsg(t, msgs).(*lnwire.CommitSig)
+	require.True(t, ok, "expected CommitSig from link")
+
+	// Bob processes our reply and sends his final revoke_and_ack.
+	_, _, err = bob.ReceiveRevocation(aliceRev)
+	require.NoError(t, err, "bob unable to receive revocation")
+	err = bob.ReceiveNewCommitment(&lnwallet.CommitSigs{
+		CommitSig: aliceSig.CommitSig,
+	})
+	require.NoError(t, err, "bob unable to receive new commitment")
+	bobRev, _, _, err := bob.RevokeCurrentCommitment()
+	require.NoError(t, err, "bob unable to revoke commitment")
+
+	coreLink.HandleChannelUpdate(bobRev)
+
+	// Wait for both chains to lock in. The negotiation state returning to
+	// idle is set (under the updater lock) only after applyDynParams has run,
+	// so it is a safe synchronization point for the config reads below.
 	require.Eventually(t, func() bool {
-		return coreLink.updater.State() == dyn.StateCommitting
-	}, 5*time.Second, 10*time.Millisecond)
+		return coreLink.updater.State() == dyn.StateIdle
+	}, 5*time.Second, 10*time.Millisecond, "dance did not complete")
+
+	// The agreed params are applied with proposer-owned semantics: a remote
+	// proposer's max_accepted_htlcs change lands in our local config.
+	require.Equal(t, uint16(20),
+		coreLink.channel.State().LocalChanCfg.MaxAcceptedHtlcs,
+		"agreed params not applied after lock-in")
+
+	// The dyn commit advanced both commitment heights like a normal
+	// commitment_signed.
+	require.Equal(t, aliceHeightBefore+1,
+		coreLink.channel.State().LocalCommitment.CommitHeight,
+		"our commit height did not advance")
+	require.Equal(t, bobHeightBefore+1,
+		bob.State().LocalCommitment.CommitHeight,
+		"bob commit height did not advance")
+
+	// Quiescence was exited so htlc traffic can resume.
+	require.False(t, coreLink.quiescer.IsQuiescent(),
+		"channel should no longer be quiescent")
 }
 
-// TestChannelLinkDynProposer exercises the proposer path end to end at the link
-// level: a local proposal request first drives quiescence with us as the
-// initiator, then sends a dyn_propose, and a valid dyn_ack reply drives the
-// updater to the accepted (ready-to-commit) state.
+// TestChannelLinkDynProposer drives the proposer path end to end at the link
+// level: a local proposal request drives quiescence with us as the initiator,
+// sends a dyn_propose, and a valid dyn_ack triggers the bundled dyn_commit_sig.
+// The peer completes the dance with its revoke_and_ack + commitment_signed, our
+// link replies with its final revoke_and_ack, and once both chains lock in the
+// agreed params are applied, both heights advance, and quiescence is exited.
 func TestChannelLinkDynProposer(t *testing.T) {
 	t.Parallel()
 
-	_, coreLink, msgs := newDynLinkHarness(t)
+	harness, coreLink, msgs := newDynLinkHarness(t)
+	bob := harness.bobChannel
 
 	chanID := coreLink.ChanID()
 
+	// We are the proposer, so a max_accepted_htlcs change constrains the
+	// counterparty (remote) config.
+	params := lnwallet.ChannelParams{
+		MaxAcceptedHtlcs: fn.Some(uint16(20)),
+	}
+	require.NotEqual(t, uint16(20),
+		coreLink.channel.State().RemoteChanCfg.MaxAcceptedHtlcs)
+
+	aliceHeightBefore := coreLink.channel.State().LocalCommitment.CommitHeight
+	bobHeightBefore := bob.State().LocalCommitment.CommitHeight
+
 	// Request a local proposal. This drives quiescence first.
-	errCh := coreLink.initDynProposal(dyn.ProposalRequest{
-		Params: lnwallet.ChannelParams{
-			MaxAcceptedHtlcs: fn.Some(uint16(20)),
-		},
-	})
+	errCh := coreLink.initDynProposal(dyn.ProposalRequest{Params: params})
 
 	// The link should send its Stfu as the quiescence initiator.
 	msg := recvLinkMsg(t, msgs)
@@ -356,14 +426,19 @@ func TestChannelLinkDynProposer(t *testing.T) {
 
 	require.Equal(t, dyn.StateAwaitingAck, coreLink.updater.State())
 
-	// The peer accepts by returning a valid dyn_ack over the exact proposal
-	// TLVs, bound to the next commitment height and chain.
+	// Bob (the responder) stages the agreed update into his remote log so
+	// that his rendering of both commitments matches ours, then accepts by
+	// returning a valid dyn_ack over the exact proposal TLVs, bound to the
+	// next commitment height and chain.
+	_, err := bob.ReceiveDynUpdate(params)
+	require.NoError(t, err, "bob unable to stage dyn update")
+
 	tlvs, err := dp.SerializeTlvData()
 	require.NoError(t, err)
 
 	bobNodePriv, _ := btcec.PrivKeyFromBytes(bobPrivKey)
 	height := coreLink.channel.State().LocalCommitment.CommitHeight + 1
-	sig, err := lnwire.SignDynAck(
+	ackSig, err := lnwire.SignDynAck(
 		bobNodePriv, coreLink.channel.State().ChainHash, chanID, height,
 		tlvs,
 	)
@@ -371,14 +446,65 @@ func TestChannelLinkDynProposer(t *testing.T) {
 
 	coreLink.HandleChannelUpdate(&lnwire.DynAck{
 		ChanID: chanID,
-		Sig:    sig,
+		Sig:    ackSig,
 	})
 
-	// The valid ack drives the updater to the accepted state and emits the
-	// ready-to-commit handoff (the dance itself is a TODO).
+	// The valid ack triggers the bundled dyn_commit_sig: our commitment
+	// signature over the responder's next commitment, the echoed dyn_ack
+	// signature, and the accepted proposal.
+	dc, ok := recvLinkMsg(t, msgs).(*lnwire.DynCommit)
+	require.True(t, ok, "expected DynCommit from link")
+	require.Equal(t, ackSig, dc.AckSig, "dyn_commit_sig echoed wrong ack")
+
+	// Bob validates the bundled sig against his newly rendered commitment,
+	// revokes, and signs our next commitment (a normal commitment_signed).
+	err = bob.ReceiveNewCommitment(&lnwallet.CommitSigs{
+		CommitSig: dc.CommitSig,
+	})
+	require.NoError(t, err, "bob unable to receive dyn commitment")
+	bobRev, _, _, err := bob.RevokeCurrentCommitment()
+	require.NoError(t, err, "bob unable to revoke commitment")
+	bobCommit, err := bob.SignNextCommitment(t.Context())
+	require.NoError(t, err, "bob unable to sign next commitment")
+
+	// Our link processes the peer's revoke_and_ack and commitment_signed,
+	// then replies with its final revoke_and_ack.
+	coreLink.HandleChannelUpdate(bobRev)
+	coreLink.HandleChannelUpdate(&lnwire.CommitSig{
+		ChanID:    chanID,
+		CommitSig: bobCommit.CommitSig,
+	})
+
+	aliceRev, ok := recvLinkMsg(t, msgs).(*lnwire.RevokeAndAck)
+	require.True(t, ok, "expected final RevokeAndAck from link")
+	_, _, err = bob.ReceiveRevocation(aliceRev)
+	require.NoError(t, err, "bob unable to receive final revocation")
+
+	// Wait for both chains to lock in. The negotiation state returning to
+	// idle is set (under the updater lock) only after applyDynParams has run,
+	// so it is a safe synchronization point for the config reads below.
 	require.Eventually(t, func() bool {
-		return coreLink.updater.State() == dyn.StateAccepted
-	}, 5*time.Second, 10*time.Millisecond)
+		return coreLink.updater.State() == dyn.StateIdle
+	}, 5*time.Second, 10*time.Millisecond, "dance did not complete")
+
+	// The agreed params are applied with proposer-owned semantics: a local
+	// proposer's max_accepted_htlcs change lands in the remote config.
+	require.Equal(t, uint16(20),
+		coreLink.channel.State().RemoteChanCfg.MaxAcceptedHtlcs,
+		"agreed params not applied after lock-in")
+
+	// The dyn commit advanced both commitment heights like a normal
+	// commitment_signed.
+	require.Equal(t, aliceHeightBefore+1,
+		coreLink.channel.State().LocalCommitment.CommitHeight,
+		"our commit height did not advance")
+	require.Equal(t, bobHeightBefore+1,
+		bob.State().LocalCommitment.CommitHeight,
+		"bob commit height did not advance")
+
+	// Quiescence was exited so htlc traffic can resume.
+	require.False(t, coreLink.quiescer.IsQuiescent(),
+		"channel should no longer be quiescent")
 }
 
 // TestChannelLinkApplyDynParams verifies the apply-at-lock-in step: applying an

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -2137,7 +2137,8 @@ type singleLinkTestHarness struct {
 }
 
 func newSingleLinkTestHarness(t *testing.T, chanAmt,
-	chanReserve btcutil.Amount) (singleLinkTestHarness, error) {
+	chanReserve btcutil.Amount,
+	chanType ...channeldb.ChannelType) (singleLinkTestHarness, error) {
 
 	var chanIDBytes [8]byte
 	if _, err := io.ReadFull(rand.Reader, chanIDBytes[:]); err != nil {
@@ -2149,7 +2150,7 @@ func newSingleLinkTestHarness(t *testing.T, chanAmt,
 
 	aliceLc, bobLc, err := createTestChannel(
 		t, alicePrivKey, bobPrivKey, chanAmt, chanAmt,
-		chanReserve, chanReserve, chanID,
+		chanReserve, chanReserve, chanID, chanType...,
 	)
 	if err != nil {
 		return singleLinkTestHarness{}, err

--- a/htlcswitch/test_utils.go
+++ b/htlcswitch/test_utils.go
@@ -133,8 +133,16 @@ type testLightningChannel struct {
 // TODO(roasbeef): need to factor out, similar func re-used in many parts of codebase
 func createTestChannel(t *testing.T, alicePrivKey, bobPrivKey []byte,
 	aliceAmount, bobAmount, aliceReserve, bobReserve btcutil.Amount,
-	chanID lnwire.ShortChannelID) (*testLightningChannel,
+	chanID lnwire.ShortChannelID,
+	chanTypeOpt ...channeldb.ChannelType) (*testLightningChannel,
 	*testLightningChannel, error) {
+
+	// Default to a tweakless single-funder channel unless the caller asked
+	// for a specific type (e.g. a taproot channel).
+	chanType := channeldb.SingleFunderTweaklessBit
+	if len(chanTypeOpt) > 0 {
+		chanType = chanTypeOpt[0]
+	}
 
 	aliceKeyPriv, aliceKeyPub := btcec.PrivKeyFromBytes(alicePrivKey)
 	bobKeyPriv, bobKeyPub := btcec.PrivKeyFromBytes(bobPrivKey)
@@ -244,7 +252,7 @@ func createTestChannel(t *testing.T, alicePrivKey, bobPrivKey []byte,
 
 	aliceCommitTx, bobCommitTx, err := lnwallet.CreateCommitmentTxns(
 		aliceAmount, bobAmount, &aliceCfg, &bobCfg, aliceCommitPoint,
-		bobCommitPoint, *fundingTxIn, channeldb.SingleFunderTweaklessBit,
+		bobCommitPoint, *fundingTxIn, chanType,
 		isAliceInitiator, 0,
 	)
 	if err != nil {
@@ -296,7 +304,7 @@ func createTestChannel(t *testing.T, alicePrivKey, bobPrivKey []byte,
 		RemoteChanCfg:           bobCfg,
 		IdentityPub:             aliceKeyPub,
 		FundingOutpoint:         *prevOut,
-		ChanType:                channeldb.SingleFunderTweaklessBit,
+		ChanType:                chanType,
 		IsInitiator:             isAliceInitiator,
 		Capacity:                channelCapacity,
 		RemoteCurrentRevocation: bobCommitPoint,
@@ -315,7 +323,7 @@ func createTestChannel(t *testing.T, alicePrivKey, bobPrivKey []byte,
 		RemoteChanCfg:           aliceCfg,
 		IdentityPub:             bobKeyPub,
 		FundingOutpoint:         *prevOut,
-		ChanType:                channeldb.SingleFunderTweaklessBit,
+		ChanType:                chanType,
 		IsInitiator:             !isAliceInitiator,
 		Capacity:                channelCapacity,
 		RemoteCurrentRevocation: aliceCommitPoint,
@@ -365,6 +373,31 @@ func createTestChannel(t *testing.T, alicePrivKey, bobPrivKey []byte,
 		return nil, nil, err
 	}
 	bobPool.Start()
+
+	// For taproot (musig2) channels we must also simulate the initial nonce
+	// exchange that normally rides channel_ready / channel_reestablish, so
+	// that both channels can sign and verify commitment states. This mirrors
+	// lnwallet.initMusigNonce, using only the exported channel methods.
+	if chanType.IsTaproot() {
+		aliceNonces, err := channelAlice.GenMusigNonces()
+		if err != nil {
+			return nil, nil, err
+		}
+		bobNonces, err := channelBob.GenMusigNonces()
+		if err != nil {
+			return nil, nil, err
+		}
+		if err := channelAlice.InitRemoteMusigNonces(
+			bobNonces,
+		); err != nil {
+			return nil, nil, err
+		}
+		if err := channelBob.InitRemoteMusigNonces(
+			aliceNonces,
+		); err != nil {
+			return nil, nil, err
+		}
+	}
 
 	// Now that the channel are open, simulate the start of a session by
 	// having Alice and Bob extend their revocation windows to each other.


### PR DESCRIPTION
Part of the Dynamic Commitments milestone: #60

Mounts the updater on the link and executes the bundled `dyn_commit_sig` dance, incl. taproot/MuSig2 signing.

**Stacked PR** — based on `yy-dyn-6-updatelog`; review after that branch (the base updates automatically as the parent merges).

Opened as a **draft**: this is part of the exploratory params-only stack (coarse commits, not final hygiene).