### PR TITLE
htlcswitch: dyn reestablish and retransmission

### DIFF
--- a/channeldb/dyn_persister.go
+++ b/channeldb/dyn_persister.go
@@ -45,18 +45,30 @@ type DynAcceptedProposal struct {
 	// exchanged for this negotiation yet.
 	AckSig fn.Option[lnwire.Sig]
 
-	// CommitSig is the proposer's dyn_commit_sig commitment signature. Its
-	// presence is the persisted flag that a dyn_commit_sig has been sent (by
-	// the proposer) or received (by the responder) before disconnect, which
-	// is what promotes a negotiation from "forget on reconnect" to "retain
-	// and retransmit". When absent, no dyn_commit_sig has been persisted.
+	// CommitSig is the proposer's dyn_commit_sig commitment signature for a
+	// non-taproot (ECDSA) channel. Its presence, or the presence of
+	// PartialSig, is the persisted flag that a dyn_commit_sig has been sent
+	// (by the proposer) or received (by the responder) before disconnect,
+	// which is what promotes a negotiation from "forget on reconnect" to
+	// "retain and retransmit". When absent, no ECDSA dyn_commit_sig has been
+	// persisted.
 	CommitSig fn.Option[lnwire.Sig]
+
+	// PartialSig is the proposer's dyn_commit_sig commitment signature for a
+	// taproot (musig2) channel, carried as a partial_signature_with_nonce.
+	// It is the taproot counterpart of CommitSig: for a taproot channel the
+	// dyn_commit_sig rides this field and CommitSig is absent, while for a
+	// non-taproot channel this field is absent and CommitSig carries the
+	// ECDSA signature. Its presence is likewise a persisted flag that a
+	// dyn_commit_sig has crossed the wire.
+	PartialSig fn.Option[lnwire.PartialSigWithNonce]
 }
 
 // serialize writes the DynAcceptedProposal to the given writer following the
 // channeldb fixed-layout conventions: the proposer role and lock-in height, the
-// optional dyn_ack and dyn_commit_sig signatures each with a presence flag, and
-// finally the accepted proposal encoded as a length-prefixed lnwire message.
+// optional dyn_ack signature, the optional ECDSA and taproot-partial
+// dyn_commit_sig signatures each with a presence flag, and finally the accepted
+// proposal encoded as a length-prefixed lnwire message.
 func (p *DynAcceptedProposal) serialize(w io.Writer) error {
 	if p.Proposal == nil {
 		return fmt.Errorf("dyn accepted proposal has a nil proposal")
@@ -72,6 +84,10 @@ func (p *DynAcceptedProposal) serialize(w io.Writer) error {
 	}
 
 	if err := writeOptionalSig(w, p.CommitSig); err != nil {
+		return err
+	}
+
+	if err := writeOptionalPartialSig(w, p.PartialSig); err != nil {
 		return err
 	}
 
@@ -117,6 +133,11 @@ func deserializeDynAcceptedProposal(r io.Reader) (*DynAcceptedProposal, error) {
 		return nil, err
 	}
 
+	partialSig, err := readOptionalPartialSig(r)
+	if err != nil {
+		return nil, err
+	}
+
 	var propLen uint16
 	if err := ReadElement(r, &propLen); err != nil {
 		return nil, err
@@ -138,6 +159,7 @@ func deserializeDynAcceptedProposal(r io.Reader) (*DynAcceptedProposal, error) {
 		NextCommitHeight: nextHeight,
 		AckSig:           ackSig,
 		CommitSig:        commitSig,
+		PartialSig:       partialSig,
 	}, nil
 }
 
@@ -179,6 +201,47 @@ func readOptionalSig(r io.Reader) (fn.Option[lnwire.Sig], error) {
 	sig, err := lnwire.NewSigFromWireECDSA(raw[:])
 	if err != nil {
 		return fn.None[lnwire.Sig](), err
+	}
+
+	return fn.Some(sig), nil
+}
+
+// writeOptionalPartialSig writes an optional musig2 partial signature with
+// nonce: a presence flag followed, when present, by the 98-byte serialized
+// partial_signature_with_nonce (32-byte scalar || 66-byte nonce).
+func writeOptionalPartialSig(w io.Writer,
+	sig fn.Option[lnwire.PartialSigWithNonce]) error {
+
+	if sig.IsNone() {
+		return WriteElement(w, false)
+	}
+
+	if err := WriteElement(w, true); err != nil {
+		return err
+	}
+
+	s := sig.UnsafeFromSome()
+
+	return s.Encode(w)
+}
+
+// readOptionalPartialSig reads an optional musig2 partial signature with nonce
+// written by writeOptionalPartialSig.
+func readOptionalPartialSig(r io.Reader) (
+	fn.Option[lnwire.PartialSigWithNonce], error) {
+
+	var present bool
+	if err := ReadElement(r, &present); err != nil {
+		return fn.None[lnwire.PartialSigWithNonce](), err
+	}
+
+	if !present {
+		return fn.None[lnwire.PartialSigWithNonce](), nil
+	}
+
+	var sig lnwire.PartialSigWithNonce
+	if err := sig.Decode(r); err != nil {
+		return fn.None[lnwire.PartialSigWithNonce](), err
 	}
 
 	return fn.Some(sig), nil

--- a/channeldb/dyn_persister.go
+++ b/channeldb/dyn_persister.go
@@ -1,0 +1,253 @@
+package channeldb
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math"
+
+	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/kvdb"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+// dynAcceptedProposalBucket is the top-level bucket that stores the accepted
+// dynamic-commitments proposal context for channels with an in-flight
+// negotiation. It is keyed by the 32-byte lnwire.ChannelID of the channel and
+// holds a single serialized DynAcceptedProposal per channel. The context only
+// lives here between the persistence boundaries the extension BOLT calls out
+// (from dyn_propose/dyn_ack up to a locked-in dyn_commit_sig), so at most one
+// entry per channel exists and it is deleted once the negotiation is forgotten
+// or fully committed.
+var dynAcceptedProposalBucket = []byte("dyn-accepted-proposal")
+
+// DynAcceptedProposal is the durable form of an accepted dynamic-commitments
+// proposal. It mirrors the htlcswitch/dyn.AcceptedProposal context so that a
+// reconnect after a crash can decide whether to resume or forget a negotiation.
+// It is a channeldb-native type (channeldb must not depend on htlcswitch/dyn);
+// the htlcswitch layer converts between the two.
+type DynAcceptedProposal struct {
+	// Proposer is the party that sent the dyn_propose. If it equals
+	// lntypes.Local we are the proposer, otherwise we are the responder.
+	Proposer lntypes.ChannelParty
+
+	// Proposal is the accepted proposal message.
+	Proposal *lnwire.DynPropose
+
+	// NextCommitHeight is the commitment number the update binds to; it is
+	// bound into the dyn_ack signature digest.
+	NextCommitHeight uint64
+
+	// AckSig is the responder's dyn_ack signature. It is set on the
+	// responder once it signs its dyn_ack, and on the proposer once it
+	// verifies the received dyn_ack. When absent, no dyn_ack has been
+	// exchanged for this negotiation yet.
+	AckSig fn.Option[lnwire.Sig]
+
+	// CommitSig is the proposer's dyn_commit_sig commitment signature. Its
+	// presence is the persisted flag that a dyn_commit_sig has been sent (by
+	// the proposer) or received (by the responder) before disconnect, which
+	// is what promotes a negotiation from "forget on reconnect" to "retain
+	// and retransmit". When absent, no dyn_commit_sig has been persisted.
+	CommitSig fn.Option[lnwire.Sig]
+}
+
+// serialize writes the DynAcceptedProposal to the given writer following the
+// channeldb fixed-layout conventions: the proposer role and lock-in height, the
+// optional dyn_ack and dyn_commit_sig signatures each with a presence flag, and
+// finally the accepted proposal encoded as a length-prefixed lnwire message.
+func (p *DynAcceptedProposal) serialize(w io.Writer) error {
+	if p.Proposal == nil {
+		return fmt.Errorf("dyn accepted proposal has a nil proposal")
+	}
+
+	err := WriteElements(w, uint8(p.Proposer), p.NextCommitHeight)
+	if err != nil {
+		return err
+	}
+
+	if err := writeOptionalSig(w, p.AckSig); err != nil {
+		return err
+	}
+
+	if err := writeOptionalSig(w, p.CommitSig); err != nil {
+		return err
+	}
+
+	// The accepted proposal message is variable length, so it is stored
+	// with a uint16 byte-length prefix. An lnwire message never exceeds the
+	// uint16 range, but we guard the conversion defensively.
+	var buf bytes.Buffer
+	if err := p.Proposal.Encode(&buf, 0); err != nil {
+		return fmt.Errorf("encode dyn proposal: %w", err)
+	}
+	if buf.Len() > math.MaxUint16 {
+		return fmt.Errorf("dyn proposal too large to persist: %d bytes",
+			buf.Len())
+	}
+
+	if err := WriteElement(w, uint16(buf.Len())); err != nil {
+		return err
+	}
+
+	_, err = w.Write(buf.Bytes())
+
+	return err
+}
+
+// deserializeDynAcceptedProposal reads a DynAcceptedProposal from the given
+// reader, inverting serialize.
+func deserializeDynAcceptedProposal(r io.Reader) (*DynAcceptedProposal, error) {
+	var (
+		proposer   uint8
+		nextHeight uint64
+	)
+	if err := ReadElements(r, &proposer, &nextHeight); err != nil {
+		return nil, err
+	}
+
+	ackSig, err := readOptionalSig(r)
+	if err != nil {
+		return nil, err
+	}
+
+	commitSig, err := readOptionalSig(r)
+	if err != nil {
+		return nil, err
+	}
+
+	var propLen uint16
+	if err := ReadElement(r, &propLen); err != nil {
+		return nil, err
+	}
+
+	propBytes := make([]byte, propLen)
+	if _, err := io.ReadFull(r, propBytes); err != nil {
+		return nil, err
+	}
+
+	var proposal lnwire.DynPropose
+	if err := proposal.Decode(bytes.NewReader(propBytes), 0); err != nil {
+		return nil, fmt.Errorf("decode dyn proposal: %w", err)
+	}
+
+	return &DynAcceptedProposal{
+		Proposer:         lntypes.ChannelParty(proposer),
+		Proposal:         &proposal,
+		NextCommitHeight: nextHeight,
+		AckSig:           ackSig,
+		CommitSig:        commitSig,
+	}, nil
+}
+
+// writeOptionalSig writes an optional 64-byte signature: a presence flag
+// followed, when present, by the raw signature bytes. dyn signatures are always
+// 64-byte ECDSA.
+func writeOptionalSig(w io.Writer, sig fn.Option[lnwire.Sig]) error {
+	if sig.IsNone() {
+		return WriteElement(w, false)
+	}
+
+	if err := WriteElement(w, true); err != nil {
+		return err
+	}
+
+	s := sig.UnsafeFromSome()
+	_, err := w.Write(s.RawBytes())
+
+	return err
+}
+
+// readOptionalSig reads an optional 64-byte signature written by
+// writeOptionalSig.
+func readOptionalSig(r io.Reader) (fn.Option[lnwire.Sig], error) {
+	var present bool
+	if err := ReadElement(r, &present); err != nil {
+		return fn.None[lnwire.Sig](), err
+	}
+
+	if !present {
+		return fn.None[lnwire.Sig](), nil
+	}
+
+	var raw [64]byte
+	if _, err := io.ReadFull(r, raw[:]); err != nil {
+		return fn.None[lnwire.Sig](), err
+	}
+
+	sig, err := lnwire.NewSigFromWireECDSA(raw[:])
+	if err != nil {
+		return fn.None[lnwire.Sig](), err
+	}
+
+	return fn.Some(sig), nil
+}
+
+// StoreDynAcceptedProposal persists (or overwrites) the accepted
+// dynamic-commitments proposal context for the given channel.
+func (c *ChannelStateDB) StoreDynAcceptedProposal(chanID lnwire.ChannelID,
+	p DynAcceptedProposal) error {
+
+	var b bytes.Buffer
+	if err := p.serialize(&b); err != nil {
+		return err
+	}
+
+	return kvdb.Update(c.backend, func(tx kvdb.RwTx) error {
+		bucket, err := tx.CreateTopLevelBucket(dynAcceptedProposalBucket)
+		if err != nil {
+			return err
+		}
+
+		return bucket.Put(chanID[:], b.Bytes())
+	}, func() {})
+}
+
+// FetchDynAcceptedProposal loads the persisted accepted dynamic-commitments
+// proposal context for the given channel. It returns fn.None when no context is
+// stored (either the bucket does not exist or the channel has no entry).
+func (c *ChannelStateDB) FetchDynAcceptedProposal(chanID lnwire.ChannelID) (
+	fn.Option[DynAcceptedProposal], error) {
+
+	var proposal fn.Option[DynAcceptedProposal]
+	err := kvdb.View(c.backend, func(tx kvdb.RTx) error {
+		bucket := tx.ReadBucket(dynAcceptedProposalBucket)
+		if bucket == nil {
+			return nil
+		}
+
+		raw := bucket.Get(chanID[:])
+		if raw == nil {
+			return nil
+		}
+
+		p, err := deserializeDynAcceptedProposal(bytes.NewReader(raw))
+		if err != nil {
+			return err
+		}
+
+		proposal = fn.Some(*p)
+
+		return nil
+	}, func() {
+		proposal = fn.None[DynAcceptedProposal]()
+	})
+
+	return proposal, err
+}
+
+// DeleteDynAcceptedProposal removes any persisted accepted dynamic-commitments
+// proposal context for the given channel. It is a no-op when none exists.
+func (c *ChannelStateDB) DeleteDynAcceptedProposal(
+	chanID lnwire.ChannelID) error {
+
+	return kvdb.Update(c.backend, func(tx kvdb.RwTx) error {
+		bucket := tx.ReadWriteBucket(dynAcceptedProposalBucket)
+		if bucket == nil {
+			return nil
+		}
+
+		return bucket.Delete(chanID[:])
+	}, func() {})
+}

--- a/channeldb/dyn_persister_test.go
+++ b/channeldb/dyn_persister_test.go
@@ -30,6 +30,29 @@ func dynTestSig(t *testing.T) lnwire.Sig {
 	return wireSig
 }
 
+// dynTestPartialSig returns a well-formed musig2 partial signature with nonce
+// for use where the signature content is not itself under test. The nonce is
+// built from two real compressed secp256k1 points so it passes the wire-level
+// nonce validation performed on decode.
+func dynTestPartialSig(t *testing.T) lnwire.PartialSigWithNonce {
+	t.Helper()
+
+	priv1, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	priv2, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	var nonce [66]byte
+	copy(nonce[:33], priv1.PubKey().SerializeCompressed())
+	copy(nonce[33:], priv2.PubKey().SerializeCompressed())
+
+	var s btcec.ModNScalar
+	s.SetInt(42)
+
+	return *lnwire.NewPartialSigWithNonce(nonce, s)
+}
+
 // dynTestProposal builds a DynPropose that exercises multiple TLV fields so the
 // round-trip covers a non-trivial proposal.
 func dynTestProposal() *lnwire.DynPropose {
@@ -108,13 +131,26 @@ func TestDynAcceptedProposalRoundTrip(t *testing.T) {
 			},
 		},
 		{
-			name: "commit sig persisted",
+			name: "commit sig persisted (ecdsa)",
 			prop: DynAcceptedProposal{
 				Proposer:         lntypes.Local,
 				Proposal:         dynTestProposal(),
 				NextCommitHeight: 100,
 				AckSig:           fn.Some(dynTestSig(t)),
 				CommitSig:        fn.Some(dynTestSig(t)),
+			},
+		},
+		{
+			name: "commit sig persisted (taproot partial)",
+			prop: DynAcceptedProposal{
+				Proposer:         lntypes.Local,
+				Proposal:         dynTestProposal(),
+				NextCommitHeight: 101,
+				AckSig:           fn.Some(dynTestSig(t)),
+				CommitSig:        fn.None[lnwire.Sig](),
+				PartialSig: fn.Some(
+					dynTestPartialSig(t),
+				),
 			},
 		},
 	}
@@ -138,6 +174,7 @@ func TestDynAcceptedProposalRoundTrip(t *testing.T) {
 			)
 			require.Equal(t, tc.prop.AckSig, got.AckSig)
 			require.Equal(t, tc.prop.CommitSig, got.CommitSig)
+			require.Equal(t, tc.prop.PartialSig, got.PartialSig)
 
 			// The proposal must survive the encode/decode round
 			// trip byte-for-byte.

--- a/channeldb/dyn_persister_test.go
+++ b/channeldb/dyn_persister_test.go
@@ -1,0 +1,169 @@
+package channeldb
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/tlv"
+	"github.com/stretchr/testify/require"
+)
+
+// dynTestSig returns a well-formed 64-byte ECDSA signature for use where the
+// signature content is not itself under test.
+func dynTestSig(t *testing.T) lnwire.Sig {
+	t.Helper()
+
+	priv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	// Produce a deterministic 64-byte signature via the dyn_ack helper so
+	// the bytes are always a valid low-S ECDSA signature.
+	wireSig, err := lnwire.SignDynAck(
+		priv, [32]byte{}, lnwire.ChannelID{}, 0, []byte{0x00},
+	)
+	require.NoError(t, err)
+
+	return wireSig
+}
+
+// dynTestProposal builds a DynPropose that exercises multiple TLV fields so the
+// round-trip covers a non-trivial proposal.
+func dynTestProposal() *lnwire.DynPropose {
+	dp := &lnwire.DynPropose{
+		ChanID: lnwire.ChannelID{0xaa, 0xbb, 0xcc},
+	}
+
+	var dust tlv.RecordT[tlv.TlvType0, tlv.BigSizeT[btcutil.Amount]]
+	dust.Val = tlv.NewBigSizeT(btcutil.Amount(700))
+	dp.DustLimit = tlv.SomeRecordT(dust)
+
+	var csv tlv.RecordT[tlv.TlvType4, uint16]
+	csv.Val = 288
+	dp.CsvDelay = tlv.SomeRecordT(csv)
+
+	var maxHtlcs tlv.RecordT[tlv.TlvType5, uint16]
+	maxHtlcs.Val = 30
+	dp.MaxAcceptedHTLCs = tlv.SomeRecordT(maxHtlcs)
+
+	return dp
+}
+
+// TestDynAcceptedProposalRoundTrip persists, loads, and deletes a
+// DynAcceptedProposal, asserting the loaded value matches what was stored, that
+// absence yields fn.None, and that delete is idempotent.
+func TestDynAcceptedProposalRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	fullDB, err := MakeTestDB(t)
+	require.NoError(t, err)
+	cdb := fullDB.ChannelStateDB()
+
+	chanID := lnwire.ChannelID{0x11, 0x22, 0x33}
+
+	// Absence must yield fn.None with no error, both before the bucket
+	// exists and generally.
+	got, err := cdb.FetchDynAcceptedProposal(chanID)
+	require.NoError(t, err)
+	require.True(t, got.IsNone())
+
+	// Deleting a non-existent entry is a no-op.
+	require.NoError(t, cdb.DeleteDynAcceptedProposal(chanID))
+
+	testCases := []struct {
+		name string
+		prop DynAcceptedProposal
+	}{
+		{
+			name: "proposer, pre-ack",
+			prop: DynAcceptedProposal{
+				Proposer:         lntypes.Local,
+				Proposal:         dynTestProposal(),
+				NextCommitHeight: 7,
+				AckSig:           fn.None[lnwire.Sig](),
+				CommitSig:        fn.None[lnwire.Sig](),
+			},
+		},
+		{
+			name: "proposer, ack received",
+			prop: DynAcceptedProposal{
+				Proposer:         lntypes.Local,
+				Proposal:         dynTestProposal(),
+				NextCommitHeight: 42,
+				AckSig:           fn.Some(dynTestSig(t)),
+				CommitSig:        fn.None[lnwire.Sig](),
+			},
+		},
+		{
+			name: "responder, ack sent",
+			prop: DynAcceptedProposal{
+				Proposer:         lntypes.Remote,
+				Proposal:         dynTestProposal(),
+				NextCommitHeight: 99,
+				AckSig:           fn.Some(dynTestSig(t)),
+				CommitSig:        fn.None[lnwire.Sig](),
+			},
+		},
+		{
+			name: "commit sig persisted",
+			prop: DynAcceptedProposal{
+				Proposer:         lntypes.Local,
+				Proposal:         dynTestProposal(),
+				NextCommitHeight: 100,
+				AckSig:           fn.Some(dynTestSig(t)),
+				CommitSig:        fn.Some(dynTestSig(t)),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			require.NoError(
+				t, cdb.StoreDynAcceptedProposal(chanID, tc.prop),
+			)
+
+			loaded, err := cdb.FetchDynAcceptedProposal(chanID)
+			require.NoError(t, err)
+			require.True(t, loaded.IsSome())
+
+			got := loaded.UnsafeFromSome()
+			require.Equal(t, tc.prop.Proposer, got.Proposer)
+			require.Equal(
+				t, tc.prop.NextCommitHeight,
+				got.NextCommitHeight,
+			)
+			require.Equal(t, tc.prop.AckSig, got.AckSig)
+			require.Equal(t, tc.prop.CommitSig, got.CommitSig)
+
+			// The proposal must survive the encode/decode round
+			// trip byte-for-byte.
+			assertProposalEqual(t, tc.prop.Proposal, got.Proposal)
+		})
+	}
+
+	// Storing again overwrites, and delete removes the entry so a
+	// subsequent fetch is fn.None.
+	require.NoError(t, cdb.DeleteDynAcceptedProposal(chanID))
+
+	got, err = cdb.FetchDynAcceptedProposal(chanID)
+	require.NoError(t, err)
+	require.True(t, got.IsNone())
+}
+
+// assertProposalEqual asserts two DynPropose messages encode identically.
+func assertProposalEqual(t *testing.T, want, got *lnwire.DynPropose) {
+	t.Helper()
+
+	wantTLV, err := want.SerializeTlvData()
+	require.NoError(t, err)
+
+	gotTLV, err := got.SerializeTlvData()
+	require.NoError(t, err)
+
+	require.Equal(t, want.ChanID, got.ChanID)
+	require.Equal(t, wantTLV, gotTLV)
+}

--- a/htlcswitch/dyn/interfaces.go
+++ b/htlcswitch/dyn/interfaces.go
@@ -117,6 +117,21 @@ type AcceptedProposal struct {
 	// responder once it signs, and on the proposer once it verifies the
 	// received dyn_ack.
 	AckSig fn.Option[lnwire.Sig]
+
+	// CommitSig is the proposer's dyn_commit_sig commitment signature. Its
+	// presence is the persisted flag that a dyn_commit_sig has crossed the
+	// wire before a disconnect: the proposer sets it when it sends the
+	// bundled dyn_commit_sig, and the responder sets it when it receives and
+	// persists one before sending its revoke_and_ack. A negotiation with a
+	// persisted CommitSig is retained and retransmitted across a reconnect;
+	// one without is forgotten (see Decide).
+	//
+	// TODO(dyn): the commitment dance that actually produces and consumes
+	// dyn_commit_sig is not complete on the branch this is stacked on, so
+	// nothing sets this in the live flow yet. The reconnect decision logic
+	// and the durable persistence handle it now so the retransmission path
+	// is ready to be wired once the dance lands.
+	CommitSig fn.Option[lnwire.Sig]
 }
 
 // Params returns the canonical channel-params view of the accepted proposal.

--- a/htlcswitch/dyn/interfaces.go
+++ b/htlcswitch/dyn/interfaces.go
@@ -118,25 +118,37 @@ type AcceptedProposal struct {
 	// received dyn_ack.
 	AckSig fn.Option[lnwire.Sig]
 
-	// CommitSig is the proposer's dyn_commit_sig commitment signature. Its
-	// presence is the persisted flag that a dyn_commit_sig has crossed the
-	// wire before a disconnect: the proposer sets it when it sends the
-	// bundled dyn_commit_sig, and the responder sets it when it receives and
-	// persists one before sending its revoke_and_ack. A negotiation with a
-	// persisted CommitSig is retained and retransmitted across a reconnect;
-	// one without is forgotten (see Decide).
-	//
-	// TODO(dyn): the commitment dance that actually produces and consumes
-	// dyn_commit_sig is not complete on the branch this is stacked on, so
-	// nothing sets this in the live flow yet. The reconnect decision logic
-	// and the durable persistence handle it now so the retransmission path
-	// is ready to be wired once the dance lands.
+	// CommitSig is the proposer's dyn_commit_sig commitment signature for a
+	// non-taproot (ECDSA) channel. Its presence, or the presence of
+	// PartialSig, is the persisted flag that a dyn_commit_sig has crossed
+	// the wire before a disconnect: the proposer sets it when it sends the
+	// bundled dyn_commit_sig, and the responder sets it when it receives one
+	// before sending its revoke_and_ack. A negotiation with a persisted
+	// commit sig is retained and retransmitted across a reconnect; one
+	// without is forgotten (see Decide).
 	CommitSig fn.Option[lnwire.Sig]
+
+	// PartialSig is the proposer's dyn_commit_sig commitment signature for a
+	// taproot (musig2) channel, carried as a partial_signature_with_nonce.
+	// It is the taproot counterpart of CommitSig: for a taproot channel the
+	// dyn_commit_sig rides this field and CommitSig is absent, while for a
+	// non-taproot channel this field is absent and CommitSig carries the
+	// ECDSA signature.
+	PartialSig fn.Option[lnwire.PartialSigWithNonce]
 }
 
 // Params returns the canonical channel-params view of the accepted proposal.
 func (a *AcceptedProposal) Params() lnwallet.ChannelParams {
 	return lnwallet.ChannelParamsFromDynPropose(a.Proposal)
+}
+
+// HasCommitSig returns true if a dyn_commit_sig commitment signature has been
+// persisted for this negotiation, in either its ECDSA (CommitSig) or taproot
+// partial (PartialSig) form. It is the persisted flag the reconnect decision
+// keys on to tell a negotiation that must be retransmitted from one that must
+// be forgotten.
+func (a AcceptedProposal) HasCommitSig() bool {
+	return a.CommitSig.IsSome() || a.PartialSig.IsSome()
 }
 
 // Persister persists the accepted-proposal context at the boundaries the state

--- a/htlcswitch/dyn/reestablish.go
+++ b/htlcswitch/dyn/reestablish.go
@@ -1,0 +1,187 @@
+package dyn
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/lightningnetwork/lnd/lntypes"
+)
+
+// ReconnectAction enumerates what to do with a persisted dyn-negotiation
+// context when a channel is reestablished after a disconnect. It is the output
+// of the pure Decide function, which encodes the locked reconnect rules of the
+// dynamic-commitments extension BOLT.
+type ReconnectAction uint8
+
+const (
+	// ReconnectForget indicates the persisted negotiation must be abandoned
+	// and its context deleted. This covers every pre-dyn_commit_sig
+	// negotiation with one exception (see ReconnectRetainAndWait): a
+	// proposer that has not persisted a dyn_commit_sig — whether or not it
+	// received a dyn_ack — as well as a responder that had not yet sent its
+	// dyn_ack. A received dyn_ack in particular MUST NOT be reused after a
+	// reconnect unless a dyn_commit_sig was persisted before the disconnect.
+	ReconnectForget ReconnectAction = iota
+
+	// ReconnectRetainAndWait indicates a responder that sent its dyn_ack
+	// before the disconnect must retain the acceptance across the reconnect
+	// and wait for the proposer's dyn_commit_sig, a superseding proposal, or
+	// a timeout, without proactively resending any dyn message itself.
+	ReconnectRetainAndWait
+
+	// ReconnectRetransmitCommitSig indicates the proposer persisted a
+	// dyn_commit_sig that the peer has not yet processed, so it must be
+	// retransmitted before any other update even though quiescence has
+	// ended. It is counted as the corresponding commitment_signed for the
+	// peer's next_commitment_number accounting.
+	ReconnectRetransmitCommitSig
+
+	// ReconnectResume indicates the dyn_commit_sig has already been processed
+	// by the peer (or was received by us as the responder), so the update is
+	// effectively locked in and normal commitment retransmission covers the
+	// remainder of the dance.
+	ReconnectResume
+)
+
+// String returns a human-readable representation of the action.
+func (a ReconnectAction) String() string {
+	switch a {
+	case ReconnectForget:
+		return "Forget"
+
+	case ReconnectRetainAndWait:
+		return "RetainAndWait"
+
+	case ReconnectRetransmitCommitSig:
+		return "RetransmitCommitSig"
+
+	case ReconnectResume:
+		return "Resume"
+
+	default:
+		return fmt.Sprintf("Unknown(%d)", a)
+	}
+}
+
+// ReestablishState captures the reconnect-time inputs, beyond the persisted
+// AcceptedProposal, that the reconnect decision depends on. These come from the
+// channel_reestablish the peer sent on reconnection.
+type ReestablishState struct {
+	// PeerNextCommitHeight is the next_commitment_number the peer advertised
+	// in its channel_reestablish (its NextLocalCommitHeight), i.e. the
+	// commitment number it expects to receive from us next. A persisted
+	// dyn_commit_sig must be retransmitted when this still equals the height
+	// the dyn_commit_sig binds to, since a dyn_commit_sig is counted as the
+	// commitment_signed for that height.
+	PeerNextCommitHeight uint64
+}
+
+// Decide is the pure reconnect decision function. Given a persisted
+// AcceptedProposal and the peer's reestablish state, it returns the action the
+// caller must take, implementing the locked design decisions:
+//
+//   - Pre-dyn_commit_sig negotiations abort on disconnect (no retransmit of
+//     dyn_propose/dyn_ack/dyn_reject).
+//   - A received dyn_ack MUST NOT be reused after reconnect unless a
+//     dyn_commit_sig was persisted before disconnect.
+//   - A responder that sent dyn_ack retains its acceptance across reconnect and
+//     waits for dyn_commit_sig / a proposer update / a timeout.
+//   - A persisted dyn_commit_sig is retransmitted when the peer still expects
+//     it, and is otherwise treated as already locked in.
+//
+// It performs no side effects and does not consult persistence; the caller
+// loads the persisted context and applies the returned action.
+func Decide(p AcceptedProposal, r ReestablishState) ReconnectAction {
+	ackKnown := p.AckSig.IsSome()
+	commitSigned := p.CommitSig.IsSome()
+	proposer := p.Proposer == lntypes.Local
+
+	switch {
+	// No dyn_commit_sig crossed the wire before the disconnect. Every such
+	// negotiation is abandoned, except a responder that already sent its
+	// dyn_ack, which retains the acceptance and waits.
+	case !commitSigned:
+		if !proposer && ackKnown {
+			return ReconnectRetainAndWait
+		}
+
+		return ReconnectForget
+
+	// A dyn_commit_sig was persisted. Only the proposer ever sends one, so
+	// only the proposer retransmits, and only while the peer's next expected
+	// commitment number still points at the height the dyn_commit_sig binds
+	// to.
+	case proposer && r.PeerNextCommitHeight == p.NextCommitHeight:
+		return ReconnectRetransmitCommitSig
+
+	// Either the peer has already advanced past the dyn_commit_sig, or we are
+	// the responder that received one: the update is locked in and normal
+	// commitment retransmission handles the rest.
+	default:
+		return ReconnectResume
+	}
+}
+
+// Restore rehydrates the in-memory session of a freshly-constructed Updater
+// from a persisted AcceptedProposal after a reconnect, so the machine can
+// continue (or complete) a negotiation that survived the disconnect. The target
+// state is derived from the persisted role and signatures. It is the caller's
+// responsibility to only call this for negotiations that Decide says to keep
+// (RetainAndWait, RetransmitCommitSig, Resume); a negotiation to forget must be
+// dropped via Reset instead.
+//
+// The context is accepted for symmetry with the rest of the API and future use;
+// Restore itself performs no persistence.
+func (u *Updater) Restore(_ context.Context, p AcceptedProposal) error {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	if p.Proposal == nil {
+		return fmt.Errorf("cannot restore dyn session with nil proposal")
+	}
+
+	u.role = p.Proposer
+	u.proposal = p.Proposal
+	u.nextHeight = p.NextCommitHeight
+	u.ackSig = p.AckSig
+	u.clearTimeout()
+
+	proposer := p.Proposer == lntypes.Local
+
+	switch {
+	// A dyn_commit_sig was persisted, so the negotiation is past the
+	// abort/timeout boundary and in the committing handoff.
+	case p.CommitSig.IsSome():
+		u.state = StateCommitting
+
+	// Proposer that received and verified the dyn_ack but had not yet sent
+	// the dyn_commit_sig.
+	case proposer && p.AckSig.IsSome():
+		u.state = StateAccepted
+
+	// Proposer that had sent dyn_propose and was still awaiting the dyn_ack.
+	// The negotiation is still time-bounded.
+	case proposer:
+		u.state = StateAwaitingAck
+		u.armTimeout()
+
+	// Responder that had sent its dyn_ack and is waiting for the
+	// dyn_commit_sig. The negotiation is still time-bounded.
+	case p.AckSig.IsSome():
+		u.state = StateAckSent
+		u.armTimeout()
+
+	// Responder without a persisted dyn_ack is not a valid state to retain:
+	// the responder only persists after signing its dyn_ack.
+	default:
+		u.resetLocked()
+
+		return fmt.Errorf("cannot restore responder session without a "+
+			"persisted dyn_ack for ChannelID(%v)", u.chanID)
+	}
+
+	log.Infof("Restored dyn session for ChannelID(%v): role=%v, state=%s, "+
+		"height=%d", u.chanID, u.role, u.state, u.nextHeight)
+
+	return nil
+}

--- a/htlcswitch/dyn/reestablish.go
+++ b/htlcswitch/dyn/reestablish.go
@@ -93,7 +93,7 @@ type ReestablishState struct {
 // loads the persisted context and applies the returned action.
 func Decide(p AcceptedProposal, r ReestablishState) ReconnectAction {
 	ackKnown := p.AckSig.IsSome()
-	commitSigned := p.CommitSig.IsSome()
+	commitSigned := p.HasCommitSig()
 	proposer := p.Proposer == lntypes.Local
 
 	switch {
@@ -144,6 +144,8 @@ func (u *Updater) Restore(_ context.Context, p AcceptedProposal) error {
 	u.proposal = p.Proposal
 	u.nextHeight = p.NextCommitHeight
 	u.ackSig = p.AckSig
+	u.commitSig = p.CommitSig
+	u.partialSig = p.PartialSig
 	u.clearTimeout()
 
 	proposer := p.Proposer == lntypes.Local
@@ -151,7 +153,7 @@ func (u *Updater) Restore(_ context.Context, p AcceptedProposal) error {
 	switch {
 	// A dyn_commit_sig was persisted, so the negotiation is past the
 	// abort/timeout boundary and in the committing handoff.
-	case p.CommitSig.IsSome():
+	case p.HasCommitSig():
 		u.state = StateCommitting
 
 	// Proposer that received and verified the dyn_ack but had not yet sent

--- a/htlcswitch/dyn/reestablish_test.go
+++ b/htlcswitch/dyn/reestablish_test.go
@@ -1,0 +1,292 @@
+package dyn
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/stretchr/testify/require"
+)
+
+// mkAccepted builds an AcceptedProposal for the reconnect tests with the given
+// role and optional dyn_ack / dyn_commit_sig signatures set.
+func mkAccepted(t *testing.T, proposer lntypes.ChannelParty,
+	ack, commit bool) AcceptedProposal {
+
+	t.Helper()
+
+	p := AcceptedProposal{
+		Proposer:         proposer,
+		Proposal:         validProposal().ToDynPropose(testChanID),
+		NextCommitHeight: testNextHeight,
+		AckSig:           fn.None[lnwire.Sig](),
+		CommitSig:        fn.None[lnwire.Sig](),
+	}
+	if ack {
+		p.AckSig = fn.Some(testSig(t))
+	}
+	if commit {
+		p.CommitSig = fn.Some(testSig(t))
+	}
+
+	return p
+}
+
+// TestDecideTable exhaustively exercises the reconnect decision function across
+// every meaningful combination of role, dyn_ack presence, dyn_commit_sig
+// presence, and the peer's next commitment height, asserting the locked design
+// decisions.
+func TestDecideTable(t *testing.T) {
+	t.Parallel()
+
+	const (
+		heightEq   = testNextHeight     // peer still expects the sig.
+		heightPast = testNextHeight + 1 // peer already processed the sig.
+		heightBack = testNextHeight - 1 // defensive: peer behind us.
+	)
+
+	testCases := []struct {
+		name     string
+		proposer lntypes.ChannelParty
+		ack      bool
+		commit   bool
+		peerNext uint64
+		want     ReconnectAction
+	}{
+		// Pre-dyn_commit_sig: everything is forgotten except a
+		// responder that already sent its dyn_ack.
+		{
+			name:     "proposer pre-ack forgets",
+			proposer: lntypes.Local,
+			ack:      false,
+			commit:   false,
+			peerNext: heightEq,
+			want:     ReconnectForget,
+		},
+		{
+			name:     "proposer received ack no commitsig forgets",
+			proposer: lntypes.Local,
+			ack:      true,
+			commit:   false,
+			peerNext: heightEq,
+			want:     ReconnectForget,
+		},
+		{
+			name:     "responder pre-ack forgets",
+			proposer: lntypes.Remote,
+			ack:      false,
+			commit:   false,
+			peerNext: heightEq,
+			want:     ReconnectForget,
+		},
+		{
+			name:     "responder sent ack retains and waits",
+			proposer: lntypes.Remote,
+			ack:      true,
+			commit:   false,
+			peerNext: heightEq,
+			want:     ReconnectRetainAndWait,
+		},
+
+		// dyn_commit_sig persisted by the proposer: retransmit while the
+		// peer still expects it, otherwise resume.
+		{
+			name:     "proposer commitsig peer expects retransmits",
+			proposer: lntypes.Local,
+			ack:      true,
+			commit:   true,
+			peerNext: heightEq,
+			want:     ReconnectRetransmitCommitSig,
+		},
+		{
+			name:     "proposer commitsig peer advanced resumes",
+			proposer: lntypes.Local,
+			ack:      true,
+			commit:   true,
+			peerNext: heightPast,
+			want:     ReconnectResume,
+		},
+		{
+			name:     "proposer commitsig peer behind resumes",
+			proposer: lntypes.Local,
+			ack:      true,
+			commit:   true,
+			peerNext: heightBack,
+			want:     ReconnectResume,
+		},
+
+		// dyn_commit_sig persisted by the responder (received it): the
+		// responder never retransmits it, so it always resumes.
+		{
+			name:     "responder commitsig peer expects resumes",
+			proposer: lntypes.Remote,
+			ack:      true,
+			commit:   true,
+			peerNext: heightEq,
+			want:     ReconnectResume,
+		},
+		{
+			name:     "responder commitsig peer advanced resumes",
+			proposer: lntypes.Remote,
+			ack:      true,
+			commit:   true,
+			peerNext: heightPast,
+			want:     ReconnectResume,
+		},
+
+		// Defensive: signatures in impossible combinations still resolve
+		// to a total, sensible action.
+		{
+			name:     "proposer commitsig without ack retransmits",
+			proposer: lntypes.Local,
+			ack:      false,
+			commit:   true,
+			peerNext: heightEq,
+			want:     ReconnectRetransmitCommitSig,
+		},
+		{
+			name:     "responder commitsig without ack resumes",
+			proposer: lntypes.Remote,
+			ack:      false,
+			commit:   true,
+			peerNext: heightEq,
+			want:     ReconnectResume,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			p := mkAccepted(t, tc.proposer, tc.ack, tc.commit)
+			got := Decide(p, ReestablishState{
+				PeerNextCommitHeight: tc.peerNext,
+			})
+			require.Equalf(t, tc.want, got,
+				"want %s, got %s", tc.want, got)
+		})
+	}
+}
+
+// TestReconnectActionStrings checks that every action has a distinct,
+// non-default string form.
+func TestReconnectActionStrings(t *testing.T) {
+	t.Parallel()
+
+	actions := []ReconnectAction{
+		ReconnectForget, ReconnectRetainAndWait,
+		ReconnectRetransmitCommitSig, ReconnectResume,
+	}
+	seen := make(map[string]struct{})
+	for _, a := range actions {
+		str := a.String()
+		require.NotContains(t, str, "Unknown")
+		require.NotContains(t, seen, str)
+		seen[str] = struct{}{}
+	}
+}
+
+// TestRestoreState verifies that Restore rehydrates a freshly-constructed
+// Updater into the correct state for each retained-negotiation shape, and that
+// the negotiation timeout is (re)armed only for the still-waiting states.
+func TestRestoreState(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	testCases := []struct {
+		name      string
+		proposer  lntypes.ChannelParty
+		ack       bool
+		commit    bool
+		wantState State
+		wantArmed bool
+	}{
+		{
+			name:      "proposer awaiting ack",
+			proposer:  lntypes.Local,
+			ack:       false,
+			commit:    false,
+			wantState: StateAwaitingAck,
+			wantArmed: true,
+		},
+		{
+			name:      "proposer accepted",
+			proposer:  lntypes.Local,
+			ack:       true,
+			commit:    false,
+			wantState: StateAccepted,
+			wantArmed: false,
+		},
+		{
+			name:      "responder ack sent",
+			proposer:  lntypes.Remote,
+			ack:       true,
+			commit:    false,
+			wantState: StateAckSent,
+			wantArmed: true,
+		},
+		{
+			name:      "committing after commitsig",
+			proposer:  lntypes.Local,
+			ack:       true,
+			commit:    true,
+			wantState: StateCommitting,
+			wantArmed: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			rig := newRig(t, tc.proposer)
+			p := mkAccepted(t, tc.proposer, tc.ack, tc.commit)
+
+			require.NoError(t, rig.u.Restore(ctx, p))
+			require.Equal(t, tc.wantState, rig.u.State())
+
+			// Advance the clock beyond the negotiation timeout and
+			// tick. An armed timer must fire (Disconnect), a
+			// disarmed one must not.
+			rig.clk.SetTime(
+				rig.clk.Now().Add(2 * DefaultTimeout),
+			)
+			tr, err := rig.u.CheckTimeout(ctx)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantArmed, tr.Disconnect)
+		})
+	}
+}
+
+// TestRestoreInvalid verifies Restore rejects the shapes that cannot represent
+// a retained negotiation: a nil proposal and a responder without a dyn_ack.
+func TestRestoreInvalid(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	t.Run("nil proposal", func(t *testing.T) {
+		t.Parallel()
+
+		rig := newRig(t, lntypes.Local)
+		err := rig.u.Restore(ctx, AcceptedProposal{
+			Proposer: lntypes.Local,
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("responder without ack", func(t *testing.T) {
+		t.Parallel()
+
+		rig := newRig(t, lntypes.Remote)
+		p := mkAccepted(t, lntypes.Remote, false, false)
+		err := rig.u.Restore(ctx, p)
+		require.Error(t, err)
+		require.Equal(t, StateIdle, rig.u.State())
+	})
+}

--- a/htlcswitch/dyn/reestablish_test.go
+++ b/htlcswitch/dyn/reestablish_test.go
@@ -171,6 +171,32 @@ func TestDecideTable(t *testing.T) {
 	}
 }
 
+// TestDecideTaprootCommitSig verifies the reconnect decision treats a taproot
+// dyn_commit_sig (persisted as a partial signature, with the ECDSA CommitSig
+// absent) exactly like an ECDSA one: a persisted commit sig in either form
+// promotes the negotiation from forget to retransmit/resume.
+func TestDecideTaprootCommitSig(t *testing.T) {
+	t.Parallel()
+
+	// A proposer that persisted a taproot partial commit sig, with the peer
+	// still expecting it, must retransmit.
+	p := mkAccepted(t, lntypes.Local, true, false)
+	p.PartialSig = fn.Some(testPartialSig(t))
+	require.True(t, p.HasCommitSig())
+	require.True(t, p.CommitSig.IsNone())
+
+	got := Decide(p, ReestablishState{
+		PeerNextCommitHeight: testNextHeight,
+	})
+	require.Equal(t, ReconnectRetransmitCommitSig, got)
+
+	// The same partial sig, once the peer has advanced past it, resumes.
+	got = Decide(p, ReestablishState{
+		PeerNextCommitHeight: testNextHeight + 1,
+	})
+	require.Equal(t, ReconnectResume, got)
+}
+
 // TestReconnectActionStrings checks that every action has a distinct,
 // non-default string form.
 func TestReconnectActionStrings(t *testing.T) {
@@ -261,6 +287,29 @@ func TestRestoreState(t *testing.T) {
 			require.Equal(t, tc.wantArmed, tr.Disconnect)
 		})
 	}
+}
+
+// TestRestoreTaprootCommitSig verifies Restore rehydrates a proposer that
+// persisted a taproot dyn_commit_sig (a partial signature, with the ECDSA
+// CommitSig absent) into the committing state, mirroring the ECDSA path.
+func TestRestoreTaprootCommitSig(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	rig := newRig(t, lntypes.Local)
+	p := mkAccepted(t, lntypes.Local, true, false)
+	p.PartialSig = fn.Some(testPartialSig(t))
+	require.True(t, p.HasCommitSig())
+
+	require.NoError(t, rig.u.Restore(ctx, p))
+	require.Equal(t, StateCommitting, rig.u.State())
+
+	// The negotiation is past the timeout boundary, so no timer is armed.
+	rig.clk.SetTime(rig.clk.Now().Add(2 * DefaultTimeout))
+	tr, err := rig.u.CheckTimeout(ctx)
+	require.NoError(t, err)
+	require.False(t, tr.Disconnect)
 }
 
 // TestRestoreInvalid verifies Restore rejects the shapes that cannot represent

--- a/htlcswitch/dyn/updater.go
+++ b/htlcswitch/dyn/updater.go
@@ -708,6 +708,14 @@ func (u *Updater) send(ctx context.Context, t *Transition,
 }
 
 // persist writes the current in-flight session as an AcceptedProposal.
+//
+// TODO(dyn): the persisted context does not yet carry a CommitSig. It is set
+// only once the commitment dance sends (proposer) or receives (responder) the
+// bundled dyn_commit_sig, and that dance is not complete on the branch this is
+// stacked on. Until then every persisted context has a None CommitSig, so a
+// disconnect always resolves to "forget" or "retain-and-wait" (never
+// "retransmit"); the retransmit path is exercised by unit tests that inject a
+// CommitSig directly.
 func (u *Updater) persist(ctx context.Context) error {
 	return u.cfg.Persister.StoreAcceptedProposal(
 		ctx, u.chanID, AcceptedProposal{
@@ -715,6 +723,7 @@ func (u *Updater) persist(ctx context.Context) error {
 			Proposal:         u.proposal,
 			NextCommitHeight: u.nextHeight,
 			AckSig:           u.ackSig,
+			CommitSig:        fn.None[lnwire.Sig](),
 		},
 	)
 }

--- a/htlcswitch/dyn/updater.go
+++ b/htlcswitch/dyn/updater.go
@@ -193,6 +193,17 @@ type Updater struct {
 	// ackSig holds the responder's dyn_ack signature once known.
 	ackSig fn.Option[lnwire.Sig]
 
+	// commitSig holds the ECDSA dyn_commit_sig commitment signature once the
+	// proposer has sent it or the responder has received it. It is only set
+	// for non-taproot channels; taproot channels use partialSig instead.
+	commitSig fn.Option[lnwire.Sig]
+
+	// partialSig holds the taproot (musig2) dyn_commit_sig commitment
+	// signature once the proposer has sent it or the responder has received
+	// it. It is only set for taproot channels; non-taproot channels use
+	// commitSig instead.
+	partialSig fn.Option[lnwire.PartialSigWithNonce]
+
 	// deadline is the time at which the in-flight negotiation times out. It
 	// is only meaningful while timerArmed is true.
 	deadline time.Time
@@ -507,16 +518,31 @@ func (u *Updater) RecvCommit(ctx context.Context,
 }
 
 // MarkCommitSent records that the proposer has sent the bundled dyn_commit_sig,
-// completing this machine's role and moving it to Committing. From here the
-// link owns the commitment dance and the negotiation is no longer abortable on
-// a reconnect.
-func (u *Updater) MarkCommitSent(_ context.Context) (*Transition, error) {
+// completing this machine's role and moving it to Committing. It persists the
+// real commitment signature it just sent (the ECDSA commitSig for non-taproot
+// channels or the taproot partialSig) before advancing, matching the extension
+// BOLT requirement that a sent dyn_commit_sig is persisted for retransmission.
+// From here the link owns the commitment dance and the negotiation is no longer
+// abortable on a reconnect: it is retransmitted, not forgotten.
+func (u *Updater) MarkCommitSent(ctx context.Context,
+	commitSig fn.Option[lnwire.Sig],
+	partialSig fn.Option[lnwire.PartialSigWithNonce]) (*Transition, error) {
+
 	u.mu.Lock()
 	defer u.mu.Unlock()
 
 	if u.state != StateAccepted {
 		return nil, fmt.Errorf("%w: commit-sent in state %s",
 			ErrInvalidTransition, u.state)
+	}
+
+	// Record and persist the sent commitment signature before advancing, so
+	// a disconnect after this point resolves to retransmit rather than
+	// forget.
+	u.commitSig = commitSig
+	u.partialSig = partialSig
+	if err := u.persist(ctx); err != nil {
+		return nil, fmt.Errorf("persist sent commit: %w", err)
 	}
 
 	t, err := u.applyEvent(eventCommitSent)
@@ -528,6 +554,38 @@ func (u *Updater) MarkCommitSent(_ context.Context) (*Transition, error) {
 		u.chanID)
 
 	return t, nil
+}
+
+// RecordCommitReceived persists the responder's received dyn_commit_sig before
+// it sends its revoke_and_ack, matching the extension BOLT requirement that the
+// receiver MUST persist the received dyn_commit_sig before revoke_and_ack. It
+// records the real commitment signature (the ECDSA commitSig for non-taproot
+// channels or the taproot partialSig) so a reconnect resolves to resume rather
+// than forget the negotiation. It does not change the machine's state: the
+// responder is already in the committing handoff when this is called.
+func (u *Updater) RecordCommitReceived(ctx context.Context,
+	commitSig fn.Option[lnwire.Sig],
+	partialSig fn.Option[lnwire.PartialSigWithNonce]) error {
+
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	if u.state != StateCommitting {
+		return fmt.Errorf("%w: record-commit-received in state %s",
+			ErrInvalidTransition, u.state)
+	}
+
+	u.commitSig = commitSig
+	u.partialSig = partialSig
+
+	if err := u.persist(ctx); err != nil {
+		return fmt.Errorf("persist received commit: %w", err)
+	}
+
+	log.Infof("Persisted received dyn_commit_sig for ChannelID(%v)",
+		u.chanID)
+
+	return nil
 }
 
 // CheckTimeout advances the negotiation timeout. The caller ticks it (for
@@ -707,15 +765,10 @@ func (u *Updater) send(ctx context.Context, t *Transition,
 	return nil
 }
 
-// persist writes the current in-flight session as an AcceptedProposal.
-//
-// TODO(dyn): the persisted context does not yet carry a CommitSig. It is set
-// only once the commitment dance sends (proposer) or receives (responder) the
-// bundled dyn_commit_sig, and that dance is not complete on the branch this is
-// stacked on. Until then every persisted context has a None CommitSig, so a
-// disconnect always resolves to "forget" or "retain-and-wait" (never
-// "retransmit"); the retransmit path is exercised by unit tests that inject a
-// CommitSig directly.
+// persist writes the current in-flight session as an AcceptedProposal. Once the
+// commitment dance has sent (proposer) or received (responder) the bundled
+// dyn_commit_sig, the recorded commitment signature is included so a reconnect
+// resolves to retransmit/resume rather than forget the negotiation.
 func (u *Updater) persist(ctx context.Context) error {
 	return u.cfg.Persister.StoreAcceptedProposal(
 		ctx, u.chanID, AcceptedProposal{
@@ -723,7 +776,8 @@ func (u *Updater) persist(ctx context.Context) error {
 			Proposal:         u.proposal,
 			NextCommitHeight: u.nextHeight,
 			AckSig:           u.ackSig,
-			CommitSig:        fn.None[lnwire.Sig](),
+			CommitSig:        u.commitSig,
+			PartialSig:       u.partialSig,
 		},
 	)
 }
@@ -743,12 +797,15 @@ func (u *Updater) forget(ctx context.Context) error {
 }
 
 // clearInflight drops the in-flight session data (role, proposal, height, ack
-// signature, and timer) without touching the state. The caller must hold u.mu.
+// and commitment signatures, and timer) without touching the state. The caller
+// must hold u.mu.
 func (u *Updater) clearInflight() {
 	u.role = lntypes.Local
 	u.proposal = nil
 	u.nextHeight = 0
 	u.ackSig = fn.None[lnwire.Sig]()
+	u.commitSig = fn.None[lnwire.Sig]()
+	u.partialSig = fn.None[lnwire.PartialSigWithNonce]()
 	u.clearTimeout()
 }
 

--- a/htlcswitch/dyn/updater_test.go
+++ b/htlcswitch/dyn/updater_test.go
@@ -285,11 +285,22 @@ func TestLocalInitToReadyToCommit(t *testing.T) {
 	require.True(t, handoff.Params.DustLimit.IsSome())
 	require.True(t, handoff.ReceivedCommit.IsNone())
 
-	// Finally, hand off the dance.
-	tr, err = rig.u.MarkCommitSent(ctx)
+	// Finally, hand off the dance, recording the sent ECDSA commit sig.
+	sentSig := testSig(t)
+	tr, err = rig.u.MarkCommitSent(
+		ctx, fn.Some(sentSig), fn.None[lnwire.PartialSigWithNonce](),
+	)
 	require.NoError(t, err)
 	require.Equal(t, StateCommitting, rig.u.State())
 	require.True(t, rig.u.State().IsTerminal())
+
+	// The sent commitment signature must have been persisted so a reconnect
+	// resolves to retransmit rather than forget.
+	stored, err = rig.persister.FetchAcceptedProposal(ctx, testChanID)
+	require.NoError(t, err)
+	require.True(t, stored.IsSome())
+	require.True(t, stored.UnsafeFromSome().HasCommitSig())
+	require.Equal(t, fn.Some(sentSig), stored.UnsafeFromSome().CommitSig)
 }
 
 // TestRemoteProposalAccept walks the responder happy path: validate an incoming
@@ -349,6 +360,22 @@ func TestRemoteProposalAccept(t *testing.T) {
 	require.Equal(t, lntypes.Remote, handoff.Proposer)
 	require.True(t, handoff.ReceivedCommit.IsSome())
 	require.Equal(t, commit, handoff.ReceivedCommit.UnsafeFromSome())
+
+	// The link records the received commitment signature before it sends its
+	// revoke_and_ack. Simulate that here and confirm it is persisted so a
+	// reconnect resolves to resume rather than forget.
+	require.NoError(t, rig.u.RecordCommitReceived(
+		ctx, fn.Some(commit.CommitSig),
+		fn.None[lnwire.PartialSigWithNonce](),
+	))
+
+	stored, err = rig.persister.FetchAcceptedProposal(ctx, testChanID)
+	require.NoError(t, err)
+	require.True(t, stored.IsSome())
+	require.True(t, stored.UnsafeFromSome().HasCommitSig())
+	require.Equal(
+		t, fn.Some(commit.CommitSig), stored.UnsafeFromSome().CommitSig,
+	)
 }
 
 // TestRejectInvalidParam checks that a proposal with an out-of-policy parameter
@@ -641,7 +668,10 @@ func TestInvalidTransitions(t *testing.T) {
 	_, err = rig.u.RecvCommit(ctx, &lnwire.DynCommit{})
 	require.ErrorIs(t, err, ErrInvalidTransition)
 
-	_, err = rig.u.MarkCommitSent(ctx)
+	_, err = rig.u.MarkCommitSent(
+		ctx, fn.None[lnwire.Sig](),
+		fn.None[lnwire.PartialSigWithNonce](),
+	)
 	require.ErrorIs(t, err, ErrInvalidTransition)
 
 	require.Equal(t, StateIdle, rig.u.State())
@@ -724,4 +754,26 @@ func testSig(t *testing.T) lnwire.Sig {
 	require.NoError(t, err)
 
 	return sig
+}
+
+// testPartialSig returns an arbitrary well-formed musig2 partial signature with
+// nonce for use where the content of a taproot commitment signature is not
+// under test.
+func testPartialSig(t *testing.T) lnwire.PartialSigWithNonce {
+	t.Helper()
+
+	priv1, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	priv2, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	var nonce [66]byte
+	copy(nonce[:33], priv1.PubKey().SerializeCompressed())
+	copy(nonce[33:], priv2.PubKey().SerializeCompressed())
+
+	var s btcec.ModNScalar
+	s.SetInt(7)
+
+	return *lnwire.NewPartialSigWithNonce(nonce, s)
 }

--- a/htlcswitch/dyn_persister.go
+++ b/htlcswitch/dyn_persister.go
@@ -1,0 +1,80 @@
+package htlcswitch
+
+import (
+	"context"
+
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/htlcswitch/dyn"
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+// dbDynPersister is the durable, channeldb-backed implementation of the
+// dyn.Persister interface. It stores the accepted-proposal context per channel
+// so an in-flight dynamic-commitments negotiation survives a restart and can be
+// resumed or forgotten on reconnect. It converts between the htlcswitch/dyn
+// context type and the channeldb-native storage type, keeping channeldb free of
+// any dependency on htlcswitch/dyn.
+type dbDynPersister struct {
+	// db is the channel-state database the context is persisted to.
+	db *channeldb.ChannelStateDB
+}
+
+// A compile-time assertion that dbDynPersister implements dyn.Persister.
+var _ dyn.Persister = (*dbDynPersister)(nil)
+
+// newDBDynPersister constructs a channeldb-backed dyn.Persister over the given
+// channel-state database.
+func newDBDynPersister(db *channeldb.ChannelStateDB) *dbDynPersister {
+	return &dbDynPersister{db: db}
+}
+
+// StoreAcceptedProposal persists (or overwrites) the accepted-proposal context
+// for the given channel.
+//
+// NOTE: Part of the dyn.Persister interface.
+func (p *dbDynPersister) StoreAcceptedProposal(_ context.Context,
+	chanID lnwire.ChannelID, prop dyn.AcceptedProposal) error {
+
+	return p.db.StoreDynAcceptedProposal(chanID, channeldb.DynAcceptedProposal{
+		Proposer:         prop.Proposer,
+		Proposal:         prop.Proposal,
+		NextCommitHeight: prop.NextCommitHeight,
+		AckSig:           prop.AckSig,
+		CommitSig:        prop.CommitSig,
+	})
+}
+
+// FetchAcceptedProposal loads the persisted context for the given channel, if
+// any.
+//
+// NOTE: Part of the dyn.Persister interface.
+func (p *dbDynPersister) FetchAcceptedProposal(_ context.Context,
+	chanID lnwire.ChannelID) (fn.Option[dyn.AcceptedProposal], error) {
+
+	stored, err := p.db.FetchDynAcceptedProposal(chanID)
+	if err != nil {
+		return fn.None[dyn.AcceptedProposal](), err
+	}
+
+	return fn.MapOption(func(s channeldb.DynAcceptedProposal,
+	) dyn.AcceptedProposal {
+
+		return dyn.AcceptedProposal{
+			Proposer:         s.Proposer,
+			Proposal:         s.Proposal,
+			NextCommitHeight: s.NextCommitHeight,
+			AckSig:           s.AckSig,
+			CommitSig:        s.CommitSig,
+		}
+	})(stored), nil
+}
+
+// DeleteAcceptedProposal removes any persisted context for the given channel.
+//
+// NOTE: Part of the dyn.Persister interface.
+func (p *dbDynPersister) DeleteAcceptedProposal(_ context.Context,
+	chanID lnwire.ChannelID) error {
+
+	return p.db.DeleteDynAcceptedProposal(chanID)
+}

--- a/htlcswitch/dyn_persister.go
+++ b/htlcswitch/dyn_persister.go
@@ -42,6 +42,7 @@ func (p *dbDynPersister) StoreAcceptedProposal(_ context.Context,
 		NextCommitHeight: prop.NextCommitHeight,
 		AckSig:           prop.AckSig,
 		CommitSig:        prop.CommitSig,
+		PartialSig:       prop.PartialSig,
 	})
 }
 
@@ -66,6 +67,7 @@ func (p *dbDynPersister) FetchAcceptedProposal(_ context.Context,
 			NextCommitHeight: s.NextCommitHeight,
 			AckSig:           s.AckSig,
 			CommitSig:        s.CommitSig,
+			PartialSig:       s.PartialSig,
 		}
 	})(stored), nil
 }

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -447,6 +447,13 @@ type channelLink struct {
 	// guarded on it being non-nil so non-dyn channels are unaffected.
 	updater *dyn.Updater
 
+	// dynPersister is the durable, channeldb-backed store for the
+	// accepted-proposal context of an in-flight dynamic-commitments
+	// negotiation. It is the same instance the updater persists through, and
+	// is consulted directly on reconnect (see handleDynReestablish). It is
+	// nil whenever updater is nil, so non-dyn channels never touch it.
+	dynPersister dyn.Persister
+
 	// dynProposalReqs carries locally-initiated dynamic-commitments
 	// proposal requests into the htlcManager event loop. It is only ever fed
 	// by InitDynProposal, which errors out when the feature is not enabled.
@@ -1119,6 +1126,17 @@ func (l *channelLink) syncChanStates(ctx context.Context) error {
 		if len(msgsToReSend) > 0 {
 			l.log.Infof("sending %v updates to synchronize the "+
 				"state", len(msgsToReSend))
+		}
+
+		// Apply the dynamic-commitments reconnect rules to any
+		// negotiation that was in flight across the disconnect. This is
+		// a no-op for non-dyn channels and never affects the normal
+		// commitment retransmission handled above.
+		if err := l.handleDynReestablish(
+			ctx, remoteChanSyncMsg,
+		); err != nil {
+
+			return err
 		}
 
 		// If we have any messages to retransmit, we'll do so

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -1130,12 +1130,15 @@ func (l *channelLink) syncChanStates(ctx context.Context) error {
 
 		// Apply the dynamic-commitments reconnect rules to any
 		// negotiation that was in flight across the disconnect. This is
-		// a no-op for non-dyn channels and never affects the normal
-		// commitment retransmission handled above.
-		if err := l.handleDynReestablish(
-			ctx, remoteChanSyncMsg,
-		); err != nil {
-
+		// a no-op for non-dyn channels; for a dyn channel that must
+		// retransmit a persisted dyn_commit_sig it folds the split
+		// dyn_commit + commitment_signed above into the bundled
+		// dyn_commit_sig the peer expects, leaving all other
+		// retransmission untouched.
+		msgsToReSend, err = l.handleDynReestablish(
+			ctx, remoteChanSyncMsg, msgsToReSend,
+		)
+		if err != nil {
 			return err
 		}
 

--- a/htlcswitch/link_dyn.go
+++ b/htlcswitch/link_dyn.go
@@ -604,12 +604,41 @@ func (l *channelLink) driveDynProposerCommit(ctx context.Context,
 	}
 
 	// Record that we have sent the bundled dyn_commit_sig, moving the state
-	// machine to its committing terminal state.
-	if _, err := l.updater.MarkCommitSent(ctx); err != nil {
+	// machine to its committing terminal state. MarkCommitSent persists the
+	// real commitment signature we just sent (the ECDSA CommitSig for a
+	// non-taproot channel or the taproot PartialSig) so a disconnect after
+	// this point resolves to retransmit rather than forget the negotiation.
+	commitSig, partialSig := dynCommitSigOptions(
+		newCommit.CommitSig, newCommit.PartialSig,
+	)
+	if _, err := l.updater.MarkCommitSent(
+		ctx, commitSig, partialSig,
+	); err != nil {
+
 		return fmt.Errorf("mark commit sent: %w", err)
 	}
 
 	return nil
+}
+
+// dynCommitSigOptions splits a commitment signature into the ECDSA and taproot
+// partial-signature option forms the dyn negotiation state machine persists. A
+// taproot channel produces a partial_signature_with_nonce and a blank ECDSA
+// signature, so the partial form is returned and the ECDSA form is absent;
+// otherwise the ECDSA signature is returned and the partial form is absent.
+func dynCommitSigOptions(commitSig lnwire.Sig,
+	partial lnwire.OptPartialSigWithNonceTLV) (fn.Option[lnwire.Sig],
+	fn.Option[lnwire.PartialSigWithNonce]) {
+
+	var ps fn.Option[lnwire.PartialSigWithNonce]
+	partial.WhenSome(func(r lnwire.PartialSigWithNonceTLV) {
+		ps = fn.Some(r.Val)
+	})
+	if ps.IsSome() {
+		return fn.None[lnwire.Sig](), ps
+	}
+
+	return fn.Some(commitSig), fn.None[lnwire.PartialSigWithNonce]()
 }
 
 // driveDynResponderCommit executes the responder side of the bundled
@@ -654,9 +683,22 @@ func (l *channelLink) driveDynResponderCommit(ctx context.Context,
 	// commitment using the channel's existing nonce state for taproot, and
 	// the ECDSA sig otherwise.
 	//
-	// The accepted proposal TLVs and dyn_ack signature were already persisted
-	// by the negotiation state machine at accept time; durable persistence of
-	// the received dyn_commit_sig for reconnect resume is branch 9.
+	// Before we send our revoke_and_ack, durably persist the received
+	// dyn_commit_sig (its ECDSA or taproot partial form). The extension BOLT
+	// requires the receiver to persist the received dyn_commit_sig before
+	// revoke_and_ack so a reconnect resolves to resume rather than forget the
+	// locked-in update. The accepted proposal TLVs and dyn_ack signature were
+	// already persisted by the negotiation state machine at accept time.
+	commitSig, partialSig := dynCommitSigOptions(
+		dynCommit.CommitSig, dynCommit.PartialSig,
+	)
+	if err := l.updater.RecordCommitReceived(
+		ctx, commitSig, partialSig,
+	); err != nil {
+
+		return fmt.Errorf("record received dyn_commit_sig: %w", err)
+	}
+
 	return l.processRemoteCommitSig(ctx, &lnwire.CommitSig{
 		ChanID:     l.ChanID(),
 		CommitSig:  dynCommit.CommitSig,

--- a/htlcswitch/link_dyn.go
+++ b/htlcswitch/link_dyn.go
@@ -519,11 +519,10 @@ type dynDance struct {
 // apply the params and exit quiescence at the termination point (once both
 // chains have locked in).
 //
-// What remains for the reestablish branch (branch 9): retransmitting the
-// bundled dyn_commit_sig when a peer's channel_reestablish expects it,
-// forgetting a negotiation that disconnects before dyn_commit_sig, and durably
-// persisting the bundled sig so the dance survives a restart. Those are out of
-// scope here.
+// A disconnect mid-dance is recovered by handleDynReestablish: the persisted
+// dyn_commit_sig is retransmitted when the peer's channel_reestablish still
+// expects it, a pre-dyn_commit_sig negotiation is forgotten, and the in-flight
+// dance is restored so the params still apply once both chains lock in.
 func (l *channelLink) handleDynCommitHandoff(ctx context.Context,
 	h dyn.CommitHandoff) error {
 
@@ -781,6 +780,14 @@ func (l *channelLink) applyDynParams(h dyn.CommitHandoff,
 // syncChanStates with the peer's channel_reestablish so the peer's next
 // expected commitment height is known.
 //
+// It takes the set of messages ProcessChanSyncMsg already computed for
+// retransmission and returns a possibly-modified set. When a persisted
+// dyn_commit_sig must be retransmitted it folds the split
+// dyn_commit + commitment_signed that ProcessChanSyncMsg reconstructed for the
+// dyn commit height into a single bundled dyn_commit_sig, so the peer receives
+// exactly one commitment_signed equivalent (the dyn_commit_sig) for that
+// height. Every other case returns the set unchanged.
+//
 // Non-dyn channels never mount an updater or a persister, so this is a
 // no-op for them and normal commitment_signed / revoke_and_ack
 // retransmission (driven by ProcessChanSyncMsg in syncChanStates) is
@@ -789,25 +796,26 @@ func (l *channelLink) applyDynParams(h dyn.CommitHandoff,
 // NOTE: MUST be called from syncChanStates before the link starts its normal
 // event loop.
 func (l *channelLink) handleDynReestablish(ctx context.Context,
-	remoteSync *lnwire.ChannelReestablish) error {
+	remoteSync *lnwire.ChannelReestablish,
+	msgsToReSend []lnwire.Message) ([]lnwire.Message, error) {
 
 	// The feature is inert for this channel: nothing was ever persisted, so
 	// there is nothing to resume or forget.
 	if l.updater == nil || l.dynPersister == nil {
-		return nil
+		return msgsToReSend, nil
 	}
 
 	chanID := l.ChanID()
 
 	persisted, err := l.dynPersister.FetchAcceptedProposal(ctx, chanID)
 	if err != nil {
-		return fmt.Errorf("fetch dyn proposal for ChannelID(%v): %w",
-			chanID, err)
+		return nil, fmt.Errorf("fetch dyn proposal for "+
+			"ChannelID(%v): %w", chanID, err)
 	}
 
 	// No negotiation was in flight across the disconnect; nothing to do.
 	if persisted.IsNone() {
-		return nil
+		return msgsToReSend, nil
 	}
 	p := persisted.UnsafeFromSome()
 
@@ -825,7 +833,7 @@ func (l *channelLink) handleDynReestablish(ctx context.Context,
 	// start a new negotiation later. No dyn message is retransmitted.
 	case dyn.ReconnectForget:
 		if err := l.updater.Reset(ctx); err != nil {
-			return fmt.Errorf("reset dyn updater for "+
+			return nil, fmt.Errorf("reset dyn updater for "+
 				"ChannelID(%v): %w", chanID, err)
 		}
 
@@ -835,59 +843,141 @@ func (l *channelLink) handleDynReestablish(ctx context.Context,
 	// handled correctly. We do not proactively resend the dyn_ack.
 	case dyn.ReconnectRetainAndWait:
 		if err := l.updater.Restore(ctx, p); err != nil {
-			return fmt.Errorf("restore dyn updater for "+
+			return nil, fmt.Errorf("restore dyn updater for "+
 				"ChannelID(%v): %w", chanID, err)
 		}
 
 	// We are the proposer and a dyn_commit_sig was persisted that the peer
-	// has not yet processed. Rehydrate the machine and retransmit the
-	// bundled dyn_commit_sig before any other update.
+	// has not yet processed. Rehydrate the machine, restore the in-flight
+	// dance so the params still apply once both chains lock in, and fold the
+	// split dyn_commit + commitment_signed ProcessChanSyncMsg reconstructed
+	// for this height into the bundled dyn_commit_sig the peer expects.
 	//
-	// TODO(dyn): the retransmission itself and the commitment-number
-	// accounting depend on the branch-6 commitment dance that produces and
-	// persists dyn_commit_sig, which is not complete on the branch this is
-	// stacked on. The concrete remaining sub-steps are:
-	//
-	//  1. Reconstruct the bundled lnwire.DynCommit from the persisted
-	//     context (p.Proposal, p.AckSig, p.CommitSig) and send it via
-	//     l.cfg.Peer before the normal msgsToReSend loop in syncChanStates,
-	//     so it precedes any other update even though quiescence has ended.
-	//  2. Count the sent dyn_commit_sig as the commitment_signed for the
-	//     responder's next_commitment_number so ProcessChanSyncMsg does not
-	//     also retransmit a bare commitment_signed for the same height, and
-	//     so the revocation accounting (next_revocation_number) lines up.
-	//  3. Apply the params at lock-in and clear the persisted context once
-	//     both chains have locked in (see handleDynCommitHandoff).
-	//
-	// Until the dance lands, p.CommitSig is always None in the live flow, so
-	// Decide never returns this action in production; it is exercised only by
-	// unit tests that inject a CommitSig. We still rehydrate the machine so
-	// the structure is complete and correct.
+	// ProcessChanSyncMsg already performed the commitment-number accounting:
+	// it detected that we owe the peer the commitment at p.NextCommitHeight
+	// (the dyn_commit_sig height) and reconstructed the commitment_signed for
+	// it (re-signing the musig2 partial sig against the peer's fresh nonce
+	// for taproot channels). We reuse that signature verbatim, so the
+	// dyn_commit_sig is counted as the commitment_signed for the peer's
+	// next_commitment_number and the revocation accounting lines up, exactly
+	// as a bare commitment_signed retransmission would.
 	case dyn.ReconnectRetransmitCommitSig:
 		if err := l.updater.Restore(ctx, p); err != nil {
-			return fmt.Errorf("restore dyn updater for "+
+			return nil, fmt.Errorf("restore dyn updater for "+
 				"ChannelID(%v): %w", chanID, err)
 		}
 
-		l.log.Warnf("Dyn dyn_commit_sig retransmission for "+
-			"ChannelID(%v) is not yet wired to the commitment "+
-			"dance; skipping resend", chanID)
+		l.restoreDynDance(p)
+
+		msgsToReSend, err = l.bundleDynCommitResend(p, msgsToReSend)
+		if err != nil {
+			return nil, err
+		}
 
 	// The dyn_commit_sig has already been processed by the peer (or received
 	// by us as the responder): the update is locked in and the remainder of
 	// the dance is covered by normal commitment retransmission. Rehydrate the
-	// machine to its committing state.
+	// machine to its committing state and restore the in-flight dance so the
+	// agreed params still apply once both chains lock in.
 	//
-	// TODO(dyn): clearing the persisted context and applying the params at
-	// lock-in depend on the branch-6 dance (see handleDynCommitHandoff).
+	// TODO(dyn): a crash after both chains locked in but before
+	// maybeFinishDynDance ran (applying the params and deleting the persisted
+	// context) leaves the channel already clean on reconnect, so no further
+	// commitment_signed / revoke_and_ack arrives to drive maybeFinishDynDance
+	// and apply the params. Proactively finishing an already-clean restored
+	// dance here would have to reconcile with quiescence restoration, which
+	// is not modeled across a restart yet; it is deferred to the quiescence
+	// persistence work.
 	case dyn.ReconnectResume:
 		if err := l.updater.Restore(ctx, p); err != nil {
-			return fmt.Errorf("restore dyn updater for "+
+			return nil, fmt.Errorf("restore dyn updater for "+
 				"ChannelID(%v): %w", chanID, err)
 		}
+
+		l.restoreDynDance(p)
 	}
 
-	return nil
+	return msgsToReSend, nil
+}
+
+// restoreDynDance rebuilds the in-flight commitment-dance state from a
+// persisted accepted proposal after a reconnect, so maybeFinishDynDance applies
+// the agreed params (and records the commit-chain epoch) once both chains lock
+// in. The pendingDynDance is in-memory only, so it is lost on any disconnect; a
+// negotiation whose dyn_commit_sig was persisted must restore it to complete.
+// ReceivedCommit is left None: it is only consumed while first driving the
+// responder side, which has already happened for any restored dance.
+func (l *channelLink) restoreDynDance(p dyn.AcceptedProposal) {
+	lockInHeight := p.NextCommitHeight - 1
+	l.pendingDynDance = fn.Some(dynDance{
+		handoff: dyn.CommitHandoff{
+			Proposer:         p.Proposer,
+			Params:           p.Params(),
+			Proposal:         p.Proposal,
+			NextCommitHeight: p.NextCommitHeight,
+			AckSig:           p.AckSig.UnwrapOr(lnwire.Sig{}),
+		},
+		lockIn: lntypes.Dual[uint64]{
+			Local:  lockInHeight,
+			Remote: lockInHeight,
+		},
+	})
+}
+
+// bundleDynCommitResend folds the split dyn_commit and commitment_signed that
+// ProcessChanSyncMsg reconstructed for the dyn commit height into the single
+// bundled dyn_commit_sig the peer expects, and drops the now-redundant bare
+// commitment_signed from the retransmission set. The commitment signature
+// (ECDSA or the freshly re-signed taproot partial) is taken from the
+// commitment_signed ProcessChanSyncMsg produced; the echoed dyn_ack signature
+// comes from the persisted context. It errors if the expected messages are
+// absent, rather than resend a malformed dyn_commit_sig.
+func (l *channelLink) bundleDynCommitResend(p dyn.AcceptedProposal,
+	msgs []lnwire.Message) ([]lnwire.Message, error) {
+
+	dynIdx, sigIdx := -1, -1
+	for i, m := range msgs {
+		switch m.(type) {
+		case *lnwire.DynCommit:
+			if dynIdx == -1 {
+				dynIdx = i
+			}
+
+		case *lnwire.CommitSig:
+			if sigIdx == -1 {
+				sigIdx = i
+			}
+		}
+	}
+	if dynIdx == -1 || sigIdx == -1 {
+		return nil, fmt.Errorf("dyn retransmit for ChannelID(%v) "+
+			"expected a dyn_commit and commitment_signed in the "+
+			"resend set, got %d messages", l.ChanID(), len(msgs))
+	}
+
+	//nolint:forcetypeassert
+	dynCommit := msgs[dynIdx].(*lnwire.DynCommit)
+	//nolint:forcetypeassert
+	commitSig := msgs[sigIdx].(*lnwire.CommitSig)
+
+	// Bundle the (possibly re-signed) commitment signature and the echoed
+	// dyn_ack signature into the dyn_commit_sig.
+	dynCommit.CommitSig = commitSig.CommitSig
+	dynCommit.PartialSig = commitSig.PartialSig
+	ackSig, err := p.AckSig.UnwrapOrErr(fmt.Errorf(
+		"dyn retransmit for ChannelID(%v) missing persisted dyn_ack "+
+			"signature", l.ChanID()))
+	if err != nil {
+		return nil, err
+	}
+	dynCommit.AckSig = ackSig
+
+	l.log.Infof("Retransmitting bundled dyn_commit_sig for ChannelID(%v) "+
+		"at height %d", l.ChanID(), p.NextCommitHeight)
+
+	// Drop the bare commitment_signed; its signature now rides the bundled
+	// dyn_commit_sig which remains in place at its original position.
+	return append(msgs[:sigIdx], msgs[sigIdx+1:]...), nil
 }
 
 // dynFailf fails the link on a dynamic-commitments protocol violation. As with

--- a/htlcswitch/link_dyn.go
+++ b/htlcswitch/link_dyn.go
@@ -242,19 +242,18 @@ func (v *dynChannelView) HasPendingSpliceOrRBF() bool {
 }
 
 // newDynUpdater constructs the dyn.Updater for this link, wiring the concrete
-// adapters over the live link/channel/peer objects. The Persister is the
-// in-memory reference implementation for now; durable channeldb persistence and
-// the reconnect logic land in the reestablish branch.
+// adapters over the live link/channel/peer objects. It uses a durable,
+// channeldb-backed Persister so accepted-proposal context survives a restart
+// and drives the reconnect resume/forget decisions in handleDynReestablish. The
+// same Persister instance is cached on the link so the reestablish path can
+// consult it directly.
 func (l *channelLink) newDynUpdater() *dyn.Updater {
+	l.dynPersister = newDBDynPersister(l.channel.State().Db)
+
 	return dyn.NewUpdater(dyn.Config{
-		Signer:      l.cfg.DynAckSigner,
-		ChannelView: &dynChannelView{link: l},
-
-		// TODO(dyn): branch 8 replaces this with a channeldb-backed
-		// Persister so accepted-proposal context survives a restart and
-		// drives reconnect resume/forget decisions.
-		Persister: dyn.NewMemPersister(),
-
+		Signer:           l.cfg.DynAckSigner,
+		ChannelView:      &dynChannelView{link: l},
+		Persister:        l.dynPersister,
 		Sender:           &dynMessageSender{peer: l.cfg.Peer},
 		Clock:            clock.NewDefaultClock(),
 		MaxLocalCSVDelay: l.dynMaxCSVDelay(),
@@ -730,6 +729,123 @@ func (l *channelLink) applyDynParams(h dyn.CommitHandoff,
 	return l.channel.ApplyChannelParams(
 		h.Proposer, h.Params, l.dynMaxCSVDelay(), lockIn,
 	)
+}
+
+// handleDynReestablish applies the dynamic-commitments reconnect rules on
+// channel reestablishment. It consults the durable accepted-proposal context
+// and, per the locked design decisions, either forgets a stale negotiation,
+// retains a responder acceptance and waits, retransmits a persisted
+// dyn_commit_sig, or resumes a locked-in update. It is driven from
+// syncChanStates with the peer's channel_reestablish so the peer's next
+// expected commitment height is known.
+//
+// Non-dyn channels never mount an updater or a persister, so this is a
+// no-op for them and normal commitment_signed / revoke_and_ack
+// retransmission (driven by ProcessChanSyncMsg in syncChanStates) is
+// entirely unaffected.
+//
+// NOTE: MUST be called from syncChanStates before the link starts its normal
+// event loop.
+func (l *channelLink) handleDynReestablish(ctx context.Context,
+	remoteSync *lnwire.ChannelReestablish) error {
+
+	// The feature is inert for this channel: nothing was ever persisted, so
+	// there is nothing to resume or forget.
+	if l.updater == nil || l.dynPersister == nil {
+		return nil
+	}
+
+	chanID := l.ChanID()
+
+	persisted, err := l.dynPersister.FetchAcceptedProposal(ctx, chanID)
+	if err != nil {
+		return fmt.Errorf("fetch dyn proposal for ChannelID(%v): %w",
+			chanID, err)
+	}
+
+	// No negotiation was in flight across the disconnect; nothing to do.
+	if persisted.IsNone() {
+		return nil
+	}
+	p := persisted.UnsafeFromSome()
+
+	reest := dyn.ReestablishState{
+		PeerNextCommitHeight: remoteSync.NextLocalCommitHeight,
+	}
+	action := dyn.Decide(p, reest)
+
+	l.log.Infof("Dyn reconnect for ChannelID(%v): proposer=%v, height=%d, "+
+		"action=%s", chanID, p.Proposer, p.NextCommitHeight, action)
+
+	switch action {
+	// Abort and forget the negotiation: delete the persisted context and
+	// return the state machine to Idle so a fresh quiescence session can
+	// start a new negotiation later. No dyn message is retransmitted.
+	case dyn.ReconnectForget:
+		if err := l.updater.Reset(ctx); err != nil {
+			return fmt.Errorf("reset dyn updater for "+
+				"ChannelID(%v): %w", chanID, err)
+		}
+
+	// We are the responder and sent our dyn_ack before the disconnect.
+	// Retain the acceptance by rehydrating the updater to AckSent so that a
+	// subsequent dyn_commit_sig (or a superseding proposal, or a timeout) is
+	// handled correctly. We do not proactively resend the dyn_ack.
+	case dyn.ReconnectRetainAndWait:
+		if err := l.updater.Restore(ctx, p); err != nil {
+			return fmt.Errorf("restore dyn updater for "+
+				"ChannelID(%v): %w", chanID, err)
+		}
+
+	// We are the proposer and a dyn_commit_sig was persisted that the peer
+	// has not yet processed. Rehydrate the machine and retransmit the
+	// bundled dyn_commit_sig before any other update.
+	//
+	// TODO(dyn): the retransmission itself and the commitment-number
+	// accounting depend on the branch-6 commitment dance that produces and
+	// persists dyn_commit_sig, which is not complete on the branch this is
+	// stacked on. The concrete remaining sub-steps are:
+	//
+	//  1. Reconstruct the bundled lnwire.DynCommit from the persisted
+	//     context (p.Proposal, p.AckSig, p.CommitSig) and send it via
+	//     l.cfg.Peer before the normal msgsToReSend loop in syncChanStates,
+	//     so it precedes any other update even though quiescence has ended.
+	//  2. Count the sent dyn_commit_sig as the commitment_signed for the
+	//     responder's next_commitment_number so ProcessChanSyncMsg does not
+	//     also retransmit a bare commitment_signed for the same height, and
+	//     so the revocation accounting (next_revocation_number) lines up.
+	//  3. Apply the params at lock-in and clear the persisted context once
+	//     both chains have locked in (see handleDynCommitHandoff).
+	//
+	// Until the dance lands, p.CommitSig is always None in the live flow, so
+	// Decide never returns this action in production; it is exercised only by
+	// unit tests that inject a CommitSig. We still rehydrate the machine so
+	// the structure is complete and correct.
+	case dyn.ReconnectRetransmitCommitSig:
+		if err := l.updater.Restore(ctx, p); err != nil {
+			return fmt.Errorf("restore dyn updater for "+
+				"ChannelID(%v): %w", chanID, err)
+		}
+
+		l.log.Warnf("Dyn dyn_commit_sig retransmission for "+
+			"ChannelID(%v) is not yet wired to the commitment "+
+			"dance; skipping resend", chanID)
+
+	// The dyn_commit_sig has already been processed by the peer (or received
+	// by us as the responder): the update is locked in and the remainder of
+	// the dance is covered by normal commitment retransmission. Rehydrate the
+	// machine to its committing state.
+	//
+	// TODO(dyn): clearing the persisted context and applying the params at
+	// lock-in depend on the branch-6 dance (see handleDynCommitHandoff).
+	case dyn.ReconnectResume:
+		if err := l.updater.Restore(ctx, p); err != nil {
+			return fmt.Errorf("restore dyn updater for "+
+				"ChannelID(%v): %w", chanID, err)
+		}
+	}
+
+	return nil
 }
 
 // dynFailf fails the link on a dynamic-commitments protocol violation. As with

--- a/htlcswitch/link_dyn_test.go
+++ b/htlcswitch/link_dyn_test.go
@@ -723,7 +723,7 @@ func TestChannelLinkDynProposerTaproot(t *testing.T) {
 	bobHeightBefore := bob.State().LocalCommitment.CommitHeight
 
 	// Request a local proposal. This drives quiescence first.
-	errCh := coreLink.initDynProposal(dyn.ProposalRequest{Params: params})
+	errCh := coreLink.InitDynProposal(dyn.ProposalRequest{Params: params})
 
 	// The link should send its Stfu as the quiescence initiator.
 	msg := recvLinkMsg(t, msgs)

--- a/htlcswitch/link_dyn_test.go
+++ b/htlcswitch/link_dyn_test.go
@@ -1,6 +1,7 @@
 package htlcswitch
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -833,4 +834,293 @@ func TestChannelLinkDynProposerTaproot(t *testing.T) {
 	// Quiescence was exited so htlc traffic can resume.
 	require.False(t, coreLink.quiescer.IsQuiescent(),
 		"channel should no longer be quiescent")
+}
+
+// dynLinkTestSig returns a well-formed ECDSA signature for injecting a
+// persisted accepted-proposal context in the reestablish tests, where the
+// content of the signature is not itself under test.
+func dynLinkTestSig(t *testing.T) lnwire.Sig {
+	t.Helper()
+
+	priv, _ := btcec.PrivKeyFromBytes(alicePrivKey)
+	sig, err := lnwire.SignDynAck(
+		priv, chainhash.Hash{}, lnwire.ChannelID{}, 0, []byte{0x00},
+	)
+	require.NoError(t, err)
+
+	return sig
+}
+
+// driveDynProposerToCommitSent drives the proposer path from a local proposal
+// request through the bundled dyn_commit_sig send, returning the dyn_commit_sig
+// the link emitted. On return the link has signed the responder's next
+// commitment (advancing the remote commitment chain) and durably persisted the
+// sent commitment signature, exactly the state a proposer is in when a
+// disconnect strikes after dyn_commit_sig but before the responder's
+// revoke_and_ack. It works for both non-taproot and taproot channels.
+func driveDynProposerToCommitSent(t *testing.T, harness singleLinkTestHarness,
+	coreLink *channelLink, msgs chan lnwire.Message) *lnwire.DynCommit {
+
+	t.Helper()
+
+	bob := harness.bobChannel
+	chanID := coreLink.ChanID()
+
+	params := lnwallet.ChannelParams{MaxAcceptedHtlcs: fn.Some(uint16(20))}
+
+	// Request a local proposal, which drives quiescence with us as the
+	// initiator.
+	errCh := coreLink.InitDynProposal(dyn.ProposalRequest{Params: params})
+
+	stfu, ok := recvLinkMsg(t, msgs).(*lnwire.Stfu)
+	require.True(t, ok, "expected Stfu")
+	require.True(t, stfu.Initiator, "we should be the quiescence initiator")
+
+	coreLink.HandleChannelUpdate(&lnwire.Stfu{
+		ChanID:    chanID,
+		Initiator: false,
+	})
+
+	dp, ok := recvLinkMsg(t, msgs).(*lnwire.DynPropose)
+	require.True(t, ok, "expected DynPropose")
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for proposal result")
+	}
+
+	// The responder mirrors the update into its remote log and returns a
+	// valid dyn_ack over the exact proposal TLVs.
+	_, err := bob.ReceiveDynUpdate(params)
+	require.NoError(t, err, "bob unable to stage dyn update")
+
+	tlvs, err := dp.SerializeTlvData()
+	require.NoError(t, err)
+
+	bobNodePriv, _ := btcec.PrivKeyFromBytes(bobPrivKey)
+	height := coreLink.channel.State().LocalCommitment.CommitHeight + 1
+	ackSig, err := lnwire.SignDynAck(
+		bobNodePriv, coreLink.channel.State().ChainHash, chanID, height,
+		tlvs,
+	)
+	require.NoError(t, err)
+
+	coreLink.HandleChannelUpdate(&lnwire.DynAck{
+		ChanID: chanID,
+		Sig:    ackSig,
+	})
+
+	// The valid ack triggers the bundled dyn_commit_sig.
+	dc, ok := recvLinkMsg(t, msgs).(*lnwire.DynCommit)
+	require.True(t, ok, "expected DynCommit from link")
+
+	// The link sends the dyn_commit_sig before it records and persists the
+	// sent signature (MarkCommitSent), so wait for the state machine to
+	// reach its committing terminal state, at which point the send has been
+	// durably persisted.
+	require.Eventually(t, func() bool {
+		return coreLink.updater.State() == dyn.StateCommitting
+	}, 5*time.Second, 10*time.Millisecond, "commit-sent not recorded")
+
+	return dc
+}
+
+// assertDynCommitResent runs the reconnect handling for a proposer that has a
+// persisted dyn_commit_sig the peer has not yet processed, and asserts the
+// retransmission set is exactly the bundled dyn_commit_sig (echoing the sent
+// signatures) with no bare commitment_signed. It simulates a fresh link on
+// reconnect so the durable Restore + dance-restore path is exercised.
+func assertDynCommitResent(t *testing.T, coreLink *channelLink,
+	bob *lnwallet.LightningChannel, dc *lnwire.DynCommit) {
+
+	t.Helper()
+
+	ctx := context.Background()
+
+	// The sent dyn_commit_sig must have been durably persisted.
+	persisted, err := coreLink.dynPersister.FetchAcceptedProposal(
+		ctx, coreLink.ChanID(),
+	)
+	require.NoError(t, err)
+	require.True(t, persisted.IsSome())
+	require.True(t, persisted.UnsafeFromSome().HasCommitSig())
+
+	// A reconnect tears the link down and builds a new one before
+	// syncChanStates runs, so stop the event loop before mutating the link's
+	// dyn state to mirror that (and to avoid racing the running goroutine).
+	coreLink.Stop()
+
+	// Simulate a fresh link on reconnect: the in-memory updater and pending
+	// dance are gone, only the persisted context survives.
+	coreLink.updater = coreLink.newDynUpdater()
+	coreLink.pendingDynDance = fn.None[dynDance]()
+	require.Equal(t, dyn.StateIdle, coreLink.updater.State())
+
+	// A reconnect builds a fresh channel with a fresh verification nonce; the
+	// in-memory channel consumed its nonce driving the dance, so regenerate
+	// it to mirror a taproot reconnect before processing the peer's sync.
+	if coreLink.channel.State().ChanType.IsTaproot() {
+		_, err = coreLink.channel.GenMusigNonces()
+		require.NoError(t, err)
+	}
+
+	// The peer reconnects; it never processed our dyn_commit_sig, so it
+	// still expects the commitment at that height.
+	bobSync, err := bob.State().ChanSyncMsg()
+	require.NoError(t, err)
+
+	msgsToReSend, _, _, err := coreLink.channel.ProcessChanSyncMsg(
+		ctx, bobSync,
+	)
+	require.NoError(t, err)
+
+	out, err := coreLink.handleDynReestablish(ctx, bobSync, msgsToReSend)
+	require.NoError(t, err)
+
+	// Exactly one bundled dyn_commit_sig is retransmitted; no bare
+	// commitment_signed rides alongside it.
+	require.Len(t, out, 1, "expected a single bundled dyn_commit_sig")
+	resent, ok := out[0].(*lnwire.DynCommit)
+	require.True(t, ok, "expected DynCommit in resend set")
+
+	// It echoes our dyn_ack and carries the commitment signature (ECDSA or
+	// the re-signed taproot partial), and preserves the accepted proposal.
+	require.Equal(t, dc.AckSig, resent.AckSig)
+	require.Equal(t, dc.CommitSig, resent.CommitSig)
+	require.Equal(t, dc.PartialSig.IsSome(), resent.PartialSig.IsSome())
+
+	wantTLV, err := dc.DynPropose.SerializeTlvData()
+	require.NoError(t, err)
+	gotTLV, err := resent.DynPropose.SerializeTlvData()
+	require.NoError(t, err)
+	require.Equal(t, wantTLV, gotTLV)
+
+	// The updater was rehydrated to the committing state and the in-flight
+	// dance restored so the agreed params still apply once both chains lock
+	// in.
+	require.Equal(t, dyn.StateCommitting, coreLink.updater.State())
+	require.True(t, coreLink.pendingDynDance.IsSome())
+}
+
+// TestChannelLinkDynReestablishRetransmit verifies that after a completed
+// dyn_commit_sig send, a reconnect whose channel_reestablish still expects that
+// commitment triggers a retransmission of the bundled dyn_commit_sig, folding
+// the split dyn_commit + commitment_signed ProcessChanSyncMsg reconstructs into
+// the single message the peer expects.
+func TestChannelLinkDynReestablishRetransmit(t *testing.T) {
+	t.Parallel()
+
+	harness, coreLink, msgs := newDynLinkHarness(t)
+
+	dc := driveDynProposerToCommitSent(t, harness, coreLink, msgs)
+	require.True(t, dc.PartialSig.IsNone(),
+		"non-taproot dyn_commit_sig must be ECDSA")
+
+	assertDynCommitResent(t, coreLink, harness.bobChannel, dc)
+}
+
+// TestChannelLinkDynReestablishRetransmitTaproot is the taproot variant of
+// TestChannelLinkDynReestablishRetransmit: the retransmitted dyn_commit_sig
+// carries a musig2 partial_signature_with_nonce, re-signed against the peer's
+// fresh reestablish nonce by ProcessChanSyncMsg.
+func TestChannelLinkDynReestablishRetransmitTaproot(t *testing.T) {
+	t.Parallel()
+
+	harness, coreLink, msgs := newDynLinkHarness(
+		t, channeldb.SimpleTaprootFeatureBit,
+	)
+	require.True(t, coreLink.channel.State().ChanType.IsTaproot(),
+		"expected a taproot channel")
+
+	dc := driveDynProposerToCommitSent(t, harness, coreLink, msgs)
+	require.True(t, dc.PartialSig.IsSome(),
+		"taproot dyn_commit_sig must carry a partial sig")
+
+	assertDynCommitResent(t, coreLink, harness.bobChannel, dc)
+}
+
+// TestChannelLinkDynReestablishForget verifies that on reconnect a proposer
+// negotiation that never reached dyn_commit_sig is forgotten: the persisted
+// context is deleted, the updater returns to Idle, and nothing is resent.
+func TestChannelLinkDynReestablishForget(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	_, coreLink, _ := newDynLinkHarness(t)
+	chanID := coreLink.ChanID()
+
+	// Persist a proposer context that received its dyn_ack but never sent a
+	// dyn_commit_sig.
+	params := lnwallet.ChannelParams{DustLimit: fn.Some(dynTestDust)}
+	prop := dyn.AcceptedProposal{
+		Proposer:         lntypes.Local,
+		Proposal:         params.ToDynPropose(chanID),
+		NextCommitHeight: 5,
+		AckSig:           fn.Some(dynLinkTestSig(t)),
+		CommitSig:        fn.None[lnwire.Sig](),
+		PartialSig:       fn.None[lnwire.PartialSigWithNonce](),
+	}
+	require.NoError(t, coreLink.dynPersister.StoreAcceptedProposal(
+		ctx, chanID, prop,
+	))
+
+	remoteSync := &lnwire.ChannelReestablish{
+		ChanID:                chanID,
+		NextLocalCommitHeight: 5,
+	}
+	out, err := coreLink.handleDynReestablish(ctx, remoteSync, nil)
+	require.NoError(t, err)
+	require.Empty(t, out, "a forgotten negotiation retransmits nothing")
+
+	// The persisted context is gone, the updater is Idle, and no dance is
+	// pending.
+	got, err := coreLink.dynPersister.FetchAcceptedProposal(ctx, chanID)
+	require.NoError(t, err)
+	require.True(t, got.IsNone())
+	require.Equal(t, dyn.StateIdle, coreLink.updater.State())
+	require.True(t, coreLink.pendingDynDance.IsNone())
+}
+
+// TestChannelLinkDynReestablishRetainAndWait verifies that on reconnect a
+// responder that sent its dyn_ack (but has not received a dyn_commit_sig)
+// retains the acceptance and rehydrates the updater to AckSent, resending
+// nothing.
+func TestChannelLinkDynReestablishRetainAndWait(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	_, coreLink, _ := newDynLinkHarness(t)
+	chanID := coreLink.ChanID()
+
+	// Persist a responder context that sent its dyn_ack.
+	params := lnwallet.ChannelParams{DustLimit: fn.Some(dynTestDust)}
+	prop := dyn.AcceptedProposal{
+		Proposer:         lntypes.Remote,
+		Proposal:         params.ToDynPropose(chanID),
+		NextCommitHeight: 5,
+		AckSig:           fn.Some(dynLinkTestSig(t)),
+		CommitSig:        fn.None[lnwire.Sig](),
+		PartialSig:       fn.None[lnwire.PartialSigWithNonce](),
+	}
+	require.NoError(t, coreLink.dynPersister.StoreAcceptedProposal(
+		ctx, chanID, prop,
+	))
+
+	remoteSync := &lnwire.ChannelReestablish{
+		ChanID:                chanID,
+		NextLocalCommitHeight: 5,
+	}
+	out, err := coreLink.handleDynReestablish(ctx, remoteSync, nil)
+	require.NoError(t, err)
+	require.Empty(t, out, "a retained acceptance resends nothing itself")
+
+	// The acceptance is retained and the updater is rehydrated to AckSent.
+	got, err := coreLink.dynPersister.FetchAcceptedProposal(ctx, chanID)
+	require.NoError(t, err)
+	require.True(t, got.IsSome())
+	require.Equal(t, dyn.StateAckSent, coreLink.updater.State())
 }


### PR DESCRIPTION
Part of the Dynamic Commitments milestone: #60

Durable `dyn_commit_sig` persistence, reconnect decisions, and retransmission.

**Stacked PR** — based on `yy-dyn-8-rpc`; review after that branch (the base updates automatically as the parent merges).

Opened as a **draft**: this is part of the exploratory params-only stack (coarse commits, not final hygiene).