### PR TITLE
netann: dyn channel_flags announcement state

### DIFF
--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -270,6 +270,20 @@ type ChannelLinkConfig struct {
 	// be nil, in which case the re-emission is simply skipped.
 	NotifyChannelBackup func(*channeldb.OpenChannel)
 
+	// NotifyDynParamsLockIn reconciles the gossip/channel-announcement layer
+	// with a dynamic-commitments parameter update that has just locked in.
+	// It is invoked only on the dynamic-commitments apply path (see
+	// applyDynParams), after the params have been committed and persisted,
+	// with the channel_flags value from before the update, the proposer, and
+	// the agreed parameter change. The server wires it to a
+	// netann.DynAnnouncementManager, which handles public<->private
+	// conversion and channel_update realignment. Non-dynamic channels never
+	// reach this path, so ordinary gossip is byte-for-byte unaffected. It
+	// may be nil, in which case the reconciliation is simply skipped.
+	NotifyDynParamsLockIn func(chanPoint wire.OutPoint,
+		proposer lntypes.ChannelParty, oldFlags lnwire.FundingFlag,
+		params lnwallet.ChannelParams)
+
 	// HtlcNotifier is an instance of a htlcNotifier which we will pipe htlc
 	// events through.
 	HtlcNotifier htlcNotifier

--- a/htlcswitch/link_dyn.go
+++ b/htlcswitch/link_dyn.go
@@ -755,6 +755,16 @@ func (l *channelLink) maybeFinishDynDance(ctx context.Context) {
 	})
 }
 
+// NOTE on forwarding during the dyn execution window: a dyn update runs only
+// while the channel is quiescent, and the quiescer already halts forwarding for
+// the duration. eligibleToUpdate() (used on the HTLC add path) requires
+// l.quiescer.CanSendUpdates(), and handleDownstreamPkt bounces channel updates
+// while quiescent, so new HTLC adds are failed back for the whole execution
+// window with no extra machinery here. Forwarding is re-enabled when quiescence
+// is resumed at the BOLT-defined termination point (l.quiescer.Resume(), step 6
+// of handleDynCommitHandoff), i.e. after success or a safe failure. No separate
+// dyn-specific enable/disable is therefore needed.
+
 // applyDynParams applies an agreed dynamic-commitments parameter update to the
 // underlying channel at the point the given commitment chains lock in. It is
 // the "apply at lock-in" step of the commitment dance: it validates and
@@ -775,6 +785,11 @@ func (l *channelLink) maybeFinishDynDance(ctx context.Context) {
 func (l *channelLink) applyDynParams(h dyn.CommitHandoff,
 	lockIn lntypes.Dual[uint64]) error {
 
+	// Capture the announcement intent (channel_flags) before the update so
+	// the gossip layer can tell which way a public<->private conversion
+	// went. This is read before ApplyChannelParams overwrites it.
+	oldFlags := l.channel.State().ChannelFlags
+
 	if err := l.channel.ApplyChannelParams(
 		h.Proposer, h.Params, l.dynMaxCSVDelay(), lockIn,
 	); err != nil {
@@ -786,6 +801,20 @@ func (l *channelLink) applyDynParams(h dyn.CommitHandoff,
 	// channel-state changes so the exported/subscribed SCB is up to date.
 	if l.cfg.NotifyChannelBackup != nil {
 		l.cfg.NotifyChannelBackup(l.channel.ChannelState())
+	}
+
+	// Reconcile the gossip/channel-announcement layer with the committed
+	// params: drive any public<->private conversion the channel_flags change
+	// requires, and realign our advertised channel_update with the new
+	// inbound HTLC limits. The hook is fire-and-forget (it logs its own
+	// errors) so a gossip hiccup never rolls back a committed, persisted
+	// parameter update. It is only set for dyn-enabled channels, so ordinary
+	// gossip is unaffected.
+	if l.cfg.NotifyDynParamsLockIn != nil {
+		l.cfg.NotifyDynParamsLockIn(
+			l.channel.ChannelPoint(), h.Proposer, oldFlags,
+			h.Params,
+		)
 	}
 
 	return nil

--- a/htlcswitch/link_dyn_test.go
+++ b/htlcswitch/link_dyn_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/htlcswitch/dyn"
@@ -592,6 +593,77 @@ func TestChannelLinkDynParamsBackupNilSafe(t *testing.T) {
 
 	_, coreLink, _ := newDynLinkHarness(t)
 	coreLink.cfg.NotifyChannelBackup = nil
+
+	handoff := dyn.CommitHandoff{
+		Proposer: lntypes.Local,
+		Params: lnwallet.ChannelParams{
+			MaxAcceptedHtlcs: fn.Some(uint16(25)),
+		},
+	}
+	lockIn := lntypes.Dual[uint64]{Local: 0, Remote: 0}
+
+	require.NoError(t, coreLink.applyDynParams(handoff, lockIn))
+	require.Equal(t, uint16(25),
+		coreLink.channel.State().RemoteChanCfg.MaxAcceptedHtlcs)
+}
+
+// TestChannelLinkDynParamsNotifiesGossip verifies that a successful
+// apply-at-lock-in invokes the gossip-reconciliation hook with the pre-update
+// channel_flags, the proposer, and the agreed params, so the netann layer can
+// drive any public<->private conversion and channel_update realignment.
+func TestChannelLinkDynParamsNotifiesGossip(t *testing.T) {
+	t.Parallel()
+
+	_, coreLink, _ := newDynLinkHarness(t)
+
+	// Capture the arguments handed to the gossip-reconciliation hook.
+	var (
+		gossipCalls int
+		gotPoint    wire.OutPoint
+		gotProposer lntypes.ChannelParty
+		gotOldFlags lnwire.FundingFlag
+		gotParams   lnwallet.ChannelParams
+	)
+	coreLink.cfg.NotifyDynParamsLockIn = func(chanPoint wire.OutPoint,
+		proposer lntypes.ChannelParty, oldFlags lnwire.FundingFlag,
+		params lnwallet.ChannelParams) {
+
+		gossipCalls++
+		gotPoint = chanPoint
+		gotProposer = proposer
+		gotOldFlags = oldFlags
+		gotParams = params
+	}
+
+	// Record the channel_flags before the update so we can assert the hook
+	// observed the pre-update value.
+	oldFlags := coreLink.channel.State().ChannelFlags
+
+	handoff := dyn.CommitHandoff{
+		Proposer: lntypes.Local,
+		Params: lnwallet.ChannelParams{
+			MaxAcceptedHtlcs: fn.Some(uint16(25)),
+		},
+	}
+	lockIn := lntypes.Dual[uint64]{Local: 0, Remote: 0}
+
+	require.NoError(t, coreLink.applyDynParams(handoff, lockIn))
+
+	// The hook must have fired exactly once with the expected arguments.
+	require.Equal(t, 1, gossipCalls)
+	require.Equal(t, coreLink.channel.ChannelPoint(), gotPoint)
+	require.Equal(t, lntypes.Local, gotProposer)
+	require.Equal(t, oldFlags, gotOldFlags)
+	require.Equal(t, uint16(25), gotParams.MaxAcceptedHtlcs.UnwrapOr(0))
+}
+
+// TestChannelLinkDynParamsGossipNilSafe ensures the apply-at-lock-in step does
+// not panic and still succeeds when no gossip-reconciliation hook is wired.
+func TestChannelLinkDynParamsGossipNilSafe(t *testing.T) {
+	t.Parallel()
+
+	_, coreLink, _ := newDynLinkHarness(t)
+	coreLink.cfg.NotifyDynParamsLockIn = nil
 
 	handoff := dyn.CommitHandoff{
 		Proposer: lntypes.Local,

--- a/netann/channel_update.go
+++ b/netann/channel_update.go
@@ -54,6 +54,21 @@ func ChanUpdSetDisable(disabled bool) ChannelUpdateModifier {
 	}
 }
 
+// ChanUpdSetHtlcMinMax is a functional option that sets the advertised
+// htlc_minimum_msat and htlc_maximum_msat fields of the update, ensuring the
+// max-htlc message flag is set so the maximum is honored. It is used to realign
+// an advertised channel_update with a committed dynamic-commitments change to
+// the channel's inbound HTLC limits.
+func ChanUpdSetHtlcMinMax(htlcMin,
+	htlcMax lnwire.MilliSatoshi) ChannelUpdateModifier {
+
+	return func(update *lnwire.ChannelUpdate1) {
+		update.HtlcMinimumMsat = htlcMin
+		update.HtlcMaximumMsat = htlcMax
+		update.MessageFlags |= lnwire.ChanUpdateRequiredMaxHtlc
+	}
+}
+
 // ChanUpdSetTimestamp is a functional option that sets the timestamp of the
 // update to the current time, or increments it if the timestamp is already in
 // the future.

--- a/netann/dyn_announcement.go
+++ b/netann/dyn_announcement.go
@@ -1,0 +1,500 @@
+package netann
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/channeldb"
+	graphdb "github.com/lightningnetwork/lnd/graph/db"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnwallet"
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+var (
+	// ErrChanNotConfirmed is returned when a private->public conversion is
+	// attempted on a channel whose funding transaction does not yet have a
+	// confirmed short_channel_id. A channel_announcement is keyed by the
+	// confirmed SCID, so it cannot be produced before confirmation.
+	ErrChanNotConfirmed = errors.New("cannot make channel public: funding " +
+		"transaction has no confirmed short_channel_id")
+
+	// ErrScidAliasChannel is returned when a private->public conversion is
+	// attempted on an option_scid_alias channel. These channels deliberately
+	// use aliases instead of the real SCID, so publicly announcing them would
+	// leak the very SCID the type is meant to hide.
+	ErrScidAliasChannel = errors.New("cannot make channel public: " +
+		"option_scid_alias channels cannot be announced")
+
+	// ErrShutdownPending is returned when a private->public conversion is
+	// attempted while a cooperative shutdown is in progress on the channel.
+	// Announcing a channel that is being torn down would advertise a
+	// route that is about to disappear.
+	ErrShutdownPending = errors.New("cannot make channel public: a " +
+		"shutdown is pending on the channel")
+)
+
+// FlagsTransition classifies how a dynamic channel_flags update changes the
+// channel's public/private announcement intent. channel_flags is treated as a
+// channel-wide announcement intent, distinct from the per-direction
+// enable/disable policy bits carried in an ordinary channel_update.
+type FlagsTransition uint8
+
+const (
+	// FlagsUnchanged means the announcement intent (the FFAnnounceChannel
+	// bit) did not change.
+	FlagsUnchanged FlagsTransition = iota
+
+	// FlagsPrivateToPublic means the channel is being converted from a
+	// private channel into a publicly-announced one.
+	FlagsPrivateToPublic
+
+	// FlagsPublicToPrivate means the channel is being converted from a
+	// publicly-announced channel into a private one.
+	FlagsPublicToPrivate
+)
+
+// String returns a human-readable representation of the transition.
+func (t FlagsTransition) String() string {
+	switch t {
+	case FlagsUnchanged:
+		return "unchanged"
+	case FlagsPrivateToPublic:
+		return "private->public"
+	case FlagsPublicToPrivate:
+		return "public->private"
+	default:
+		return "unknown"
+	}
+}
+
+// ClassifyFlagsChange determines the announcement-intent transition implied by
+// a change from oldFlags to newFlags. Only the FFAnnounceChannel bit carries
+// announcement intent; changes to other bits do not affect the public/private
+// status.
+func ClassifyFlagsChange(oldFlags, newFlags lnwire.FundingFlag) FlagsTransition {
+	wasPublic := oldFlags&lnwire.FFAnnounceChannel != 0
+	isPublic := newFlags&lnwire.FFAnnounceChannel != 0
+
+	switch {
+	case !wasPublic && isPublic:
+		return FlagsPrivateToPublic
+
+	case wasPublic && !isPublic:
+		return FlagsPublicToPrivate
+
+	default:
+		return FlagsUnchanged
+	}
+}
+
+// CheckPrivateToPublic verifies that the given channel satisfies every
+// precondition for being converted from a private channel into a publicly
+// announced one. It returns a typed error (matchable with errors.Is) for the
+// first unmet precondition, or nil if the conversion may proceed.
+//
+// The preconditions mirror those the funding manager enforces for a channel
+// that is announced at open time:
+//
+//   - The funding transaction must have a confirmed short_channel_id. A
+//     channel_announcement is keyed by the confirmed SCID and cannot be built
+//     before confirmation (for a zero-conf channel this means the real SCID
+//     must have confirmed, not just the alias).
+//   - The channel type must not be option_scid_alias. Such channels only ever
+//     use aliases; announcing them would leak the real SCID.
+//   - Neither peer may have a cooperative shutdown in progress.
+func CheckPrivateToPublic(channel *channeldb.OpenChannel,
+	shutdownPending bool) error {
+
+	// The funding transaction must be confirmed so that a real SCID exists
+	// to key the channel_announcement by.
+	if channel.IsPending {
+		return ErrChanNotConfirmed
+	}
+
+	// A zero-conf channel opens against an alias SCID; its real SCID is only
+	// available once the funding transaction confirms. We cannot announce
+	// it until the confirmed SCID is known.
+	if channel.IsZeroConf() && !channel.ZeroConfConfirmed() {
+		return ErrChanNotConfirmed
+	}
+
+	// option_scid_alias channels are private by construction: they only
+	// share aliases and keep the real SCID hidden. Converting one to public
+	// would defeat that guarantee, so it is rejected outright.
+	if channel.ChanType.HasScidAliasChan() {
+		return ErrScidAliasChannel
+	}
+
+	// A channel that is being cooperatively closed must not be announced as
+	// a usable route.
+	if shutdownPending {
+		return ErrShutdownPending
+	}
+
+	return nil
+}
+
+// DynAnnouncementConfig bundles the dependencies the DynAnnouncementManager
+// needs to reconcile the gossip layer with a committed dynamic-commitments
+// parameter update. Every dependency is injected so the manager unit-tests
+// without a live server, gossiper, or funding manager.
+type DynAnnouncementConfig struct {
+	// MessageSigner signs channel_update messages that validate under our
+	// node identity key.
+	MessageSigner lnwallet.MessageSigner
+
+	// OurKeyLoc locates our node identity key used to sign channel_updates.
+	OurKeyLoc keychain.KeyLocator
+
+	// FetchChannel returns the persisted OpenChannel for the given channel
+	// point. It is read after the dynamic update has locked in, so it
+	// reflects the newly committed configs and channel_flags.
+	FetchChannel func(wire.OutPoint) (*channeldb.OpenChannel, error)
+
+	// FetchOurChannelUpdate returns the most recent channel_update we
+	// advertised for our direction of the given channel, along with whether
+	// the channel is still private (i.e. has no channel_announcement proof).
+	FetchOurChannelUpdate func(wire.OutPoint) (*lnwire.ChannelUpdate1, bool,
+		error)
+
+	// ApplyChannelUpdate signs-off on a freshly signed channel_update by
+	// handing it to the gossiper for local application and broadcast. The
+	// private flag selects whether the peer alias (rather than the real
+	// SCID) should be used, matching the server's applyChannelUpdate.
+	ApplyChannelUpdate func(*lnwire.ChannelUpdate1, *wire.OutPoint,
+		bool) error
+
+	// IsShutdownPending reports whether a cooperative shutdown is in
+	// progress on the channel. It gates the private->public conversion.
+	IsShutdownPending func(lnwire.ChannelID) bool
+
+	// ReAnnounceChannel re-triggers the AnnounceSignatures exchange for a
+	// formerly-private channel so that a channel_announcement is produced
+	// and the channel joins the public graph. It may be nil while the deep
+	// funding-manager re-trigger is not yet wired (see makePublic).
+	ReAnnounceChannel func(context.Context, *channeldb.OpenChannel) error
+
+	// RequestDisable disables our direction of the channel via a signed
+	// channel_update with the disable bit set (typically
+	// ChanStatusManager.RequestDisable). The manual flag mirrors the
+	// ChanStatusManager semantics.
+	RequestDisable func(wire.OutPoint, bool) error
+
+	// MinHTLCOut is the daemon's default minimum forwarded HTLC. It is used
+	// as a floor for the advertised htlc_minimum_msat, matching the funding
+	// manager's extractAnnounceParams.
+	MinHTLCOut lnwire.MilliSatoshi
+}
+
+// DynAnnouncementManager reconciles the channel-announcement/gossip state with
+// a committed dynamic-commitments parameter update. It is the entry point the
+// link/server invokes after applyDynParams has locked a dynamic update in for a
+// channel (see htlcswitch: NotifyDynParamsLockIn).
+//
+// It is entirely inert for channels that never undergo a dynamic update: the
+// link only invokes it on the dyn apply path, so ordinary gossip is unaffected.
+type DynAnnouncementManager struct {
+	cfg DynAnnouncementConfig
+}
+
+// NewDynAnnouncementManager constructs a DynAnnouncementManager from the given
+// config.
+func NewDynAnnouncementManager(
+	cfg DynAnnouncementConfig) *DynAnnouncementManager {
+
+	return &DynAnnouncementManager{cfg: cfg}
+}
+
+// ProcessDynParamsLockIn reconciles the gossip layer with a dynamic-commitments
+// parameter update that has just locked in for the given channel. It performs
+// two independent adjustments:
+//
+//  1. channel_update policy realignment: if the committed update changed the
+//     inbound HTLC limits (htlc_minimum_msat or max_htlc_value_in_flight_msat)
+//     in a way that no longer matches what we advertise, it emits a corrected
+//     directional channel_update.
+//  2. announcement intent: if the committed update changed the channel_flags
+//     announcement bit, it drives the private->public or public->private
+//     conversion (subject to the private->public preconditions).
+//
+// oldFlags is the channel_flags value before the update; params is the agreed
+// change; proposer identifies which party proposed it (proposer-owned
+// semantics). Errors are returned to the caller for logging; the parameter
+// update itself has already been committed and persisted regardless.
+func (m *DynAnnouncementManager) ProcessDynParamsLockIn(ctx context.Context,
+	chanPoint wire.OutPoint, proposer lntypes.ChannelParty,
+	oldFlags lnwire.FundingFlag, params lnwallet.ChannelParams) error {
+
+	log.Debugf("Reconciling gossip state for dyn params lock-in on "+
+		"ChannelPoint(%v): proposer=%v", chanPoint, proposer)
+
+	channel, err := m.cfg.FetchChannel(chanPoint)
+	if err != nil {
+		return fmt.Errorf("dyn gossip: fetch channel %v: %w",
+			chanPoint, err)
+	}
+
+	// First, keep our advertised channel_update consistent with the
+	// committed inbound HTLC limits. This is independent of any
+	// announcement-intent change and must run for both public and private
+	// channels.
+	if params.HtlcMinimum.IsSome() || params.MaxValueInFlight.IsSome() {
+		if err := m.realignChannelUpdate(chanPoint, channel); err != nil {
+			return fmt.Errorf("dyn gossip: realign channel "+
+				"update for %v: %w", chanPoint, err)
+		}
+	}
+
+	// Next, react to any change in the channel's announcement intent.
+	transition := FlagsUnchanged
+	params.ChannelFlags.WhenSome(func(newFlags lnwire.FundingFlag) {
+		transition = ClassifyFlagsChange(oldFlags, newFlags)
+	})
+
+	switch transition {
+	case FlagsUnchanged:
+		return nil
+
+	case FlagsPrivateToPublic:
+		return m.makePublic(ctx, chanPoint, channel)
+
+	case FlagsPublicToPrivate:
+		return m.makePrivate(chanPoint, channel)
+
+	default:
+		return nil
+	}
+}
+
+// makePublic drives a private->public conversion for a channel whose
+// channel_flags announcement bit was just set. It enforces the conversion
+// preconditions, (re-)triggers the announcement-signature exchange so a
+// channel_announcement is produced, and then publishes a fresh directional
+// channel_update.
+func (m *DynAnnouncementManager) makePublic(ctx context.Context,
+	chanPoint wire.OutPoint, channel *channeldb.OpenChannel) error {
+
+	chanID := lnwire.NewChanIDFromOutPoint(chanPoint)
+
+	shutdownPending := false
+	if m.cfg.IsShutdownPending != nil {
+		shutdownPending = m.cfg.IsShutdownPending(chanID)
+	}
+
+	// Enforce the real preconditions before touching gossip state.
+	if err := CheckPrivateToPublic(channel, shutdownPending); err != nil {
+		return err
+	}
+
+	// Re-trigger the AnnounceSignatures exchange so both peers exchange
+	// their halves of the channel_announcement proof and the channel joins
+	// the public graph.
+	//
+	// TODO(dyn): the AnnounceSignatures re-trigger requires funding-manager
+	// state (the local/bitcoin funding keys and the peer coordination that
+	// produces and processes the AnnounceSignatures1 proof) that is not
+	// wired to this manager on the current branch. The remaining sub-steps
+	// are:
+	//
+	//  1. Have the funding manager rebuild the chanAnnouncement (see
+	//     funding.Manager.newChanAnnouncement) for the now-public channel,
+	//     using its confirmed SCID.
+	//  2. Send our AnnounceSignatures1 half to the peer and await theirs,
+	//     reusing the annAfterSixConfs/announceChannel path so the gossiper
+	//     assembles the full channel_announcement and sets the edge's
+	//     AuthProof.
+	//  3. Emit a fresh NodeAnnouncement so the channel is attributable.
+	//
+	// Until that lands, ReAnnounceChannel is nil in production, so the
+	// channel_announcement is not produced and the channel_update below is
+	// still advertised privately (FetchOurChannelUpdate reports the channel
+	// as private because its AuthProof is absent). The preconditions and the
+	// publish path are exercised regardless.
+	if m.cfg.ReAnnounceChannel != nil {
+		if err := m.cfg.ReAnnounceChannel(ctx, channel); err != nil {
+			return fmt.Errorf("re-announce channel %v: %w",
+				chanPoint, err)
+		}
+	} else {
+		log.Warnf("Dyn private->public conversion for ChannelPoint"+
+			"(%v): AnnounceSignatures re-trigger is not wired "+
+			"(TODO(dyn)); publishing directional channel_update "+
+			"only", chanPoint)
+	}
+
+	// Publish a fresh directional channel_update for our side of the newly
+	// public channel with the disable bit cleared.
+	if err := m.readvertise(
+		chanPoint, ChanUpdSetDisable(false),
+	); err != nil {
+		return fmt.Errorf("publish channel update for %v: %w",
+			chanPoint, err)
+	}
+
+	log.Infof("Dyn converted ChannelPoint(%v) private->public", chanPoint)
+
+	return nil
+}
+
+// makePrivate drives a public->private conversion for a channel whose
+// channel_flags announcement bit was just cleared.
+//
+// A channel_announcement that has already propagated cannot be removed from the
+// public graph: gossip has no "un-announce" message, and other nodes retain the
+// announcement and any channel_updates they have seen. The realistic action is
+// therefore to disable our direction so we stop advertising the channel as a
+// usable route. Both peers run this after the same lock-in, so each disables
+// its own direction and the union is "both directions disabled" — but this is
+// NOT equivalent to erasing the channel's historical public presence: the
+// channel_announcement and prior updates remain in other nodes' graphs, and the
+// channel remains discoverable there until it is closed.
+func (m *DynAnnouncementManager) makePrivate(chanPoint wire.OutPoint,
+	_ *channeldb.OpenChannel) error {
+
+	// We can only sign a channel_update for our own direction, so we disable
+	// that direction. The counterparty disables its direction after the same
+	// lock-in. manual=true so a background re-enable does not silently undo
+	// the user-driven conversion.
+	if m.cfg.RequestDisable != nil {
+		if err := m.cfg.RequestDisable(chanPoint, true); err != nil {
+			return fmt.Errorf("disable channel %v: %w", chanPoint,
+				err)
+		}
+	}
+
+	log.Infof("Dyn converted ChannelPoint(%v) public->private: disabled "+
+		"our direction (channel remains in other nodes' graphs until "+
+		"closed)", chanPoint)
+
+	return nil
+}
+
+// realignChannelUpdate re-advertises our directional channel_update when the
+// committed inbound HTLC limits no longer match what we advertise.
+//
+// The advertised htlc_minimum_msat / htlc_maximum_msat are derived from our
+// local channel config exactly as the funding manager derives them at open time
+// (see extractAnnounceParams). Because a dynamic proposal is proposer-owned and
+// its htlc_minimum_msat / max_htlc_value_in_flight_msat changes are written to
+// the counterparty's config, only the counterparty (responder) sees its own
+// local config change: on the proposer this recompute is a no-op, so a single
+// symmetric implementation is correct on both nodes.
+func (m *DynAnnouncementManager) realignChannelUpdate(chanPoint wire.OutPoint,
+	channel *channeldb.OpenChannel) error {
+
+	update, private, err := m.cfg.FetchOurChannelUpdate(chanPoint)
+	switch {
+	// No advertised policy exists for this channel yet; there is nothing to
+	// realign.
+	case errors.Is(err, graphdb.ErrEdgeNotFound),
+		errors.Is(err, ErrUnableToExtractChanUpdate):
+
+		return nil
+
+	case err != nil:
+		return err
+	}
+
+	wantMin, wantMax := desiredForwardingPolicy(
+		channel.LocalChanCfg, channel.Capacity, m.cfg.MinHTLCOut,
+	)
+
+	// Detect the two realignment cases the spec calls out:
+	//
+	//   - the advertised htlc_minimum_msat no longer matches the committed
+	//     inbound minimum, and
+	//   - a max_htlc_value_in_flight_msat decrease has left our advertised
+	//     htlc_maximum_msat above the committed cap (invalidating it).
+	//
+	// We also re-advertise on any other htlc_maximum change so the two stay
+	// consistent, but the invalidating decrease is the safety-critical case.
+	minChanged := update.HtlcMinimumMsat != wantMin
+	maxInvalidated := update.HtlcMaximumMsat > wantMax
+	maxChanged := update.HtlcMaximumMsat != wantMax
+
+	if !minChanged && !maxChanged {
+		// Our advertised policy already reflects the committed params
+		// (the common case on the proposer side).
+		return nil
+	}
+
+	log.Infof("Dyn realigning channel_update for ChannelPoint(%v): "+
+		"htlc_minimum %v->%v, htlc_maximum %v->%v (min_changed=%v, "+
+		"max_invalidated=%v)", chanPoint, update.HtlcMinimumMsat,
+		wantMin, update.HtlcMaximumMsat, wantMax, minChanged,
+		maxInvalidated)
+
+	err = m.signAndApply(
+		chanPoint, private, update, ChanUpdSetHtlcMinMax(wantMin, wantMax),
+	)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// readvertise re-signs and re-broadcasts our latest directional channel_update
+// for the channel with the given modifiers applied. It fetches the most recent
+// advertised update as its starting point so the timestamp increases
+// monotonically.
+func (m *DynAnnouncementManager) readvertise(chanPoint wire.OutPoint,
+	mods ...ChannelUpdateModifier) error {
+
+	update, private, err := m.cfg.FetchOurChannelUpdate(chanPoint)
+	if err != nil {
+		return err
+	}
+
+	return m.signAndApply(chanPoint, private, update, mods...)
+}
+
+// signAndApply applies the given modifiers to the update, signs it under our
+// node key with a bumped timestamp, and hands it to the gossiper for local
+// application and broadcast.
+func (m *DynAnnouncementManager) signAndApply(chanPoint wire.OutPoint,
+	private bool, update *lnwire.ChannelUpdate1,
+	mods ...ChannelUpdateModifier) error {
+
+	mods = append(mods, ChanUpdSetTimestamp)
+	err := SignChannelUpdate(
+		m.cfg.MessageSigner, m.cfg.OurKeyLoc, update, mods...,
+	)
+	if err != nil {
+		return err
+	}
+
+	return m.cfg.ApplyChannelUpdate(update, &chanPoint, private)
+}
+
+// desiredForwardingPolicy computes the htlc_minimum_msat and htlc_maximum_msat
+// that our directional channel_update should advertise given our (possibly
+// updated) local channel config, the channel capacity, and the daemon's minimum
+// forwarded HTLC floor. It mirrors funding.Manager.extractAnnounceParams so the
+// realigned update matches how the values were originally derived.
+func desiredForwardingPolicy(cfg channeldb.ChannelConfig,
+	capacity btcutil.Amount, minHTLCFloor lnwire.MilliSatoshi) (
+	lnwire.MilliSatoshi, lnwire.MilliSatoshi) {
+
+	// The minimum we can forward is set by the remote party (stored in our
+	// local config), floored at our own default policy minimum.
+	fwdMin := cfg.MinHTLC
+	if fwdMin < minHTLCFloor {
+		fwdMin = minHTLCFloor
+	}
+
+	// The maximum we can forward is the peer's max-in-flight, capped at the
+	// channel capacity.
+	fwdMax := cfg.MaxPendingAmount
+	capacityMSat := lnwire.NewMSatFromSatoshis(capacity)
+	if fwdMax > capacityMSat {
+		fwdMax = capacityMSat
+	}
+
+	return fwdMin, fwdMax
+}

--- a/netann/dyn_announcement_test.go
+++ b/netann/dyn_announcement_test.go
@@ -1,0 +1,486 @@
+package netann_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnwallet"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/netann"
+	"github.com/stretchr/testify/require"
+)
+
+// TestClassifyFlagsChange verifies the announcement-intent transition
+// classification for every combination of the FFAnnounceChannel bit.
+func TestClassifyFlagsChange(t *testing.T) {
+	t.Parallel()
+
+	const (
+		priv = lnwire.FundingFlag(0)
+		pub  = lnwire.FFAnnounceChannel
+	)
+
+	tests := []struct {
+		name string
+		old  lnwire.FundingFlag
+		new  lnwire.FundingFlag
+		want netann.FlagsTransition
+	}{
+		{"priv->pub", priv, pub, netann.FlagsPrivateToPublic},
+		{"pub->priv", pub, priv, netann.FlagsPublicToPrivate},
+		{"pub->pub", pub, pub, netann.FlagsUnchanged},
+		{"priv->priv", priv, priv, netann.FlagsUnchanged},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := netann.ClassifyFlagsChange(tc.old, tc.new)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestCheckPrivateToPublic verifies each private->public precondition rejection
+// case as well as the success case.
+func TestCheckPrivateToPublic(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		channel         *channeldb.OpenChannel
+		shutdownPending bool
+		wantErr         error
+	}{
+		{
+			name: "unconfirmed funding tx",
+			channel: &channeldb.OpenChannel{
+				IsPending: true,
+			},
+			wantErr: netann.ErrChanNotConfirmed,
+		},
+		{
+			name: "zero-conf not yet confirmed",
+			channel: &channeldb.OpenChannel{
+				ChanType: channeldb.ZeroConfBit |
+					channeldb.ScidAliasFeatureBit,
+			},
+			wantErr: netann.ErrChanNotConfirmed,
+		},
+		{
+			name: "option_scid_alias channel",
+			channel: &channeldb.OpenChannel{
+				ChanType: channeldb.ScidAliasChanBit,
+			},
+			wantErr: netann.ErrScidAliasChannel,
+		},
+		{
+			name:            "shutdown pending",
+			channel:         &channeldb.OpenChannel{},
+			shutdownPending: true,
+			wantErr:         netann.ErrShutdownPending,
+		},
+		{
+			name:    "all preconditions met",
+			channel: &channeldb.OpenChannel{},
+			wantErr: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := netann.CheckPrivateToPublic(
+				tc.channel, tc.shutdownPending,
+			)
+			if tc.wantErr == nil {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorIs(t, err, tc.wantErr)
+		})
+	}
+}
+
+// dynHarness bundles the mock dependencies wired into a DynAnnouncementManager
+// so tests can inspect what the manager did.
+type dynHarness struct {
+	mgr *netann.DynAnnouncementManager
+
+	// channel is the OpenChannel the FetchChannel dep returns.
+	channel *channeldb.OpenChannel
+
+	// currentUpdate is the channel_update FetchOurChannelUpdate returns.
+	currentUpdate *lnwire.ChannelUpdate1
+
+	// private is the private flag FetchOurChannelUpdate returns.
+	private bool
+
+	// applied captures channel_updates handed to ApplyChannelUpdate.
+	applied []*lnwire.ChannelUpdate1
+
+	// disableCalls captures RequestDisable invocations as (outpoint, manual).
+	disableCalls []disableCall
+
+	// reAnnounceCalls counts ReAnnounceChannel invocations.
+	reAnnounceCalls int
+
+	// shutdownPending is returned by the IsShutdownPending dep.
+	shutdownPending bool
+}
+
+type disableCall struct {
+	outpoint wire.OutPoint
+	manual   bool
+}
+
+// newDynHarness constructs a DynAnnouncementManager over inspectable mocks. The
+// channel starts private, confirmed, and non-alias unless the test mutates it.
+func newDynHarness(t *testing.T) *dynHarness {
+	t.Helper()
+
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	signer := netann.NewNodeSigner(
+		keychain.NewPrivKeyMessageSigner(privKey, testKeyLoc),
+	)
+
+	h := &dynHarness{
+		channel: &channeldb.OpenChannel{
+			FundingOutpoint: randOutpoint(t),
+			ShortChannelID:  lnwire.NewShortChanIDFromInt(42),
+			Capacity:        1_000_000,
+		},
+	}
+
+	cfg := netann.DynAnnouncementConfig{
+		MessageSigner: signer,
+		OurKeyLoc:     testKeyLoc,
+		FetchChannel: func(wire.OutPoint) (*channeldb.OpenChannel,
+			error) {
+
+			return h.channel, nil
+		},
+		FetchOurChannelUpdate: func(wire.OutPoint) (
+			*lnwire.ChannelUpdate1, bool, error) {
+
+			return h.currentUpdate, h.private, nil
+		},
+		ApplyChannelUpdate: func(u *lnwire.ChannelUpdate1,
+			_ *wire.OutPoint, _ bool) error {
+
+			h.applied = append(h.applied, u)
+			return nil
+		},
+		IsShutdownPending: func(lnwire.ChannelID) bool {
+			return h.shutdownPending
+		},
+		RequestDisable: func(op wire.OutPoint, manual bool) error {
+			h.disableCalls = append(h.disableCalls, disableCall{
+				outpoint: op,
+				manual:   manual,
+			})
+			return nil
+		},
+		MinHTLCOut: 1_000,
+	}
+
+	h.mgr = netann.NewDynAnnouncementManager(cfg)
+
+	return h
+}
+
+// baseUpdate returns a channel_update carrying the given advertised HTLC
+// limits, usable as the FetchOurChannelUpdate starting point.
+func baseUpdate(htlcMin, htlcMax lnwire.MilliSatoshi) *lnwire.ChannelUpdate1 {
+	return &lnwire.ChannelUpdate1{
+		ShortChannelID:  lnwire.NewShortChanIDFromInt(42),
+		MessageFlags:    lnwire.ChanUpdateRequiredMaxHtlc,
+		HtlcMinimumMsat: htlcMin,
+		HtlcMaximumMsat: htlcMax,
+	}
+}
+
+// TestProcessDynParamsPrivateToPublicPreconditions ensures that each
+// private->public precondition failure surfaces as the corresponding typed
+// error from the top-level entry point, and that no channel_update is
+// broadcast when a precondition fails.
+func TestProcessDynParamsPrivateToPublicPreconditions(t *testing.T) {
+	t.Parallel()
+
+	makePublicParams := lnwallet.ChannelParams{
+		ChannelFlags: fn.Some(lnwire.FFAnnounceChannel),
+	}
+
+	tests := []struct {
+		name    string
+		setup   func(h *dynHarness)
+		wantErr error
+	}{
+		{
+			name: "unconfirmed funding tx",
+			setup: func(h *dynHarness) {
+				h.channel.IsPending = true
+			},
+			wantErr: netann.ErrChanNotConfirmed,
+		},
+		{
+			name: "option_scid_alias channel",
+			setup: func(h *dynHarness) {
+				h.channel.ChanType = channeldb.ScidAliasChanBit
+			},
+			wantErr: netann.ErrScidAliasChannel,
+		},
+		{
+			name: "shutdown pending",
+			setup: func(h *dynHarness) {
+				h.shutdownPending = true
+			},
+			wantErr: netann.ErrShutdownPending,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newDynHarness(t)
+			h.currentUpdate = baseUpdate(1_000, 500_000)
+			h.private = true
+			tc.setup(h)
+
+			err := h.mgr.ProcessDynParamsLockIn(
+				context.Background(),
+				h.channel.FundingOutpoint, lntypes.Local,
+				lnwire.FundingFlag(0), makePublicParams,
+			)
+			require.ErrorIs(t, err, tc.wantErr)
+
+			// A rejected conversion must not broadcast anything.
+			require.Empty(t, h.applied)
+		})
+	}
+}
+
+// TestProcessDynParamsPrivateToPublicSuccess verifies that once preconditions
+// pass, the manager re-triggers the announcement flow and publishes a fresh
+// enabled directional channel_update.
+func TestProcessDynParamsPrivateToPublicSuccess(t *testing.T) {
+	t.Parallel()
+
+	h := newDynHarness(t)
+	h.currentUpdate = baseUpdate(1_000, 500_000)
+	h.private = true
+
+	// Wire a ReAnnounceChannel dep so we can assert the re-trigger fires.
+	cfg := netann.DynAnnouncementConfig{
+		MessageSigner: netann.NewNodeSigner(
+			keychain.NewPrivKeyMessageSigner(
+				mustPrivKey(t), testKeyLoc,
+			),
+		),
+		OurKeyLoc: testKeyLoc,
+		FetchChannel: func(wire.OutPoint) (*channeldb.OpenChannel,
+			error) {
+
+			return h.channel, nil
+		},
+		FetchOurChannelUpdate: func(wire.OutPoint) (
+			*lnwire.ChannelUpdate1, bool, error) {
+
+			return h.currentUpdate, h.private, nil
+		},
+		ApplyChannelUpdate: func(u *lnwire.ChannelUpdate1,
+			_ *wire.OutPoint, _ bool) error {
+
+			h.applied = append(h.applied, u)
+			return nil
+		},
+		IsShutdownPending: func(lnwire.ChannelID) bool { return false },
+		ReAnnounceChannel: func(context.Context,
+			*channeldb.OpenChannel) error {
+
+			h.reAnnounceCalls++
+			return nil
+		},
+		MinHTLCOut: 1_000,
+	}
+	mgr := netann.NewDynAnnouncementManager(cfg)
+
+	err := mgr.ProcessDynParamsLockIn(
+		context.Background(), h.channel.FundingOutpoint, lntypes.Local,
+		lnwire.FundingFlag(0),
+		lnwallet.ChannelParams{
+			ChannelFlags: fn.Some(lnwire.FFAnnounceChannel),
+		},
+	)
+	require.NoError(t, err)
+
+	// The announcement re-trigger must have fired once.
+	require.Equal(t, 1, h.reAnnounceCalls)
+
+	// A fresh directional channel_update must have been published with the
+	// disable bit cleared.
+	require.Len(t, h.applied, 1)
+	require.Zero(t,
+		h.applied[0].ChannelFlags&lnwire.ChanUpdateDisabled,
+	)
+}
+
+// TestProcessDynParamsPublicToPrivate verifies that a public->private
+// conversion disables our direction via a manual RequestDisable.
+func TestProcessDynParamsPublicToPrivate(t *testing.T) {
+	t.Parallel()
+
+	h := newDynHarness(t)
+	h.channel.ChannelFlags = lnwire.FFAnnounceChannel
+	h.currentUpdate = baseUpdate(1_000, 500_000)
+
+	err := h.mgr.ProcessDynParamsLockIn(
+		context.Background(), h.channel.FundingOutpoint, lntypes.Local,
+		lnwire.FFAnnounceChannel,
+		lnwallet.ChannelParams{
+			ChannelFlags: fn.Some(lnwire.FundingFlag(0)),
+		},
+	)
+	require.NoError(t, err)
+
+	// Our direction must be disabled with the manual flag set so a
+	// background re-enable does not undo the conversion.
+	require.Len(t, h.disableCalls, 1)
+	require.Equal(t, h.channel.FundingOutpoint, h.disableCalls[0].outpoint)
+	require.True(t, h.disableCalls[0].manual)
+}
+
+// TestProcessDynParamsRealignHtlcMinimum verifies that a committed change to
+// the inbound htlc_minimum_msat emits a corrected directional channel_update.
+func TestProcessDynParamsRealignHtlcMinimum(t *testing.T) {
+	t.Parallel()
+
+	h := newDynHarness(t)
+	h.private = true
+
+	// We advertise a 1000 msat minimum, but the committed config now
+	// requires a 5000 msat minimum on our direction.
+	h.currentUpdate = baseUpdate(1_000, 500_000)
+	h.channel.LocalChanCfg.MinHTLC = 5_000
+	h.channel.LocalChanCfg.MaxPendingAmount = 500_000
+
+	err := h.mgr.ProcessDynParamsLockIn(
+		context.Background(), h.channel.FundingOutpoint, lntypes.Remote,
+		lnwire.FundingFlag(0),
+		lnwallet.ChannelParams{
+			HtlcMinimum: fn.Some(lnwire.MilliSatoshi(5_000)),
+		},
+	)
+	require.NoError(t, err)
+
+	require.Len(t, h.applied, 1)
+	require.Equal(t, lnwire.MilliSatoshi(5_000),
+		h.applied[0].HtlcMinimumMsat)
+	require.Equal(t, lnwire.MilliSatoshi(500_000),
+		h.applied[0].HtlcMaximumMsat)
+}
+
+// TestProcessDynParamsRealignMaxInFlight verifies that a max_in_flight decrease
+// that invalidates the advertised htlc_maximum_msat triggers a corrected
+// channel_update capping the maximum at the new value.
+func TestProcessDynParamsRealignMaxInFlight(t *testing.T) {
+	t.Parallel()
+
+	h := newDynHarness(t)
+	h.private = true
+
+	// We advertise a 500000 msat maximum, but the committed config now caps
+	// in-flight at 300000 msat, invalidating the advertised maximum.
+	h.currentUpdate = baseUpdate(1_000, 500_000)
+	h.channel.LocalChanCfg.MinHTLC = 1_000
+	h.channel.LocalChanCfg.MaxPendingAmount = 300_000
+
+	err := h.mgr.ProcessDynParamsLockIn(
+		context.Background(), h.channel.FundingOutpoint, lntypes.Remote,
+		lnwire.FundingFlag(0),
+		lnwallet.ChannelParams{
+			MaxValueInFlight: fn.Some(lnwire.MilliSatoshi(300_000)),
+		},
+	)
+	require.NoError(t, err)
+
+	require.Len(t, h.applied, 1)
+	require.Equal(t, lnwire.MilliSatoshi(300_000),
+		h.applied[0].HtlcMaximumMsat)
+	// The max-htlc message flag must remain set.
+	require.True(t, h.applied[0].MessageFlags.HasMaxHtlc())
+}
+
+// TestProcessDynParamsRealignNoop verifies that when the advertised policy
+// already matches the committed params (the common proposer-side case), no
+// channel_update is emitted.
+func TestProcessDynParamsRealignNoop(t *testing.T) {
+	t.Parallel()
+
+	h := newDynHarness(t)
+	h.private = true
+
+	// Advertised policy already matches the committed local config.
+	h.currentUpdate = baseUpdate(2_000, 400_000)
+	h.channel.LocalChanCfg.MinHTLC = 2_000
+	h.channel.LocalChanCfg.MaxPendingAmount = 400_000
+
+	err := h.mgr.ProcessDynParamsLockIn(
+		context.Background(), h.channel.FundingOutpoint, lntypes.Local,
+		lnwire.FundingFlag(0),
+		lnwallet.ChannelParams{
+			HtlcMinimum: fn.Some(lnwire.MilliSatoshi(2_000)),
+		},
+	)
+	require.NoError(t, err)
+	require.Empty(t, h.applied)
+}
+
+// TestProcessDynParamsRealignFloor verifies that a committed htlc_minimum below
+// our default forwarding floor does not trigger a re-advertisement, since we
+// never advertise below the floor.
+func TestProcessDynParamsRealignFloor(t *testing.T) {
+	t.Parallel()
+
+	h := newDynHarness(t)
+	h.private = true
+
+	// We advertise the 1000 msat floor. The committed minimum drops to 100
+	// msat, which is below the floor, so our advertised minimum is unchanged.
+	h.currentUpdate = baseUpdate(1_000, 500_000)
+	h.channel.LocalChanCfg.MinHTLC = 100
+	h.channel.LocalChanCfg.MaxPendingAmount = 500_000
+
+	err := h.mgr.ProcessDynParamsLockIn(
+		context.Background(), h.channel.FundingOutpoint, lntypes.Remote,
+		lnwire.FundingFlag(0),
+		lnwallet.ChannelParams{
+			HtlcMinimum: fn.Some(lnwire.MilliSatoshi(100)),
+		},
+	)
+	require.NoError(t, err)
+	require.Empty(t, h.applied)
+}
+
+// mustPrivKey returns a fresh private key or fails the test.
+func mustPrivKey(t *testing.T) *btcec.PrivateKey {
+	t.Helper()
+
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	return privKey
+}

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -367,6 +367,15 @@ type Config struct {
 	// apply path, after a parameter update locks in.
 	NotifyChannelBackup func(*channeldb.OpenChannel)
 
+	// NotifyDynParamsLockIn reconciles the gossip/channel-announcement layer
+	// with a dynamic-commitments parameter update that has locked in. It is
+	// passed to the ChannelLink and invoked only on the dynamic-commitments
+	// apply path, after the params are committed. See the like-named field on
+	// htlcswitch.ChannelLinkConfig.
+	NotifyDynParamsLockIn func(chanPoint wire.OutPoint,
+		proposer lntypes.ChannelParty, oldFlags lnwire.FundingFlag,
+		params lnwallet.ChannelParams)
+
 	// HtlcNotifier is used when creating a ChannelLink.
 	HtlcNotifier *htlcswitch.HtlcNotifier
 
@@ -1571,6 +1580,7 @@ func (p *Brontide) addLink(chanPoint *wire.OutPoint,
 		NotifyInactiveLinkEvent:    p.cfg.ChannelNotifier.NotifyInactiveLinkEvent,
 		NotifyChannelUpdate:        p.cfg.ChannelNotifier.NotifyChannelUpdateEvent,
 		NotifyChannelBackup:        p.cfg.NotifyChannelBackup,
+		NotifyDynParamsLockIn:      p.cfg.NotifyDynParamsLockIn,
 		HtlcNotifier:               p.cfg.HtlcNotifier,
 		GetAliases:                 p.cfg.GetAliases,
 		PreviouslySentShutdown:     shutdownMsg,

--- a/server.go
+++ b/server.go
@@ -60,6 +60,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnpeer"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
+	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnutils"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
@@ -246,6 +247,13 @@ type server struct {
 	nodeSigner *netann.NodeSigner
 
 	chanStatusMgr *netann.ChanStatusManager
+
+	// dynAnnouncementMgr reconciles the gossip/channel-announcement layer
+	// with dynamic-commitments parameter updates that lock in on a link
+	// (public<->private conversion and channel_update realignment). It is
+	// invoked via the NotifyDynParamsLockIn peer/link hook, so it is inert
+	// for channels that never undergo a dynamic update.
+	dynAnnouncementMgr *netann.DynAnnouncementManager
 
 	// listenAddrs is the list of addresses the server is currently
 	// listening on.
@@ -955,6 +963,30 @@ func newServer(ctx context.Context, cfg *Config, listenAddrs []net.Addr,
 		return nil, err
 	}
 	s.chanStatusMgr = chanStatusMgr
+
+	// The dynamic-commitments announcement manager reconciles the gossip
+	// layer with a locked-in dynamic parameter update. Its dependencies
+	// mirror the ChanStatusManager's (same signer, key, and channel_update
+	// application path) plus the channel/graph lookups it needs to enforce
+	// the private->public preconditions and realign advertised policy.
+	//
+	// TODO(dyn): ReAnnounceChannel is intentionally left nil until the
+	// funding-manager AnnounceSignatures re-trigger is wired (see
+	// netann.DynAnnouncementManager.makePublic). Until then a private->public
+	// conversion enforces its preconditions and re-advertises our directional
+	// channel_update, but the channel_announcement proof is not produced.
+	s.dynAnnouncementMgr = netann.NewDynAnnouncementManager(
+		netann.DynAnnouncementConfig{
+			MessageSigner:         s.nodeSigner,
+			OurKeyLoc:             nodeKeyDesc.KeyLocator,
+			FetchChannel:          s.chanStateDB.FetchChannel,
+			FetchOurChannelUpdate: s.fetchOurChannelUpdate,
+			ApplyChannelUpdate:    s.applyChannelUpdate,
+			IsShutdownPending:     s.isChannelShutdownPending,
+			RequestDisable:        s.chanStatusMgr.RequestDisable,
+			MinHTLCOut:            cc.RoutingPolicy.MinHTLCOut,
+		},
+	)
 
 	// If enabled, use either UPnP or NAT-PMP to automatically configure
 	// port forwarding for users behind a NAT.
@@ -4598,14 +4630,15 @@ func (s *server) peerConnected(conn net.Conn, connReq *connmgr.ConnReq,
 
 			return s.defaultOnionActorOpts
 		},
-		ActorSystem:         s.actorSystem,
-		WitnessBeacon:       s.witnessBeacon,
-		Invoices:            s.invoices,
-		ChannelNotifier:     s.channelNotifier,
-		NotifyChannelBackup: s.updateChannelBackup,
-		HtlcNotifier:        s.htlcNotifier,
-		TowerClient:         towerClient,
-		DisconnectPeer:      s.DisconnectPeer,
+		ActorSystem:           s.actorSystem,
+		WitnessBeacon:         s.witnessBeacon,
+		Invoices:              s.invoices,
+		ChannelNotifier:       s.channelNotifier,
+		NotifyChannelBackup:   s.updateChannelBackup,
+		NotifyDynParamsLockIn: s.notifyDynParamsLockIn,
+		HtlcNotifier:          s.htlcNotifier,
+		TowerClient:           towerClient,
+		DisconnectPeer:        s.DisconnectPeer,
 		GenNodeAnnouncement: func(...netann.NodeAnnModifier) (
 			lnwire.NodeAnnouncement1, error) {
 
@@ -5451,6 +5484,96 @@ func (s *server) fetchLastChanUpdate() func(lnwire.ShortChannelID) (
 			ourPubKey[:], info, edge1, edge2,
 		)
 	}
+}
+
+// fetchOurChannelUpdate returns the most recent channel_update we advertised
+// for our direction of the channel identified by the given outpoint, along with
+// whether the channel is still private (i.e. has no channel_announcement proof).
+// It is used by the dynamic-commitments announcement manager to realign and
+// re-advertise our policy after a parameter update locks in.
+func (s *server) fetchOurChannelUpdate(op wire.OutPoint) (
+	*lnwire.ChannelUpdate1, bool, error) {
+
+	ourPubKey := s.identityECDH.PubKey().SerializeCompressed()
+
+	info, edge1, edge2, err := s.graphDB.FetchChannelEdgesByOutpoint(
+		context.TODO(), &op,
+	)
+	if err != nil {
+		return nil, false, err
+	}
+
+	update, err := netann.ExtractChannelUpdate(
+		ourPubKey, info, edge1, edge2,
+	)
+	if err != nil {
+		return nil, false, err
+	}
+
+	// A channel with no authentication proof has not been announced and is
+	// therefore still private; its updates must use the peer alias.
+	private := info.AuthProof == nil
+
+	return update, private, nil
+}
+
+// isChannelShutdownPending reports whether a cooperative shutdown has been
+// initiated on our side of the channel identified by the given channel id. It
+// is a best-effort, defense-in-depth precondition for the private->public
+// dynamic conversion: the link/quiescence layer additionally prevents a dyn
+// update from being negotiated while a shutdown (sent or received) is
+// outstanding.
+func (s *server) isChannelShutdownPending(chanID lnwire.ChannelID) bool {
+	channel, err := s.chanStateDB.FetchChannelByID(chanID)
+	if err != nil {
+		// If we cannot load the channel, conservatively treat it as
+		// having a pending shutdown so we do not announce a channel we
+		// cannot verify.
+		srvrLog.Warnf("Unable to fetch channel %v to check shutdown "+
+			"state: %v", chanID, err)
+
+		return true
+	}
+
+	info, err := channel.ShutdownInfo()
+	if err != nil {
+		srvrLog.Warnf("Unable to read shutdown info for channel %v: %v",
+			chanID, err)
+
+		return true
+	}
+
+	return info.IsSome()
+}
+
+// notifyDynParamsLockIn is the NotifyDynParamsLockIn hook the peer/link invokes
+// after a dynamic-commitments parameter update has locked in for a channel. It
+// hands the change to the dynamic announcement manager, which reconciles the
+// gossip layer (public<->private conversion and channel_update realignment). It
+// is fire-and-forget from the link's perspective: the params are already
+// committed, so gossip errors are logged, not surfaced back into the commitment
+// dance. The work runs in a goroutine tied to the server lifecycle so the link
+// event loop is never blocked on gossip round-trips.
+func (s *server) notifyDynParamsLockIn(chanPoint wire.OutPoint,
+	proposer lntypes.ChannelParty, oldFlags lnwire.FundingFlag,
+	params lnwallet.ChannelParams) {
+
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+
+		ctx, cancel := lnutils.ContextFromQuit(s.quit)
+		defer cancel()
+
+		err := s.dynAnnouncementMgr.ProcessDynParamsLockIn(
+			ctx, chanPoint, proposer, oldFlags, params,
+		)
+		if err != nil {
+			srvrLog.Errorf("Unable to reconcile gossip state for "+
+				"dyn params lock-in on ChannelPoint(%v): %v",
+				chanPoint, err)
+		}
+	}()
 }
 
 // applyChannelUpdate applies the channel update to the different sub-systems of


### PR DESCRIPTION
Part of the Dynamic Commitments milestone: #60

Gossip / channel-announcement state for `channel_flags` public/private transitions.

**Stacked PR** — based on `yy-dyn-10-scb`; review after that branch (the base updates automatically as the parent merges).

Opened as a **draft**: this is part of the exploratory params-only stack (coarse commits, not final hygiene).